### PR TITLE
Save the result of the merging in SortedSetDisk to disk.

### DIFF
--- a/metagraph/src/common/chunked_wait_queue.hpp
+++ b/metagraph/src/common/chunked_wait_queue.hpp
@@ -43,18 +43,19 @@ class ChunkedWaitQueue {
 
     /**
      * Constructs a WaitQueue with the given size parameters.
-     * @param buffer_size the size of the buffer used internally by the queue
+     * @param buffer_size_bytes the size of the buffer in bytes used internally by the queue
      * @param fence_size the number of elements that can be iterated backwards. The queue
      * will always keep at least fence_size elements behind the furthest iterator for this
      * purpose. Must be smaller than #buffer_size, and in practice it's orders of
      * magnitude smaller.
      */
-    explicit ChunkedWaitQueue(size_type buffer_size, size_type fence_size)
-        : chunk_size_(std::min(std::max(1UL, buffer_size / 3), buffer_size - fence_size)),
+    explicit ChunkedWaitQueue(size_type buffer_size_bytes, size_type fence_size)
+        : chunk_size_(std::min(std::max(1UL, buffer_size_bytes / 3),
+                               buffer_size_bytes - fence_size)),
           fence_size_(fence_size),
           is_shutdown_(false) {
-        assert(fence_size * sizeof(T) < buffer_size);
-        queue_ = std::vector<T>(buffer_size);
+        assert(fence_size * sizeof(T) < buffer_size_bytes);
+        queue_ = std::vector<T>(buffer_size_bytes);
     }
 
     /**

--- a/metagraph/src/common/sorted_set_disk.hpp
+++ b/metagraph/src/common/sorted_set_disk.hpp
@@ -41,7 +41,7 @@ class SortedSetDisk {
     /** Size of the merge queue's underlying circular buffer */
     static constexpr size_t MERGE_QUEUE_SIZE = 1e9; // 1GB
     /** Number of elements that can be iterated backwards in the merge queue */
-    static constexpr size_t MERGE_QUEUE_BACKWARDS_COUNT = 100;
+    static constexpr size_t NUM_LAST_ELEMENTS_CACHED = 100;
 
     typedef T key_type;
     typedef T value_type;
@@ -61,15 +61,15 @@ class SortedSetDisk {
     SortedSetDisk(
             std::function<void(storage_type *)> = [](storage_type *) {},
             const std::string &out_file = "",
-                  size_t num_threads = 1,
-                  bool verbose = false,
-                  size_t container_size = CONTAINER_SIZE_BYTES,
-                  size_t merge_queue_size = MERGE_QUEUE_SIZE,
-                  size_t merge_queue_backwards_count = MERGE_QUEUE_BACKWARDS_COUNT)
+            size_t num_threads = 1,
+            bool verbose = false,
+            size_t container_size = CONTAINER_SIZE_BYTES,
+            size_t merge_queue_size = MERGE_QUEUE_SIZE,
+            size_t num_last_elements_cached = NUM_LAST_ELEMENTS_CACHED)
         : num_threads_(num_threads),
           verbose_(verbose),
           out_file_(out_file),
-          merge_queue_(merge_queue_size, merge_queue_backwards_count) {
+          merge_queue_(merge_queue_size, num_last_elements_cached) {
         try {
             try_reserve(container_size);
         } catch (const std::bad_alloc &exception) {
@@ -152,17 +152,18 @@ class SortedSetDisk {
 
         std::priority_queue<std::pair<T, uint32_t>, std::vector<std::pair<T, uint32_t>>, decltype(comp)>
                 merge_heap(comp);
-
+        auto get_chunk_file_name = [](uint32_t i) {
+            return output_dir + "chunk_" + std::to_string(i) + ".bin";
+        };
         for (uint32_t i = 0; i < chunk_count; ++i) {
-            const std::string file_name
-                    = output_dir + "chunk_" + std::to_string(i) + ".bin";
-            chunk_files[i].open(file_name, std::ios::in | std::ios::binary);
+            chunk_files[i].open(get_chunk_file_name(i), std::ios::in | std::ios::binary);
             T data_item;
             if (chunk_files[i].good()) {
                 chunk_files[i].read(reinterpret_cast<char *>(&data_item), sizeof(data_item));
                 merge_heap.push({ data_item, i });
             } else {
-                throw std::runtime_error("Unable to open chunk file " + file_name);
+                throw std::runtime_error("Unable to open chunk file "
+                                         + get_chunk_file_name(i));
             }
         }
         uint64_t totalSize = 0;
@@ -173,7 +174,7 @@ class SortedSetDisk {
         if (out_file != "") {
             sorted_file = std::fstream(out_file, std::ios::binary | std::ios::out);
             if (!sorted_file) {
-                std::cerr << "Could not create file " << out_file << std::endl;
+                std::cerr << "Error: Could not create file " << out_file << std::endl;
                 std::exit(EXIT_FAILURE);
             }
         }
@@ -189,7 +190,8 @@ class SortedSetDisk {
                     // be a bottleneck (a simple produce/consumer queue should work)
                     if (!sorted_file.write(reinterpret_cast<char *>(&smallest.first),
                                            sizeof(T))) {
-                        std::cerr << "Writing of merged data to " + out_file + " failed."
+                        std::cerr << "Error: Writing of merged data to " + out_file
+                                        + " failed."
                                   << std::endl;
                         std::exit(EXIT_FAILURE);
                     }
@@ -208,12 +210,8 @@ class SortedSetDisk {
         }
         merge_queue->shutdown();
         sorted_file.close();
-        if (out_file != "") {
-            for (uint32_t i = 0; i < chunk_count; ++i) {
-                const std::string file_name
-                        = output_dir + "chunk_" + std::to_string(i) + ".bin";
-                std::filesystem::remove(file_name);
-            }
+        for (uint32_t i = 0; i < chunk_count; ++i) {
+            std::filesystem::remove(get_chunk_file_name(i));
         }
     }
 

--- a/metagraph/tests/common/test_sorted_set_disk.cpp
+++ b/metagraph/tests/common/test_sorted_set_disk.cpp
@@ -53,10 +53,10 @@ SortedSetDisk<T> create_sorted_set_disk() {
     constexpr size_t thread_count = 1;
     constexpr size_t container_size = 8;
     constexpr size_t merge_queue_size = 1000;
-    constexpr size_t merge_queue_backwards_count = 10;
+    constexpr size_t num_last_elements_cached = 10;
     auto cleanup = [](typename SortedSetDisk<T>::storage_type *) {};
     return SortedSetDisk<T>(cleanup, out_file, thread_count, verbose, container_size,
-                            merge_queue_size, merge_queue_backwards_count);
+                            merge_queue_size, num_last_elements_cached);
 }
 
 TYPED_TEST(SortedSetDiskTest, Empty) {


### PR DESCRIPTION
A simple CL that enables the SortdSetDisk to optionally write its contents to disk when merging it. 
Notes: 
  - writing to disk is buffered, but blocking; this may be a bottleneck, in which case we move the writing to a  consumer thread
  - I am now cleaning up the temporary files created by SortedSetDisk 
  