### PR TITLE
Enable using ccache, if installed

### DIFF
--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -5,6 +5,9 @@ project(Metagraph)
 
 include(CheckFunctionExists)
 include(CheckLibraryExists)
+include(CMakeListsHelpers.txt)
+
+enableCCache()
 
 enable_testing()
 

--- a/metagraph/CMakeListsHelpers.txt
+++ b/metagraph/CMakeListsHelpers.txt
@@ -117,3 +117,14 @@ set(GTEST_BOTH_LIBRARIES
     "${EXTERNAL_LIB_DIR}/sdsl-lite/lib/libgtest_main.a"
     "${EXTERNAL_LIB_DIR}/sdsl-lite/lib/libgtest.a" PARENT_SCOPE)
 endfunction()
+
+# Enables using ccache in order to speed up compilation. Make sure you
+# brew install ccache to benefit from it
+function (enableCCache)
+find_program(CCACHE_FOUND ccache)
+if(CCACHE_FOUND)
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE ccache)
+else()
+    message("ccache not found. Run 'brew install ccache' to speed up compilation")
+endif(CCACHE_FOUND)
+endfunction()


### PR DESCRIPTION
Small CL to enable ccache, if available on the system. No-op if ccache is not available.

Tested with Mac/clang and Linux/gcc, works as intended.

No review needed, change is trivial, but I do recommend installing ccache to speed up your compilation:

brew install ccache

That's it. Your compilation will now be much faster when you switch branches (but obviously not when you make new changes).
If we had an NFS drive that's easy to access, we could use that for caching. Then we could benefit from each other's compilations!