### PR TITLE
Added in_graph to SequenceGraph. Cleaned up MaskedDeBruijnGraph and annotated_graph_algorithms

### DIFF
--- a/metagraph/src/graph/annotated_graph_algorithm.hpp
+++ b/metagraph/src/graph/annotated_graph_algorithm.hpp
@@ -6,7 +6,6 @@
 
 #include "annotated_dbg.hpp"
 #include "bitmap.hpp"
-#include "masked_graph.hpp"
 #include "threading.hpp"
 #include "aligner_helper.hpp"
 
@@ -33,17 +32,21 @@ using VariantCallback = std::function<void(Alignment<Index>&&,
                                            std::string&&, // query sequence
                                            Args&&...)>;
 
-typedef Alignment<MaskedDeBruijnGraph::node_index> MaskedAlignment;
-typedef VariantCallback<MaskedDeBruijnGraph::node_index,
+typedef Alignment<DeBruijnGraph::node_index> MaskedAlignment;
+typedef VariantCallback<DeBruijnGraph::node_index,
                         std::vector<AnnotatedDBG::Annotator::Label>&&> VariantLabelCallback;
 
-void call_bubbles(const MaskedDeBruijnGraph &masked_graph,
+
+// These functions will callback nothing if graph is equal to the graph stored
+// in anno_graph
+
+void call_bubbles(const DeBruijnGraph &graph,
                   const AnnotatedDBG &anno_graph,
                   const VariantLabelCallback &callback,
                   ThreadPool *thread_pool = nullptr,
                   const std::function<bool()> &terminate = []() { return false; });
 
-void call_breakpoints(const MaskedDeBruijnGraph &masked_graph,
+void call_breakpoints(const DeBruijnGraph &graph,
                       const AnnotatedDBG &anno_graph,
                       const VariantLabelCallback &callback,
                       ThreadPool *thread_pool = nullptr,

--- a/metagraph/src/graph/bitmap_graph/dbg_bitmap.cpp
+++ b/metagraph/src/graph/bitmap_graph/dbg_bitmap.cpp
@@ -75,7 +75,7 @@ void DBGBitmap::map_to_nodes_sequentially(std::string::const_iterator begin,
 
 DBGBitmap::node_index
 DBGBitmap::traverse(node_index node, char next_char) const {
-    assert(node);
+    assert(in_graph(node));
 
     auto kmer = node_to_kmer(node);
     kmer.to_next(k_, seq_encoder_.encode(next_char));
@@ -84,7 +84,7 @@ DBGBitmap::traverse(node_index node, char next_char) const {
 
 DBGBitmap::node_index
 DBGBitmap::traverse_back(node_index node, char prev_char) const {
-    assert(node);
+    assert(in_graph(node));
 
     auto kmer = node_to_kmer(node);
     kmer.to_prev(k_, seq_encoder_.encode(prev_char));
@@ -93,6 +93,8 @@ DBGBitmap::traverse_back(node_index node, char prev_char) const {
 
 void DBGBitmap::call_outgoing_kmers(node_index node,
                                     const OutgoingEdgeCallback &callback) const {
+    assert(in_graph(node));
+
     const auto &kmer = node_to_kmer(node);
 
     for (char c : alphabet()) {
@@ -106,6 +108,8 @@ void DBGBitmap::call_outgoing_kmers(node_index node,
 }
 
 size_t DBGBitmap::outdegree(node_index node) const {
+    assert(in_graph(node));
+
     size_t outdegree = 0;
     const auto &kmer = node_to_kmer(node);
 
@@ -123,6 +127,8 @@ size_t DBGBitmap::outdegree(node_index node) const {
 
 void DBGBitmap::call_incoming_kmers(node_index node,
                                     const OutgoingEdgeCallback &callback) const {
+    assert(in_graph(node));
+
     const auto &kmer = node_to_kmer(node);
 
     for (char c : alphabet()) {
@@ -136,6 +142,8 @@ void DBGBitmap::call_incoming_kmers(node_index node,
 }
 
 size_t DBGBitmap::indegree(node_index node) const {
+    assert(in_graph(node));
+
     size_t indegree = 0;
     const auto &kmer = node_to_kmer(node);
 
@@ -153,6 +161,7 @@ size_t DBGBitmap::indegree(node_index node) const {
 
 void DBGBitmap::adjacent_outgoing_nodes(node_index node,
                                         std::vector<node_index> *target_nodes) const {
+    assert(in_graph(node));
     assert(target_nodes);
 
     call_outgoing_kmers(node, [target_nodes](node_index target, char) {
@@ -162,6 +171,7 @@ void DBGBitmap::adjacent_outgoing_nodes(node_index node,
 
 void DBGBitmap::adjacent_incoming_nodes(node_index node,
                                         std::vector<node_index> *source_nodes) const {
+    assert(in_graph(node));
     assert(source_nodes);
 
     call_incoming_kmers(node, [source_nodes](node_index source, char) {
@@ -187,21 +197,19 @@ DBGBitmap::kmer_to_node(const std::string &kmer) const {
 }
 
 uint64_t DBGBitmap::node_to_index(node_index node) const {
-    assert(node);
-    assert(node < kmers_.num_set_bits());
+    assert(in_graph(node));
 
     return complete_ ? node : kmers_.select1(node + 1);
 }
 
 DBGBitmap::Kmer DBGBitmap::node_to_kmer(node_index node) const {
-    assert(node);
-    assert(node < kmers_.num_set_bits());
+    assert(in_graph(node));
 
     return Kmer { complete_ ? node - 1 : kmers_.select1(node + 1) - 1 };
 }
 
 std::string DBGBitmap::get_node_sequence(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
     assert(sequence_to_kmers(seq_encoder_.kmer_to_sequence(
         node_to_kmer(node), k_)).size() == 1);
     assert(node == to_node(sequence_to_kmers(seq_encoder_.kmer_to_sequence(
@@ -339,4 +347,10 @@ void DBGBitmap::print(std::ostream &out) const {
             << node_to_index(node) << "\t"
             << get_node_sequence(node) << std::endl;
     }
+}
+
+bool DBGBitmap::in_graph(node_index node) const {
+    assert(node > 0 && node < kmers_.num_set_bits());
+    std::ignore = node;
+    return true;
 }

--- a/metagraph/src/graph/bitmap_graph/dbg_bitmap.hpp
+++ b/metagraph/src/graph/bitmap_graph/dbg_bitmap.hpp
@@ -75,6 +75,7 @@ class DBGBitmap : public DeBruijnGraph {
 
     uint64_t num_nodes() const;
 
+    bool in_graph(node_index node) const;
 
     void serialize(std::ostream &out) const;
     void serialize(const std::string &filename) const;

--- a/metagraph/src/graph/hash_graph/dbg_hash_ordered.cpp
+++ b/metagraph/src/graph/hash_graph/dbg_hash_ordered.cpp
@@ -86,6 +86,8 @@ class DBGHashOrderedImpl : public DBGHashOrdered::DBGHashOrderedInterface {
 
     const std::string& alphabet() const { return seq_encoder_.alphabet; }
 
+    bool in_graph(node_index node) const;
+
   private:
     Vector<Kmer> sequence_to_kmers(const std::string &sequence, bool canonical = false) const {
         return seq_encoder_.sequence_to_kmers<Kmer>(sequence, k_, canonical);
@@ -184,6 +186,8 @@ void DBGHashOrderedImpl<KMER>::map_to_nodes(const std::string &sequence,
 template <typename KMER>
 void DBGHashOrderedImpl<KMER>::call_outgoing_kmers(node_index node,
                                                    const OutgoingEdgeCallback &callback) const {
+    assert(in_graph(node));
+
     const auto &kmer = get_kmer(node);
 
     for (char c : seq_encoder_.alphabet) {
@@ -199,6 +203,8 @@ void DBGHashOrderedImpl<KMER>::call_outgoing_kmers(node_index node,
 template <typename KMER>
 void DBGHashOrderedImpl<KMER>::call_incoming_kmers(node_index node,
                                                    const IncomingEdgeCallback &callback) const {
+    assert(in_graph(node));
+
     const auto &kmer = get_kmer(node);
 
     for (char c : seq_encoder_.alphabet) {
@@ -214,6 +220,8 @@ void DBGHashOrderedImpl<KMER>::call_incoming_kmers(node_index node,
 template <typename KMER>
 typename DBGHashOrderedImpl<KMER>::node_index
 DBGHashOrderedImpl<KMER>::traverse(node_index node, char next_char) const {
+    assert(in_graph(node));
+
     auto kmer = get_kmer(node);
     kmer.to_next(k_, seq_encoder_.encode(next_char));
     return get_index(kmer);
@@ -222,6 +230,8 @@ DBGHashOrderedImpl<KMER>::traverse(node_index node, char next_char) const {
 template <typename KMER>
 typename DBGHashOrderedImpl<KMER>::node_index
 DBGHashOrderedImpl<KMER>::traverse_back(node_index node, char prev_char) const {
+    assert(in_graph(node));
+
     auto kmer = get_kmer(node);
     kmer.to_prev(k_, seq_encoder_.encode(prev_char));
     return get_index(kmer);
@@ -230,6 +240,7 @@ DBGHashOrderedImpl<KMER>::traverse_back(node_index node, char prev_char) const {
 template <typename KMER>
 void DBGHashOrderedImpl<KMER>::adjacent_outgoing_nodes(node_index node,
                                                        std::vector<node_index> *target_nodes) const {
+    assert(in_graph(node));
     assert(target_nodes);
 
     call_outgoing_kmers(node, [&](auto i, char) { target_nodes->push_back(i); });
@@ -238,6 +249,7 @@ void DBGHashOrderedImpl<KMER>::adjacent_outgoing_nodes(node_index node,
 template <typename KMER>
 void DBGHashOrderedImpl<KMER>::adjacent_incoming_nodes(node_index node,
                                                        std::vector<node_index> *source_nodes) const {
+    assert(in_graph(node));
     assert(source_nodes);
 
     call_incoming_kmers(node, [&](auto i, char) { source_nodes->push_back(i); });
@@ -245,7 +257,7 @@ void DBGHashOrderedImpl<KMER>::adjacent_incoming_nodes(node_index node,
 
 template <typename KMER>
 size_t DBGHashOrderedImpl<KMER>::outdegree(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
 
     size_t outdegree = 0;
 
@@ -264,7 +276,7 @@ size_t DBGHashOrderedImpl<KMER>::outdegree(node_index node) const {
 
 template <typename KMER>
 size_t DBGHashOrderedImpl<KMER>::indegree(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
 
     size_t indegree = 0;
 
@@ -291,8 +303,7 @@ DBGHashOrderedImpl<KMER>::kmer_to_node(const std::string &kmer) const {
 
 template <typename KMER>
 std::string DBGHashOrderedImpl<KMER>::get_node_sequence(node_index node) const {
-    assert(node > 0);
-    assert(node <= kmers_.size());
+    assert(in_graph(node));
 
     return seq_encoder_.kmer_to_sequence(get_kmer(node), k_);
 }
@@ -435,11 +446,17 @@ DBGHashOrderedImpl<KMER>::get_index(const Kmer &kmer) const {
 
 template <typename KMER>
 const KMER& DBGHashOrderedImpl<KMER>::get_kmer(node_index node) const {
-    assert(node > 0);
-    assert(node <= kmers_.size());
+    assert(in_graph(node));
     assert(node == get_index(*(kmers_.nth(node - 1))));
 
     return *(kmers_.nth(node - 1));
+}
+
+template <typename KMER>
+bool DBGHashOrderedImpl<KMER>::in_graph(node_index node) const {
+    assert(node > 0 && node <= kmers_.size());
+    std::ignore = node;
+    return true;
 }
 
 

--- a/metagraph/src/graph/hash_graph/dbg_hash_ordered.hpp
+++ b/metagraph/src/graph/hash_graph/dbg_hash_ordered.hpp
@@ -122,6 +122,8 @@ class DBGHashOrdered : public DeBruijnGraph {
 
     const std::string& alphabet() const { return hash_dbg_->alphabet(); }
 
+    bool in_graph(node_index node) const { return hash_dbg_->in_graph(node); }
+
     static constexpr auto kExtension = ".orhashdbg";
 
     class DBGHashOrderedInterface : public DeBruijnGraph {

--- a/metagraph/src/graph/hash_graph/dbg_hash_string.cpp
+++ b/metagraph/src/graph/hash_graph/dbg_hash_string.cpp
@@ -70,7 +70,7 @@ DBGHashString::traverse(node_index node, char next_char) const {
 
 DBGHashString::node_index
 DBGHashString::traverse_back(node_index node, char prev_char) const {
-    assert(node);
+    assert(in_graph(node));
     auto kmer = node_to_kmer(node);
     kmer.pop_back();
     return kmer_to_node(std::string(1, prev_char) + kmer);
@@ -79,7 +79,7 @@ DBGHashString::traverse_back(node_index node, char prev_char) const {
 void DBGHashString
 ::adjacent_outgoing_nodes(node_index node,
                           std::vector<node_index> *target_nodes) const {
-    assert(node);
+    assert(in_graph(node));
     assert(target_nodes);
 
     auto prefix = node_to_kmer(node).substr(1);
@@ -94,7 +94,7 @@ void DBGHashString
 void DBGHashString
 ::adjacent_incoming_nodes(node_index node,
                           std::vector<node_index> *source_nodes) const {
-    assert(node);
+    assert(in_graph(node));
     assert(source_nodes);
 
     auto suffix = node_to_kmer(node);
@@ -110,7 +110,7 @@ void DBGHashString
 void DBGHashString
 ::call_outgoing_kmers(node_index node,
                       const OutgoingEdgeCallback &callback) const {
-    assert(node);
+    assert(in_graph(node));
 
     auto prefix = node_to_kmer(node).substr(1);
 
@@ -124,7 +124,7 @@ void DBGHashString
 void DBGHashString
 ::call_incoming_kmers(node_index node,
                       const IncomingEdgeCallback &callback) const {
-    assert(node);
+    assert(in_graph(node));
 
     auto suffix = node_to_kmer(node);
     suffix.pop_back();
@@ -137,7 +137,7 @@ void DBGHashString
 }
 
 size_t DBGHashString::outdegree(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
 
     size_t outdegree = 0;
 
@@ -154,7 +154,7 @@ size_t DBGHashString::outdegree(node_index node) const {
 }
 
 size_t DBGHashString::indegree(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
 
     size_t indegree = 0;
 
@@ -191,7 +191,7 @@ DBGHashString::kmer_to_node(const std::string &kmer) const {
 }
 
 std::string DBGHashString::node_to_kmer(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
     assert(kmers_.at(node - 1).size() == k_);
     return std::string(kmers_.at(node - 1));
 }
@@ -303,3 +303,9 @@ std::vector<std::string> DBGHashString::encode_sequence(const std::string &seque
 }
 
 const std::string& DBGHashString::alphabet() const { return alphabet_; }
+
+bool DBGHashString::in_graph(node_index node) const {
+    assert(node > 0 && node <= kmers_.size());
+    std::ignore = node;
+    return true;
+}

--- a/metagraph/src/graph/hash_graph/dbg_hash_string.hpp
+++ b/metagraph/src/graph/hash_graph/dbg_hash_string.hpp
@@ -84,6 +84,8 @@ class DBGHashString : public DeBruijnGraph {
 
     const std::string& alphabet() const;
 
+    bool in_graph(node_index node) const;
+
   private:
     std::vector<std::string> encode_sequence(const std::string &sequence) const;
 

--- a/metagraph/src/graph/masked_graph.cpp
+++ b/metagraph/src/graph/masked_graph.cpp
@@ -4,22 +4,16 @@
 
 #include "sequence_graph.hpp"
 #include "serialization.hpp"
-#include "dbg_succinct.hpp"
 
 
 MaskedDeBruijnGraph
-::MaskedDeBruijnGraph(std::shared_ptr<const DeBruijnGraph> graph, bitmap *mask)
+::MaskedDeBruijnGraph(std::shared_ptr<const DeBruijnGraph> graph,
+                      std::unique_ptr<bitmap>&& kmers_in_graph)
       : graph_(graph),
-        is_target_mask_(mask) {
-    if (!is_target_mask_.get())
-        is_target_mask_.reset(new bitmap_lazy(
-            [&](const auto &i) { return i != DeBruijnGraph::npos; },
-            graph->num_nodes() + 1,
-            graph->num_nodes()
-        ));
-
-    assert(is_target_mask_->size() == graph->num_nodes() + 1);
-    assert(!(*is_target_mask_)[DeBruijnGraph::npos]);
+        kmers_in_graph_(std::move(kmers_in_graph)) {
+    assert(kmers_in_graph_.get());
+    assert(kmers_in_graph_->size() == graph->num_nodes() + 1);
+    assert(!(*kmers_in_graph_)[DeBruijnGraph::npos]);
 }
 
 MaskedDeBruijnGraph
@@ -27,9 +21,11 @@ MaskedDeBruijnGraph
                       std::function<bool(const DeBruijnGraph::node_index&)>&& callback,
                       size_t num_set_bits)
       : MaskedDeBruijnGraph(graph,
-                            new bitmap_lazy(std::move(callback),
-                                            graph->num_nodes() + 1,
-                                            num_set_bits)) {}
+                            std::make_unique<bitmap_lazy>(
+                                std::move(callback),
+                                graph->num_nodes() + 1,
+                                num_set_bits)
+                            ) {}
 
 // Traverse the outgoing edge
 MaskedDeBruijnGraph::node_index MaskedDeBruijnGraph
@@ -52,16 +48,6 @@ size_t MaskedDeBruijnGraph::outdegree(node_index node) const {
 }
 
 size_t MaskedDeBruijnGraph::indegree(node_index node) const {
-    auto dbg_succ = dynamic_cast<const DBGSuccinct*>(graph_.get());
-    if (dbg_succ) {
-        // avoid calls to indegree computation for DBGSuccinct
-        const auto &boss = dbg_succ->get_boss();
-        auto prev_boss_edge = boss.bwd(dbg_succ->kmer_to_boss_index(node));
-
-        if (boss.is_single_incoming(prev_boss_edge))
-            return in_graph(dbg_succ->boss_to_kmer_index(prev_boss_edge));
-    }
-
     std::vector<node_index> incoming;
     graph_->adjacent_incoming_nodes(node, &incoming);
     return std::count_if(incoming.begin(), incoming.end(),
@@ -121,34 +107,15 @@ void MaskedDeBruijnGraph
     );
 }
 
-uint64_t MaskedDeBruijnGraph
-::unmasked_outdegree(node_index node) const {
-    return graph_->outdegree(node);
-}
-
-uint64_t MaskedDeBruijnGraph
-::unmasked_indegree(node_index node) const {
-    return graph_->indegree(node);
-}
-
 void MaskedDeBruijnGraph
 ::call_nodes(const std::function<void(node_index)> &callback,
              const std::function<bool()> &stop_early) const {
-    assert(is_target_mask_.get());
-
-    is_target_mask_->call_ones(
+    kmers_in_graph_->call_ones(
         [&](auto index) {
             if (!stop_early())
                 callback(index);
         }
     );
-}
-
-
-void MaskedDeBruijnGraph
-::add_sequence(const std::string &,
-               bit_vector_dyn *) {
-    throw std::runtime_error("Not implemented");
 }
 
 // Traverse graph mapping sequence to the graph nodes
@@ -179,16 +146,11 @@ void MaskedDeBruijnGraph
     );
 }
 
+// TODO: This should ideally return kmers_in_graph_->num_set_bits(), but the
+//       API assumes that all node indices from 1 to num_nodes are valid. Until
+//       we remove that restriction that, this will stay like this.
 uint64_t MaskedDeBruijnGraph::num_nodes() const {
     return graph_->num_nodes();
-}
-
-bool MaskedDeBruijnGraph::load(const std::string &) {
-    throw std::runtime_error("Not implemented");
-}
-
-void MaskedDeBruijnGraph::serialize(const std::string &) const {
-    throw std::runtime_error("Not implemented");
 }
 
 // Get string corresponding to |node_index|.
@@ -201,7 +163,7 @@ bool MaskedDeBruijnGraph::operator==(const MaskedDeBruijnGraph &other) const {
     return get_k() == other.get_k()
             && is_canonical_mode() == other.is_canonical_mode()
             && num_nodes() == other.num_nodes()
-            && *is_target_mask_ == *other.is_target_mask_
+            && *kmers_in_graph_ == *other.kmers_in_graph_
             && *graph_ == *other.graph_;
 }
 
@@ -214,5 +176,5 @@ bool MaskedDeBruijnGraph::operator==(const DeBruijnGraph &other) const {
     if (dynamic_cast<const MaskedDeBruijnGraph*>(&other))
         return operator==(dynamic_cast<const MaskedDeBruijnGraph&>(other));
 
-    throw std::runtime_error("Not implemented");
+    return DeBruijnGraph::operator==(other);
 }

--- a/metagraph/src/graph/sequence_graph.cpp
+++ b/metagraph/src/graph/sequence_graph.cpp
@@ -58,7 +58,7 @@ void DeBruijnGraph::traverse(node_index start,
                              const char* end,
                              const std::function<void(node_index)> &callback,
                              const std::function<bool()> &terminate) const {
-    assert(start != npos);
+    assert(in_graph(start));
     assert(end >= begin);
     if (terminate())
         return;
@@ -89,6 +89,7 @@ void call_sequences_from(const DeBruijnGraph &graph,
                          ProgressBar &progress_bar,
                          bool call_unitigs = false,
                          uint64_t min_tip_size = 0) {
+    assert(graph.in_graph(start));
     assert((min_tip_size <= 1 || call_unitigs)
                 && "tip pruning works only for unitig extraction");
     assert(visited);
@@ -316,8 +317,8 @@ std::ostream& operator<<(std::ostream &out, const DeBruijnGraph &graph) {
 size_t incoming_edge_rank(const DeBruijnGraph &graph,
                           DeBruijnGraph::node_index source,
                           DeBruijnGraph::node_index target) {
-    assert(source && source <= graph.num_nodes());
-    assert(target && target <= graph.num_nodes());
+    assert(graph.in_graph(source));
+    assert(graph.in_graph(target));
 
     assert(graph.get_node_sequence(source).substr(1)
                 == graph.get_node_sequence(target).substr(0, graph.get_k() - 1));

--- a/metagraph/src/graph/sequence_graph.hpp
+++ b/metagraph/src/graph/sequence_graph.hpp
@@ -57,6 +57,9 @@ class SequenceGraph {
     // Get string corresponding to |node|.
     // Note: Not efficient if sequences in nodes overlap. Use sparingly.
     virtual std::string get_node_sequence(node_index node) const = 0;
+
+    // Check if the node index is a valid node in the graph
+    virtual bool in_graph(node_index node) const = 0;
 };
 
 
@@ -134,6 +137,9 @@ class DeBruijnGraph : public SequenceGraph {
 
     // Call all nodes that have no incoming edges
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const;
+
+    // Check if the node index is a valid node in the graph
+    virtual bool in_graph(node_index node) const = 0;
 };
 
 

--- a/metagraph/src/graph/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/succinct/dbg_succinct.cpp
@@ -34,7 +34,7 @@ bool DBGSuccinct::find(const std::string &sequence,
 
 // Traverse the outgoing edge
 node_index DBGSuccinct::traverse(node_index node, char next_char) const {
-    assert(node);
+    assert(in_graph(node));
 
     // dbg node is a boss edge
     BOSS::edge_index edge = boss_graph_->fwd(kmer_to_boss_index(node));
@@ -47,7 +47,7 @@ node_index DBGSuccinct::traverse(node_index node, char next_char) const {
 
 // Traverse the incoming edge
 node_index DBGSuccinct::traverse_back(node_index node, char prev_char) const {
-    assert(node);
+    assert(in_graph(node));
 
     // map dbg node, i.e. a boss edge, to a boss node
     auto boss_edge = kmer_to_boss_index(node);
@@ -85,7 +85,7 @@ inline void call_outgoing(const BOSS &boss,
 
 void DBGSuccinct::call_outgoing_kmers(node_index node,
                                       const OutgoingEdgeCallback &callback) const {
-    assert(node);
+    assert(in_graph(node));
 
     call_outgoing(*boss_graph_, kmer_to_boss_index(node), [&](auto i) {
         auto next = boss_to_kmer_index(i);
@@ -97,7 +97,7 @@ void DBGSuccinct::call_outgoing_kmers(node_index node,
 
 void DBGSuccinct::call_incoming_kmers(node_index node,
                                       const IncomingEdgeCallback &callback) const {
-    assert(node);
+    assert(in_graph(node));
 
     auto edge = kmer_to_boss_index(node);
 
@@ -116,7 +116,7 @@ void DBGSuccinct::call_incoming_kmers(node_index node,
 
 void DBGSuccinct::adjacent_outgoing_nodes(node_index node,
                                           std::vector<node_index> *target_nodes) const {
-    assert(node);
+    assert(in_graph(node));
     assert(target_nodes);
 
     call_outgoing(*boss_graph_, kmer_to_boss_index(node), [&](auto i) {
@@ -128,7 +128,7 @@ void DBGSuccinct::adjacent_outgoing_nodes(node_index node,
 
 void DBGSuccinct::adjacent_incoming_nodes(node_index node,
                                           std::vector<node_index> *source_nodes) const {
-    assert(node);
+    assert(in_graph(node));
     assert(source_nodes);
 
     auto edge = kmer_to_boss_index(node);
@@ -184,8 +184,7 @@ void DBGSuccinct::add_seq(const std::string &sequence,
 }
 
 std::string DBGSuccinct::get_node_sequence(node_index node) const {
-    assert(node);
-    assert(node <= num_nodes());
+    assert(in_graph(node));
 
     auto boss_edge = kmer_to_boss_index(node);
 
@@ -331,7 +330,7 @@ void DBGSuccinct::traverse(node_index start,
                            const char* end,
                            const std::function<void(node_index)> &callback,
                            const std::function<bool()> &terminate) const {
-    assert(start != npos);
+    assert(in_graph(start));
     assert(end >= begin);
 
     if (terminate())
@@ -436,7 +435,7 @@ void DBGSuccinct
 }
 
 size_t DBGSuccinct::outdegree(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
 
     auto boss_edge = kmer_to_boss_index(node);
 
@@ -460,7 +459,7 @@ size_t DBGSuccinct::outdegree(node_index node) const {
 }
 
 size_t DBGSuccinct::indegree(node_index node) const {
-    assert(node);
+    assert(in_graph(node));
 
     auto boss_edge = kmer_to_boss_index(node);
 
@@ -673,7 +672,7 @@ void DBGSuccinct::reset_mask() {
 }
 
 uint64_t DBGSuccinct::kmer_to_boss_index(node_index kmer_index) const {
-    assert(kmer_index <= num_nodes());
+    assert(in_graph(kmer_index));
 
     if (!valid_edges_.get() || !kmer_index)
         return kmer_index;
@@ -765,4 +764,10 @@ void DBGSuccinct::print(std::ostream &out) const {
 
         out << std::endl;
     }
+}
+
+bool DBGSuccinct::in_graph(node_index node) const {
+    assert(node > 0 && node <= num_nodes());
+    std::ignore = node;
+    return true;
 }

--- a/metagraph/src/graph/succinct/dbg_succinct.hpp
+++ b/metagraph/src/graph/succinct/dbg_succinct.hpp
@@ -121,6 +121,9 @@ class DBGSuccinct : public DeBruijnGraph {
 
     virtual void print(std::ostream &out) const override final;
 
+    // Check if the index is valid (there is a node assigned to it)
+    virtual bool in_graph(node_index node) const override final;
+
   protected:
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const override final;
 

--- a/metagraph/src/main.cpp
+++ b/metagraph/src/main.cpp
@@ -472,6 +472,7 @@ std::unique_ptr<Annotator> initialize_annotation(const std::string &filename,
 
 std::unique_ptr<AnnotatedDBG> initialize_annotated_dbg(std::shared_ptr<DeBruijnGraph> graph,
                                                        const Config &config) {
+    // TODO: introduce something like graph->max_node_index() to replace num_nodes() here
     auto annotation_temp = config.infbase_annotators.size()
             ? initialize_annotation(parse_annotation_type(config.infbase_annotators.at(0)), config, 0)
             : initialize_annotation(config.anno_type, config, graph->num_nodes());
@@ -564,7 +565,7 @@ mask_graph(const AnnotatedDBG &anno_graph, Config *config) {
                 auto count_out = counter_out();
                 return count_out <= config->label_mask_out_fraction * (count_in + count_out);
             }
-        ).release()
+        )
     );
 }
 

--- a/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
@@ -39,7 +39,7 @@ std::unique_ptr<AnnotatedDBG> build_anno_graph(uint64_t k,
                     std::move(dynamic_cast<annotate::ColumnCompressed<>&>(
                         *anno_graph->annotator_
                     )
-                )).release()
+                ))
             )
         );
 
@@ -71,7 +71,7 @@ MaskedDeBruijnGraph build_masked_graph(const AnnotatedDBG &anno_graph,
                 return incount == ingroup.size()
                     && outcount <= cutoff * (incount + outcount);
             }
-        ).release()
+        )
     );
 }
 
@@ -91,6 +91,6 @@ MaskedDeBruijnGraph build_masked_graph_lazy(const AnnotatedDBG &anno_graph,
                 uint64_t outcount = outcounter();
                 return outcount <= cutoff * (incount + outcount);
             }
-        ).release()
+        )
     );
 }

--- a/metagraph/tests/graph/test_masked_graph.cpp
+++ b/metagraph/tests/graph/test_masked_graph.cpp
@@ -31,15 +31,14 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallPathsNoMask) {
                     std::vector<std::string>({ "AAACT", "AAATG" }),
                     std::vector<std::string>({ "ATGCAGTACTCAG", "ATGCAGTAGTCAG", "GGGGGGGGGGGGG" }) }) {
 
-            MaskedDeBruijnGraph graph(build_graph_batch<TypeParam>(k, sequences));
+            auto graph = build_graph_batch<TypeParam>(k, sequences);
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<TypeParam>(
-                k,
-                [&](const auto &callback) { graph.call_sequences(callback); }
-            ));
-            EXPECT_EQ(graph, reconstructed)
-                << dynamic_cast<const TypeParam&>(*graph.get_graph_ptr()) << std::endl
-                << dynamic_cast<const TypeParam&>(*reconstructed.get_graph_ptr());
+            auto reconstructed = build_graph_iterative<TypeParam>(
+                k, [&](const auto &callback) { graph->call_sequences(callback); }
+            );
+            EXPECT_EQ(*graph, *reconstructed)
+                << dynamic_cast<const TypeParam&>(*graph) << std::endl
+                << dynamic_cast<const TypeParam&>(*reconstructed);
         }
     }
 }
@@ -54,15 +53,14 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallUnitigsNoMask) {
                     std::vector<std::string>({ "AAACT", "AAATG" }),
                     std::vector<std::string>({ "ATGCAGTACTCAG", "ATGCAGTAGTCAG", "GGGGGGGGGGGGG" }) }) {
 
-            MaskedDeBruijnGraph graph(build_graph_batch<TypeParam>(k, sequences));
+            auto graph = build_graph_batch<TypeParam>(k, sequences);
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<TypeParam>(
-                k,
-                [&](const auto &callback) { graph.call_unitigs(callback); }
-            ));
-            EXPECT_EQ(graph, reconstructed)
-                << dynamic_cast<const TypeParam&>(*graph.get_graph_ptr()) << std::endl
-                << dynamic_cast<const TypeParam&>(*reconstructed.get_graph_ptr());
+            auto reconstructed = build_graph_iterative<TypeParam>(
+                k, [&](const auto &callback) { graph->call_unitigs(callback); }
+            );
+            EXPECT_EQ(*graph, *reconstructed)
+                << dynamic_cast<const TypeParam&>(*graph) << std::endl
+                << dynamic_cast<const TypeParam&>(*reconstructed);
         }
     }
 }
@@ -77,17 +75,16 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallPathsNoMask) {
                     std::vector<std::string>({ "AAACT", "AAATG" }),
                     std::vector<std::string>({ "ATGCAGTACTCAG", "ATGCAGTAGTCAG", "GGGGGGGGGGGGG" }) }) {
 
-            MaskedDeBruijnGraph graph(build_graph_batch<TypeParam>(k, sequences));
+            auto graph = build_graph_batch<TypeParam>(k, sequences);
 
-            MaskedDeBruijnGraph stable_graph(build_graph_batch<DBGSuccinct>(k, sequences));
+            auto stable_graph = build_graph_batch<DBGSuccinct>(k, sequences);
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<DBGSuccinct>(
-                k,
-                [&](const auto &callback) { graph.call_sequences(callback); }
-            ));
-            EXPECT_EQ(stable_graph, reconstructed)
-                << dynamic_cast<const TypeParam&>(*graph.get_graph_ptr()) << std::endl
-                << dynamic_cast<const TypeParam&>(*reconstructed.get_graph_ptr());
+            auto reconstructed = build_graph_iterative<DBGSuccinct>(
+                k, [&](const auto &callback) { graph->call_sequences(callback); }
+            );
+            EXPECT_EQ(*stable_graph, *reconstructed)
+                << dynamic_cast<const TypeParam&>(*graph) << std::endl
+                << dynamic_cast<const TypeParam&>(*reconstructed);
         }
     }
 }
@@ -102,17 +99,16 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallUnitigsNoMask) {
                     std::vector<std::string>({ "AAACT", "AAATG" }),
                     std::vector<std::string>({ "ATGCAGTACTCAG", "ATGCAGTAGTCAG", "GGGGGGGGGGGGG" }) }) {
 
-            MaskedDeBruijnGraph graph(build_graph_batch<TypeParam>(k, sequences));
+            auto graph = build_graph_batch<TypeParam>(k, sequences);
 
-            MaskedDeBruijnGraph stable_graph(build_graph_batch<DBGSuccinct>(k, sequences));
+            auto stable_graph = build_graph_batch<DBGSuccinct>(k, sequences);
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<DBGSuccinct>(
-                k,
-                [&](const auto &callback) { graph.call_unitigs(callback); }
-            ));
-            EXPECT_EQ(stable_graph, reconstructed)
-                << dynamic_cast<const TypeParam&>(*graph.get_graph_ptr()) << std::endl
-                << dynamic_cast<const TypeParam&>(*reconstructed.get_graph_ptr());
+            auto reconstructed = build_graph_iterative<DBGSuccinct>(
+                k, [&](const auto &callback) { graph->call_unitigs(callback); }
+            );
+            EXPECT_EQ(*stable_graph, *reconstructed)
+                << dynamic_cast<const TypeParam&>(*graph) << std::endl
+                << dynamic_cast<const TypeParam&>(*reconstructed);
         }
     }
 }
@@ -138,25 +134,24 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallPathsMaskFirstKmer) {
                 }
             );
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<TypeParam>(
-                k,
-                [&](const auto &callback) { graph.call_sequences(callback); }
-            ));
+            auto reconstructed = build_graph_iterative<TypeParam>(
+                k, [&](const auto &callback) { graph.call_sequences(callback); }
+            );
 
-            MaskedDeBruijnGraph ref(build_graph_iterative<TypeParam>(
+            auto ref = build_graph_iterative<TypeParam>(
                 k,
                 [&](const auto &callback) {
                     graph.call_nodes([&](const auto &index) {
                         callback(graph.get_node_sequence(index));
                     });
                 }
-            ));
-            EXPECT_EQ(ref, reconstructed)
+            );
+            EXPECT_EQ(*ref, *reconstructed)
                 << *full_graph << std::endl
                 << first_kmer << std::endl
                 << graph << std::endl
-                << ref << std::endl
-                << reconstructed;
+                << *ref << std::endl
+                << *reconstructed;
 
             std::set<std::string> ref_nodes;
             for (DeBruijnGraph::node_index i = 1; i <= full_graph->num_nodes(); ++i) {
@@ -164,8 +159,8 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallPathsMaskFirstKmer) {
             }
 
             std::set<std::string> rec_nodes;
-            reconstructed.call_nodes([&](const auto &index) {
-                rec_nodes.insert(reconstructed.get_node_sequence(index));
+            reconstructed->call_nodes([&](const auto &index) {
+                rec_nodes.insert(reconstructed->get_node_sequence(index));
             });
             if (ref_nodes.size())
                 rec_nodes.insert(first_kmer);
@@ -195,25 +190,24 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallUnitigsMaskFirstKmer) {
                 }
             );
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<TypeParam>(
-                k,
-                [&](const auto &callback) { graph.call_unitigs(callback); }
-            ));
+            auto reconstructed = build_graph_iterative<TypeParam>(
+                k, [&](const auto &callback) { graph.call_unitigs(callback); }
+            );
 
-            MaskedDeBruijnGraph ref(build_graph_iterative<TypeParam>(
+            auto ref = build_graph_iterative<TypeParam>(
                 k,
                 [&](const auto &callback) {
                     graph.call_nodes([&](const auto &index) {
                         callback(graph.get_node_sequence(index));
                     });
                 }
-            ));
-            EXPECT_EQ(ref, reconstructed)
+            );
+            EXPECT_EQ(*ref, *reconstructed)
                 << *full_graph << std::endl
                 << first_kmer << std::endl
                 << graph << std::endl
-                << ref << std::endl
-                << reconstructed;
+                << *ref << std::endl
+                << *reconstructed;
 
             std::set<std::string> ref_nodes;
             for (DeBruijnGraph::node_index i = 1; i <= full_graph->num_nodes(); ++i) {
@@ -221,8 +215,8 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallUnitigsMaskFirstKmer) {
             }
 
             std::set<std::string> rec_nodes;
-            reconstructed.call_nodes([&](const auto &index) {
-                rec_nodes.insert(reconstructed.get_node_sequence(index));
+            reconstructed->call_nodes([&](const auto &index) {
+                rec_nodes.insert(reconstructed->get_node_sequence(index));
             });
             if (ref_nodes.size())
                 rec_nodes.insert(first_kmer);
@@ -252,25 +246,24 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallPathsMaskFirstKmer) {
                 }
             );
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<DBGSuccinct>(
-                k,
-                [&](const auto &callback) { graph.call_sequences(callback); }
-            ));
+            auto reconstructed = build_graph_iterative<DBGSuccinct>(
+                k, [&](const auto &callback) { graph.call_sequences(callback); }
+            );
 
-            MaskedDeBruijnGraph ref(build_graph_iterative<DBGSuccinct>(
+            auto ref = build_graph_iterative<DBGSuccinct>(
                 k,
                 [&](const auto &callback) {
                     graph.call_nodes([&](const auto &index) {
                         callback(graph.get_node_sequence(index));
                     });
                 }
-            ));
-            EXPECT_EQ(ref, reconstructed)
+            );
+            EXPECT_EQ(*ref, *reconstructed)
                 << *full_graph << std::endl
                 << first_kmer << std::endl
                 << graph << std::endl
-                << ref << std::endl
-                << reconstructed;
+                << *ref << std::endl
+                << *reconstructed;
 
             std::set<std::string> ref_nodes;
             for (DeBruijnGraph::node_index i = 1; i <= full_graph->num_nodes(); ++i) {
@@ -278,8 +271,8 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallPathsMaskFirstKmer) {
             }
 
             std::set<std::string> rec_nodes;
-            reconstructed.call_nodes([&](const auto &index) {
-                rec_nodes.insert(reconstructed.get_node_sequence(index));
+            reconstructed->call_nodes([&](const auto &index) {
+                rec_nodes.insert(reconstructed->get_node_sequence(index));
             });
             if (ref_nodes.size())
                 rec_nodes.insert(first_kmer);
@@ -309,25 +302,24 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallUnitigsMaskFirstKmer) {
                 }
             );
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<DBGSuccinct>(
-                k,
-                [&](const auto &callback) { graph.call_unitigs(callback); }
-            ));
+            auto reconstructed = build_graph_iterative<DBGSuccinct>(
+                k, [&](const auto &callback) { graph.call_unitigs(callback); }
+            );
 
-            MaskedDeBruijnGraph ref(build_graph_iterative<DBGSuccinct>(
+            auto ref = build_graph_iterative<DBGSuccinct>(
                 k,
                 [&](const auto &callback) {
                     graph.call_nodes([&](const auto &index) {
                         callback(graph.get_node_sequence(index));
                     });
                 }
-            ));
-            EXPECT_EQ(ref, reconstructed)
+            );
+            EXPECT_EQ(*ref, *reconstructed)
                 << *full_graph << std::endl
                 << first_kmer << std::endl
                 << graph << std::endl
-                << ref << std::endl
-                << reconstructed;
+                << *ref << std::endl
+                << *reconstructed;
 
             std::set<std::string> ref_nodes;
             for (DeBruijnGraph::node_index i = 1; i <= full_graph->num_nodes(); ++i) {
@@ -335,8 +327,8 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallUnitigsMaskFirstKmer) {
             }
 
             std::set<std::string> rec_nodes;
-            reconstructed.call_nodes([&](const auto &index) {
-                rec_nodes.insert(reconstructed.get_node_sequence(index));
+            reconstructed->call_nodes([&](const auto &index) {
+                rec_nodes.insert(reconstructed->get_node_sequence(index));
             });
             if (ref_nodes.size())
                 rec_nodes.insert(first_kmer);
@@ -353,8 +345,8 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallContigsMaskPath) {
         auto full_graph = build_graph_batch<TypeParam>(k, sequences);
 
         for (const auto &sequence : sequences) {
-            std::unique_ptr<bit_vector> mask(
-                new bit_vector_stat(full_graph->num_nodes() + 1, true)
+            auto mask = std::make_unique<bit_vector_stat>(
+                full_graph->num_nodes() + 1, true
             );
             mask->set(DeBruijnGraph::npos, false);
             full_graph->map_to_nodes(
@@ -362,7 +354,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallContigsMaskPath) {
                 [&](const auto &index) { mask->set(index, false); }
             );
 
-            MaskedDeBruijnGraph graph(full_graph, mask.release());
+            MaskedDeBruijnGraph graph(full_graph, std::move(mask));
 
             size_t counter = 0;
             graph.map_to_nodes(
@@ -375,10 +367,9 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallContigsMaskPath) {
 
             EXPECT_EQ(sequence.size() + 1 - graph.get_k(), counter);
 
-            MaskedDeBruijnGraph reconstructed(build_graph_iterative<TypeParam>(
-                k,
-                [&](const auto &callback) { graph.call_sequences(callback); }
-            ));
+            auto reconstructed = build_graph_iterative<TypeParam>(
+                k, [&](const auto &callback) { graph.call_sequences(callback); }
+            );
 
             std::multiset<std::string> all_nodes;
             for (DeBruijnGraph::node_index i = 1; i <= full_graph->num_nodes(); ++i) {
@@ -397,8 +388,8 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallContigsMaskPath) {
             });
 
             std::multiset<std::string> rec_nodes;
-            reconstructed.call_nodes([&](const auto &index) {
-                rec_nodes.insert(reconstructed.get_node_sequence(index));
+            reconstructed->call_nodes([&](const auto &index) {
+                rec_nodes.insert(reconstructed->get_node_sequence(index));
             });
             EXPECT_EQ(called_nodes, rec_nodes);
         }
@@ -413,8 +404,8 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CheckNodes) {
         auto full_graph = build_graph_batch<TypeParam>(k, sequences);
 
         for (const auto &sequence : sequences) {
-            std::unique_ptr<bit_vector> mask(
-                new bit_vector_stat(full_graph->num_nodes() + 1, true)
+            auto mask = std::make_unique<bit_vector_stat>(
+                full_graph->num_nodes() + 1, true
             );
             mask->set(DeBruijnGraph::npos, false);
             std::set<std::string> erased;
@@ -426,7 +417,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CheckNodes) {
                 }
             );
 
-            MaskedDeBruijnGraph graph(full_graph, mask.release());
+            MaskedDeBruijnGraph graph(full_graph, std::move(mask));
 
             std::multiset<MaskedDeBruijnGraph::node_index> nodes;
             graph.call_nodes([&](const auto &node) { nodes.insert(node); });
@@ -450,8 +441,8 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CheckOutgoingNodes) {
         auto full_graph = build_graph_batch<TypeParam>(k, sequences);
 
         for (const auto &sequence : sequences) {
-            std::unique_ptr<bit_vector> mask(
-                new bit_vector_stat(full_graph->num_nodes() + 1, true)
+            auto mask = std::make_unique<bit_vector_stat>(
+                full_graph->num_nodes() + 1, true
             );
             mask->set(DeBruijnGraph::npos, false);
             std::set<std::string> erased;
@@ -463,7 +454,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CheckOutgoingNodes) {
                 }
             );
 
-            MaskedDeBruijnGraph graph(full_graph, mask.release());
+            MaskedDeBruijnGraph graph(full_graph, std::move(mask));
 
             graph.call_nodes(
                 [&](const auto &node) {
@@ -493,8 +484,8 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CheckIncomingNodes) {
         auto full_graph = build_graph_batch<TypeParam>(k, sequences);
 
         for (const auto &sequence : sequences) {
-            std::unique_ptr<bit_vector> mask(
-                new bit_vector_stat(full_graph->num_nodes() + 1, true)
+            auto mask = std::make_unique<bit_vector_stat>(
+                full_graph->num_nodes() + 1, true
             );
             mask->set(DeBruijnGraph::npos, false);
             std::set<std::string> erased;
@@ -506,7 +497,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CheckIncomingNodes) {
                 }
             );
 
-            MaskedDeBruijnGraph graph(full_graph, mask.release());
+            MaskedDeBruijnGraph graph(full_graph, std::move(mask));
 
             graph.call_nodes(
                 [&](const auto &node) {


### PR DESCRIPTION
Changelog
1) Added `SequenceGraph::in_graph`
2) Refactored algorithms in `annotated_graph_algorithm` to use `DeBruijnGraph` instead of `MaskedDeBruijnGraph`
3) Cleaned up unneeded functions from `MaskedDeBruijnGraph`
4) Removed ability to construct a `MaskedDeBruijnGraph` without a set bit mask (which before resulted in a graph with a bit mask that always evaluated to true)