### PR TITLE
Changed VectorFileStream constructor to fix Utils.RowsFromColumnsTransformer unit tests

### DIFF
--- a/metagraph/src/common/serialization.cpp
+++ b/metagraph/src/common/serialization.cpp
@@ -418,13 +418,25 @@ VectorFileStream::VectorFileStream(const std::string &file)
     if (!istream_.good())
         throw std::ifstream::failure(std::string("Bad stream file ") + file);
 
+    max_val_ = load_number(istream_);
+
     values_left_ = load_number(istream_);
 }
 
 uint64_t VectorFileStream::next_value() {
     assert(values_left_ > 0);
     values_left_--;
-    return load_number(istream_);
+
+    size_t cur_val = load_number(istream_);
+
+    if (cur_val >= max_val_)
+        throw std::runtime_error(
+            "Error: invalid index "
+                + std::to_string(cur_val) + " >= "
+                + std::to_string(max_val_)
+        );
+
+    return cur_val;
 }
 
 VectorBitStream::VectorBitStream(const bit_vector &vec,

--- a/metagraph/src/common/serialization.hpp
+++ b/metagraph/src/common/serialization.hpp
@@ -91,6 +91,7 @@ class VectorFileStream : public VectorStream {
 
     Stream istream_;
     uint64_t values_left_;
+    uint64_t max_val_;
 };
 
 // Return set bits from a bit vector

--- a/metagraph/tests/test_utils.cpp
+++ b/metagraph/tests/test_utils.cpp
@@ -47,11 +47,11 @@ utils::RowsFromColumnsTransformer generate_rct_file() {
     annotation.set_labels(4, { "Label1" });
     annotation.set_labels(5, { "Label0", "Label1" });
 
-    annotation.dump_columns(test_dump_basename);
+    annotation.dump_columns(test_dump_basename, true);
 
     utils::RowsFromColumnsTransformer rct(7, {
-        test_dump_basename + ".0.raw.column.annodbg",
-        test_dump_basename + ".1.raw.column.annodbg"
+        test_dump_basename + ".0.raw.annodbg",
+        test_dump_basename + ".1.raw.annodbg"
     });
 
     return rct;


### PR DESCRIPTION
This slightly changes the functionality of VectorFileStream. It now expects the first number to be the maximal value of the following numbers + 1 (i.e., the length of a bit vector), then the second number to be the number of following numbers (i.e., the number of set bits).

I double-checked and it seems like we don't use VectorFileStream anywhere except for the unit tests mentioned in the title.