### PR TITLE
Small fixes to main build file to make it work on my Mac

### DIFF
--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -100,7 +100,7 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   ")
 endif()
 
-if (APPLE)
+if(APPLE)
     # Fix include directories on 10.14+, as they are not added by default any longer
     string(APPEND CMAKE_CXX_FLAGS " \
     -I/usr/include \
@@ -110,6 +110,7 @@ if (APPLE)
   LINK_DIRECTORIES(/usr/lib)
   LINK_DIRECTORIES(/usr/local/lib)
 endif()
+
 # unset OpenMP_CXX_FLAGS. If OpenMP loading fails once, it will be set to NOT_FOUND
 # and happily cached, thus messing up the compilation flags forever
 unset(OpenMP_CXX_FLAGS CACHE)
@@ -354,8 +355,6 @@ endif()
 # check for std::filesystem::temp_directory_path
 include(CheckCXXSourceRuns)
 set(CMAKE_REQUIRED_FLAGS " -std=c++17")
-
-unset(CPPNOFS CACHE)
 check_cxx_source_runs("
     #include <iostream>
     #include <filesystem>


### PR DESCRIPTION
This fixes some small issues: 
  - on newer Macs, /usr/local/include and /usr/local/lib are not searched by default anymore. This can be worked around by setting some corresponding env variables, but this is more robuts
  - if openmp is not loaded once, the build will never work again, as NOT_FOUND is cached on disk for the openmp library. I fixed that by resetting the value of the openmp_cxx_flags and tested that it works

Though unlikely, it *is* possible that I broke something on other platforms. Feel free to try it out on Linux/gcc.