### PR TITLE
Proposed clang-format file for automatically formatting our code

### DIFF
--- a/metagraph/.clang-format
+++ b/metagraph/.clang-format
@@ -38,7 +38,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializersBeforeComma: false
 BreakConstructorInitializers: BeforeColon
 BreakStringLiterals: true
-ColumnLimit: 100
+ColumnLimit: 90
 CompactNamespaces: false
 ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 6
@@ -85,7 +85,6 @@ SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
 SpaceBeforeParens: ControlStatements
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyBlock: false
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 1
 SpacesInAngles: false


### PR DESCRIPTION
The idea is that we never have to think about formatting code again, and think instead about the code itself. This also ensures a uniform and professional look of the codebase, should it be made publicly available.
At the same time, I am trying to mimic as closely as possible the style that you guys already have, so that the disruption is minimal. The only slightly contentious change that I introduced is to slightly extend the line length to 100 chars (I used 120 chars in my previous projects, but I wanted to be sensitive at people who review code on small screens).
The best way to review the code is to pull the file and use your favourite editor to format the code using clang format (all editors in the universe support it). You can then see if any of the changes offend you. I personally don't really care about how we format it, as long as I don't have to think about formatting :)