### PR TITLE
Parallelize reverse complement generation for in-memory graph construction

### DIFF
--- a/metagraph/src/graph/representation/succinct/boss_chunk_construct.cpp
+++ b/metagraph/src/graph/representation/succinct/boss_chunk_construct.cpp
@@ -194,6 +194,7 @@ void add_reverse_complements(size_t k, size_t num_threads, Vector<T> *kmers) {
                 if (buffer.size() == buffer.capacity()) {
                     #pragma omp critical
                     {
+                        // this is guaranteed to not reallocate
                         kmers->insert(kmers->end(), buffer.begin(), buffer.end());
                     }
                     buffer.resize(0);


### PR DESCRIPTION
The parallelization doubles the speed of rc generation when using 4 threads. Overall speed gain is however modest, as rc complement generation is not a large chunk of the computation.

The parallelization could be made much nicer (avoid intermediary buffer) if we didn't have the annoying palindrome k-mers.