### PR TITLE
Cache rows in all annotators

### DIFF
--- a/metagraph/src/annotation/annotate.hpp
+++ b/metagraph/src/annotation/annotate.hpp
@@ -8,6 +8,9 @@
 #include <memory>
 #include <functional>
 
+#include <cache.hpp>
+#include <lru_cache_policy.hpp>
+
 
 namespace annotate {
 
@@ -193,8 +196,17 @@ class MultiLabelEncoded
 
     virtual std::string file_extension() const override = 0;
 
+    virtual void reset_row_cache(size_t size) final {
+        cached_rows_.reset(size ? new RowCacheType(size) : nullptr);
+    }
+
   protected:
     LabelEncoder<Label> label_encoder_;
+
+    typedef caches::fixed_sized_cache<Index,
+                                      std::vector<uint64_t>,
+                                      caches::LRUCachePolicy<Index>> RowCacheType;
+    mutable std::unique_ptr<RowCacheType> cached_rows_;
 };
 
 } // namespace annotate

--- a/metagraph/src/annotation/annotate_static.cpp
+++ b/metagraph/src/annotation/annotate_static.cpp
@@ -158,12 +158,6 @@ std::vector<uint64_t> StaticBinRelAnnotator<BinaryMatrixType, Label>
 }
 
 template <class BinaryMatrixType, typename Label>
-void StaticBinRelAnnotator<BinaryMatrixType, Label>
-::reset_row_cache(size_t size) {
-    cached_rows_.reset(size ? new RowCacheType(size) : nullptr);
-}
-
-template <class BinaryMatrixType, typename Label>
 bool StaticBinRelAnnotator<BinaryMatrixType, Label>
 ::dump_columns(const std::string &prefix, bool binary, uint64_t num_threads) const {
     size_t m = num_labels();
@@ -226,7 +220,7 @@ bool StaticBinRelAnnotator<BinaryMatrixType, Label>
 template <class BinaryMatrixType, typename Label>
 StaticBinRelAnnotator<BinaryMatrixType, Label>
 ::StaticBinRelAnnotator(size_t row_cache_size) : matrix_(new BinaryMatrixType()) {
-    reset_row_cache(row_cache_size);
+    MultiLabelEncoded<uint64_t, Label>::reset_row_cache(row_cache_size);
 }
 
 template <class BinaryMatrixType, typename Label>
@@ -235,7 +229,7 @@ StaticBinRelAnnotator<BinaryMatrixType, Label>
                         const LabelEncoder<Label> &label_encoder,
                         size_t row_cache_size) : matrix_(std::move(matrix)) {
     assert(matrix_.get());
-    reset_row_cache(row_cache_size);
+    MultiLabelEncoded<uint64_t, Label>::reset_row_cache(row_cache_size);
     label_encoder_ = label_encoder;
 }
 

--- a/metagraph/src/annotation/annotate_static.hpp
+++ b/metagraph/src/annotation/annotate_static.hpp
@@ -4,9 +4,6 @@
 #include <memory>
 #include <vector>
 
-#include <cache.hpp>
-#include <lru_cache_policy.hpp>
-
 #include "annotate.hpp"
 
 
@@ -50,8 +47,6 @@ class StaticBinRelAnnotator : public MultiLabelEncoded<uint64_t, Label> {
     void call_objects(const Label &label,
                       std::function<void(Index)> callback) const override;
 
-    void reset_row_cache(size_t size);
-
     std::string file_extension() const override;
 
   private:
@@ -63,12 +58,11 @@ class StaticBinRelAnnotator : public MultiLabelEncoded<uint64_t, Label> {
         MultiLabelEncoded<uint64_t, Label>::label_encoder_
     };
 
-    std::vector<uint64_t> get_label_codes(Index i) const override;
+    std::unique_ptr<typename MultiLabelEncoded<uint64_t, Label>::RowCacheType> &cached_rows_ {
+        MultiLabelEncoded<uint64_t, Label>::cached_rows_
+    };
 
-    typedef caches::fixed_sized_cache<Index,
-                                      std::vector<uint64_t>,
-                                      caches::LRUCachePolicy<Index>> RowCacheType;
-    mutable std::unique_ptr<RowCacheType> cached_rows_;
+    std::vector<uint64_t> get_label_codes(Index i) const override;
 
     static const std::string kExtension;
 };

--- a/metagraph/src/annotation/column_compressed/annotate_column_compressed.hpp
+++ b/metagraph/src/annotation/column_compressed/annotate_column_compressed.hpp
@@ -32,10 +32,14 @@ class ColumnCompressed : public MultiLabelEncoded<uint64_t, Label> {
 
     ColumnCompressed(uint64_t num_rows = 0,
                      size_t num_columns_cached = 1,
-                     bool verbose = false);
+                     bool verbose = false,
+                     size_t row_cache_size = 0);
 
     ColumnCompressed(const ColumnCompressed&) = delete;
     ColumnCompressed& operator=(const ColumnCompressed&) = delete;
