### PR TITLE
Fix clang warning in test_bloom_filter.cpp

### DIFF
--- a/metagraph/tests/common/test_bloom_filter.cpp
+++ b/metagraph/tests/common/test_bloom_filter.cpp
@@ -18,10 +18,10 @@ TEST(BloomFilter, restrict_to) {
         }
     }
 
-    ASSERT_EQ(0, BloomFilter::restrict_to(0, 0));
-    ASSERT_EQ(0, BloomFilter::restrict_to(0, 0xFFFFFFFFFFFFFFFF));
-    ASSERT_EQ(0, BloomFilter::restrict_to(0xFFFFFFFFFFFFFFFF, 0));
-    ASSERT_EQ(0xFFFFFFFFFFFFFFFE,
+    ASSERT_EQ(0UL, BloomFilter::restrict_to(0, 0));
+    ASSERT_EQ(0UL, BloomFilter::restrict_to(0, 0xFFFFFFFFFFFFFFFF));
+    ASSERT_EQ(0UL, BloomFilter::restrict_to(0xFFFFFFFFFFFFFFFF, 0));
+    ASSERT_EQ(0xFFFFFFFFFFFFFFFEUL,
               BloomFilter::restrict_to(0xFFFFFFFFFFFFFFFF, 0xFFFFFFFFFFFFFFFF));
 
     // test multiples of powers of 10


### PR DESCRIPTION
Unlike gcc, clang gets upset if one compares an unsigned int with a signed one.