### PR TITLE
Construct add_sequences lambdas with a shared pointer to the data 

### DIFF
--- a/metagraph/src/kmer/kmer_collector.cpp
+++ b/metagraph/src/kmer/kmer_collector.cpp
@@ -266,8 +266,10 @@ void KmerCollector<KMER, KmerExtractor, Container>
 template <typename KMER, class KmerExtractor, class Container>
 void KmerCollector<KMER, KmerExtractor, Container>
 ::add_batch(std::vector<std::pair<std::string, uint64_t>>&& sequences) {
-    // we keep only a pointer to #sequences in the #add_sequences callback to avoid
-    // copying the vector when the callback is later std::bound in the thread-pool
+    // we capture only a pointer to #sequences in the lambda expression to avoid
+    // copying the sequences when the lambda is transformed to a callback which is passed
+    // to std::bind by const reference in #add_sequences and hence is copied with all
+    // its parameters captured.
     auto seqs = std::make_shared<std::vector<std::pair<std::string, uint64_t>>>(std::move(sequences));
     add_sequences([seqs](CallStringCount callback) {
         for (const auto &[seq, count] : *seqs) {


### PR DESCRIPTION
… in order to avoid copy construction when std::bound in the thread-pool.

Massif is now happy.