### PR TITLE
Add ability to install metagraph as a library.

### DIFF
--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -282,10 +282,10 @@ target_link_libraries(
 #-------------------
 
 file(GLOB header_files
-        "src/*.hpp"
-        "src/*/*.hpp"
-        "src/*/*/*.hpp"
-        )
+  "src/*.hpp"
+  "src/*/*.hpp"
+  "src/*/*/*.hpp"
+)
 
 install(TARGETS metagraph DESTINATION lib)
 install(FILES ${header_files} DESTINATION include/metagraph)


### PR DESCRIPTION
Makes it much easier to prototype and create multiple small programs that are using the metagraph functionality.
The only difference is that one has to use `#include <metagraph/header_name.hpp>` instead of `#include "header_name.hpp"`