+
+    ColumnCompressed(ColumnCompressed&& other) noexcept;
+    ColumnCompressed& operator=(ColumnCompressed&& other) noexcept = delete;
 
     ~ColumnCompressed();
 
@@ -114,6 +118,10 @@ class ColumnCompressed : public MultiLabelEncoded<uint64_t, Label> {
 
     LabelEncoder<Label> &label_encoder_ {
         MultiLabelEncoded<uint64_t, Label>::label_encoder_
+    };
+
+    std::unique_ptr<typename MultiLabelEncoded<uint64_t, Label>::RowCacheType> &cached_rows_ {
+        MultiLabelEncoded<uint64_t, Label>::cached_rows_
     };
 
     bool verbose_;

--- a/metagraph/src/annotation/row_compressed/annotate_row_compressed.hpp
+++ b/metagraph/src/annotation/row_compressed/annotate_row_compressed.hpp
@@ -40,7 +40,7 @@ class RowCompressed : public MultiLabelEncoded<uint64_t, Label> {
     using Index = typename MultiLabelEncoded<uint64_t, Label>::Index;
     using VLabels = typename MultiLabelEncoded<uint64_t, Label>::VLabels;
 
-    RowCompressed(uint64_t num_rows = 0, bool sparse = false);
+    RowCompressed(uint64_t num_rows = 0, bool sparse = false, size_t row_cache_size = 0);
 
     void set_labels(Index i, const VLabels &labels);
     VLabels get_labels(Index i) const;
@@ -68,12 +68,16 @@ class RowCompressed : public MultiLabelEncoded<uint64_t, Label> {
     std::string file_extension() const { return kExtension; }
 
   private:
-    void reinitialize(uint64_t num_rows);
+    void reinitialize(uint64_t num_rows, size_t row_cache_size = 0);
 
     std::unique_ptr<BinaryMatrixRowDynamic> matrix_;
 
     LabelEncoder<Label> &label_encoder_ {
         MultiLabelEncoded<uint64_t, Label>::label_encoder_
+    };
+
+    std::unique_ptr<typename MultiLabelEncoded<uint64_t, Label>::RowCacheType> &cached_rows_ {
+        MultiLabelEncoded<uint64_t, Label>::cached_rows_
     };
 
     static std::unique_ptr<LabelEncoder<Label>>
@@ -98,9 +102,7 @@ class RowCompressed : public MultiLabelEncoded<uint64_t, Label> {
                            const LabelEncoder<Label> &label_encoder,
                            const std::function<void(BinaryMatrix::RowCallback&)> &call_rows);
 
-    std::vector<uint64_t> get_label_codes(Index i) const {
-        return matrix_->get_row(i);
-    }
+    std::vector<uint64_t> get_label_codes(Index i) const;
 
     static constexpr auto kExtension = kRowAnnotatorExtension;
 };


### PR DESCRIPTION
Addresses #44 

I think the current test for repeatedly calling a subset of rows happens to pick the rows that are hardest to query, based on these results

```
Note: Google Test filter = *Cache*LONG*
[==========] Running 5 tests from 5 test cases.
[----------] Global test environment set-up.
[----------] 1 test from AnnotatorStaticLargeTest/0, where TypeParam = annotate::StaticBinRelAnnotator<BRWT, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >
[ RUN      ] AnnotatorStaticLargeTest/0.DISABLED_QueryRowsCached_LONG_TEST
[          ] Query some rows repeatedly Cache size:     0               Time:   120.786
[          ] Query some rows repeatedly Cache size:     1000            Time:   131.353
[          ] Query some rows repeatedly Cache size:     10000           Time:   5.32745
[          ] Query some rows repeatedly Cache size:     100000          Time:   5.36247
[          ] Query some rows repeatedly Cache size:     1000000         Time:   5.34255
[          ] Query some rows repeatedly Cache size:     10000000                Time:   5.32671
[          ] Query all rows     Cache size:     0               Time:   0.165871
[          ] Query all rows     Cache size:     1000            Time:   4.45716
[          ] Query all rows     Cache size:     10000           Time:   4.45469
[          ] Query all rows     Cache size:     100000          Time:   4.43731
[          ] Query all rows     Cache size:     1000000         Time:   4.58845
[          ] Query all rows     Cache size:     10000000                Time:   4.6503
[       OK ] AnnotatorStaticLargeTest/0.DISABLED_QueryRowsCached_LONG_TEST (296876 ms)
[----------] 1 test from AnnotatorStaticLargeTest/0 (296876 ms total)

[----------] 1 test from AnnotatorStaticLargeTest/1, where TypeParam = annotate::StaticBinRelAnnotator<Rainbowfish, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >
[ RUN      ] AnnotatorStaticLargeTest/1.DISABLED_QueryRowsCached_LONG_TEST
[          ] Query some rows repeatedly Cache size:     0               Time:   28.496
[          ] Query some rows repeatedly Cache size:     1000            Time:   34.6514
[          ] Query some rows repeatedly Cache size:     10000           Time:   5.44702
[          ] Query some rows repeatedly Cache size:     100000          Time:   5.55994
[          ] Query some rows repeatedly Cache size:     1000000         Time:   5.5049
[          ] Query some rows repeatedly Cache size:     10000000                Time:   5.5011
[          ] Query all rows     Cache size:     0               Time:   0.522106
[          ] Query all rows     Cache size:     1000            Time:   4.64717
[          ] Query all rows     Cache size:     10000           Time:   4.65375
[          ] Query all rows     Cache size:     100000          Time:   4.65384
[          ] Query all rows     Cache size:     1000000         Time:   4.71095
[          ] Query all rows     Cache size:     10000000                Time:   4.79809
[       OK ] AnnotatorStaticLargeTest/1.DISABLED_QueryRowsCached_LONG_TEST (109899 ms)
[----------] 1 test from AnnotatorStaticLargeTest/1 (109899 ms total)

[----------] 1 test from AnnotatorStaticLargeTest/2, where TypeParam = annotate::StaticBinRelAnnotator<RowConcatenated<bit_vector_sd>, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >
[ RUN      ] AnnotatorStaticLargeTest/2.DISABLED_QueryRowsCached_LONG_TEST
[          ] Query some rows repeatedly Cache size:     0               Time:   14.4849
[          ] Query some rows repeatedly Cache size:     1000            Time:   20.3568
[          ] Query some rows repeatedly Cache size:     10000           Time:   5.5015
[          ] Query some rows repeatedly Cache size:     100000          Time:   5.34419
[          ] Query some rows repeatedly Cache size:     1000000         Time:   5.31847
[          ] Query some rows repeatedly Cache size:     10000000                Time:   5.28343
[          ] Query all rows     Cache size:     0               Time:   0.118336
[          ] Query all rows     Cache size:     1000            Time:   4.45128
[          ] Query all rows     Cache size:     10000           Time:   4.38539
[          ] Query all rows     Cache size:     100000          Time:   4.40261
[          ] Query all rows     Cache size:     1000000         Time:   4.51563
[          ] Query all rows     Cache size:     10000000                Time:   4.57298
[       OK ] AnnotatorStaticLargeTest/2.DISABLED_QueryRowsCached_LONG_TEST (79321 ms)
[----------] 1 test from AnnotatorStaticLargeTest/2 (79321 ms total)

[----------] 1 test from AnnotatorStaticLargeTest/3, where TypeParam = annotate::ColumnCompressed<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >
[ RUN      ] AnnotatorStaticLargeTest/3.DISABLED_QueryRowsCached_LONG_TEST
[          ] Query some rows repeatedly Cache size:     0               Time:   34.5397
[          ] Query some rows repeatedly Cache size:     1000            Time:   42.0483
[          ] Query some rows repeatedly Cache size:     10000           Time:   5.9716
[          ] Query some rows repeatedly Cache size:     100000          Time:   5.94687
[          ] Query some rows repeatedly Cache size:     1000000         Time:   5.98963
[          ] Query some rows repeatedly Cache size:     10000000                Time:   5.96111
[          ] Query all rows     Cache size:     0               Time:   23.0588
[          ] Query all rows     Cache size:     1000            Time:   28.3425
[          ] Query all rows     Cache size:     10000           Time:   28.2223
[          ] Query all rows     Cache size:     100000          Time:   28.3814
[          ] Query all rows     Cache size:     1000000         Time:   28.5629
[          ] Query all rows     Cache size:     10000000                Time:   28.6116
[       OK ] AnnotatorStaticLargeTest/3.DISABLED_QueryRowsCached_LONG_TEST (266190 ms)
[----------] 1 test from AnnotatorStaticLargeTest/3 (266190 ms total)

[----------] 1 test from AnnotatorStaticLargeTest/4, where TypeParam = annotate::RowCompressed<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > >
[ RUN      ] AnnotatorStaticLargeTest/4.DISABLED_QueryRowsCached_LONG_TEST
[          ] Query some rows repeatedly Cache size:     0               Time:   4.93414
[          ] Query some rows repeatedly Cache size:     1000            Time:   8.95731
[          ] Query some rows repeatedly Cache size:     10000           Time:   4.96763
[          ] Query some rows repeatedly Cache size:     100000          Time:   5.00911
[          ] Query some rows repeatedly Cache size:     1000000         Time:   4.97877
[          ] Query some rows repeatedly Cache size:     10000000                Time:   5.01719
[          ] Query all rows     Cache size:     0               Time:   0.02706
[          ] Query all rows     Cache size:     1000            Time:   3.03807
[          ] Query all rows     Cache size:     10000           Time:   3.06128
[          ] Query all rows     Cache size:     100000          Time:   3.04991
[          ] Query all rows     Cache size:     1000000         Time:   3.15491
[          ] Query all rows     Cache size:     10000000                Time:   3.23382
[       OK ] AnnotatorStaticLargeTest/4.DISABLED_QueryRowsCached_LONG_TEST (50011 ms)
[----------] 1 test from AnnotatorStaticLargeTest/4 (50011 ms total)

[----------] Global test environment tear-down
[==========] 5 tests from 5 test cases ran. (802300 ms total)
[  PASSED  ] 5 tests.
```