### PR TITLE
Restrict RAM usage per alignment

### DIFF
--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -152,8 +152,7 @@ class GraphClient:
               max_alternative_alignments: int = 1,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> pd.DataFrame:
         json_obj, err = self._json_client.align(sequence, discovery_threshold,
-                                                max_alternative_alignments,
-                                                max_num_nodes_per_seq_char)
+                                                max_alternative_alignments, max_num_nodes_per_seq_char)
 
         if err:
             raise RuntimeError(f"Error while calling the server API {str(err)}")

--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -4,6 +4,7 @@ from typing import Dict, Tuple, List, Iterable, Union, Any
 
 import pandas as pd
 import requests
+import warnings
 
 """Metagraph client."""
 
@@ -37,6 +38,9 @@ class GraphClientJson:
             raise ValueError(
                 f"discovery_threshold should be between 0 and 1 inclusive. Got {discovery_threshold}")
 
+        if max_num_nodes_per_seq_char < 0:
+            warnings.warn("max_num_nodes_per_seq_char < 0, treating as infinite", RuntimeWarning)
+
         param_dict = {"count_labels": True,
                       "discovery_fraction": discovery_threshold,
                       "num_labels": top_labels,
@@ -49,6 +53,13 @@ class GraphClientJson:
               discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> Tuple[JsonDict, str]:
+        if discovery_threshold < 0.0 or discovery_threshold > 1.0:
+            raise ValueError(
+                f"discovery_threshold should be between 0 and 1 inclusive. Got {discovery_threshold}")
+
+        if max_num_nodes_per_seq_char < 0:
+            warnings.warn("max_num_nodes_per_seq_char < 0, treating as infinite", RuntimeWarning)
+
         params = {'max_alternative_alignments': max_alternative_alignments,
                   'max_num_nodes_per_seq_char': max_num_nodes_per_seq_char,
                   'discovery_fraction': discovery_threshold}

--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -10,7 +10,6 @@ import requests
 DEFAULT_TOP_LABELS = 10000
 DEFAULT_DISCOVERY_THRESHOLD = 0.7
 DEFAULT_NUM_NODES_PER_SEQ_CHAR = 10.0
-DEFAULT_MAX_RAM_PER_ALIGNMENT = 700.0
 
 JsonDict = Dict[str, Any]
 JsonStrList = List[str]
@@ -33,7 +32,6 @@ class GraphClientJson:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                align: bool = False,
-               max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
                max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> Tuple[JsonDict, str]:
         if discovery_threshold < 0.0 or discovery_threshold > 1.0:
             raise ValueError(
@@ -43,7 +41,6 @@ class GraphClientJson:
                       "discovery_fraction": discovery_threshold,
                       "num_labels": top_labels,
                       "align": align,
-                      "max_ram_per_alignment": max_ram_per_alignment,
                       "max_num_nodes_per_seq_char": max_num_nodes_per_seq_char}
 
         return self._json_seq_query(sequence, param_dict, "search")
@@ -51,10 +48,8 @@ class GraphClientJson:
     def align(self, sequence: Union[str, Iterable[str]],
               discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
-              max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> Tuple[JsonDict, str]:
         params = {'max_alternative_alignments': max_alternative_alignments,
-                  'max_ram_per_alignment': max_ram_per_alignment,
                   'max_num_nodes_per_seq_char': max_num_nodes_per_seq_char,
                   'discovery_fraction': discovery_threshold}
         return self._json_seq_query(sequence, params, "align")
@@ -111,12 +106,9 @@ class GraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                align: bool = False,
-               max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
                max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> pd.DataFrame:
-        # TODO: detect if max_ram_per_alignment is too low
         (json_obj, err) = self._json_client.search(sequence, top_labels,
                                                    discovery_threshold, align,
-                                                   max_ram_per_alignment,
                                                    max_num_nodes_per_seq_char)
 
         if err:
@@ -158,12 +150,9 @@ class GraphClient:
     def align(self, sequence: Union[str, Iterable[str]],
               discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
-              max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> pd.DataFrame:
-        # TODO: detect if max_ram_per_alignment is too low
         json_obj, err = self._json_client.align(sequence, discovery_threshold,
                                                 max_alternative_alignments,
-                                                max_ram_per_alignment,
                                                 max_num_nodes_per_seq_char)
 
         if err:
@@ -213,17 +202,14 @@ class MultiGraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                align: bool = False,
-               max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
                max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> \
             Dict[str, pd.DataFrame]:
 
         result = {}
         for label, graph_client in self.graphs.items():
-            # TODO: detect if max_ram_per_alignment is too low
             result[label] = graph_client.search(sequence, top_labels,
                                                 discovery_threshold,
                                                 align,
-                                                max_ram_per_alignment,
                                                 max_num_nodes_per_seq_char)
 
         return result
@@ -231,16 +217,13 @@ class MultiGraphClient:
     def align(self, sequence: Union[str, Iterable[str]],
               discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
-              max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> Dict[
         str, pd.DataFrame]:
         result = {}
         for label, graph_client in self.graphs.items():
             # TODO: do this async
-            # TODO: detect if max_ram_per_alignment is too low
             result[label] = graph_client.align(sequence, discovery_threshold,
                                                max_alternative_alignments,
-                                               max_ram_per_alignment,
                                                max_num_nodes_per_seq_char)
 
         return result

--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -10,6 +10,7 @@ import requests
 DEFAULT_TOP_LABELS = 10000
 DEFAULT_DISCOVERY_THRESHOLD = 0.7
 DEFAULT_NUM_NODES_PER_SEQ_CHAR = 10.0
+DEFAULT_MAX_RAM_PER_ALIGNMENT = 700.0
 
 JsonDict = Dict[str, Any]
 JsonStrList = List[str]
@@ -32,6 +33,7 @@ class GraphClientJson:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                align: bool = False,
+               max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
                max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> Tuple[JsonDict, str]:
         if discovery_threshold < 0.0 or discovery_threshold > 1.0:
             raise ValueError(
@@ -41,6 +43,7 @@ class GraphClientJson:
                       "discovery_fraction": discovery_threshold,
                       "num_labels": top_labels,
                       "align": align,
+                      "max_ram_per_alignment": max_ram_per_alignment,
                       "max_num_nodes_per_seq_char": max_num_nodes_per_seq_char}
 
         return self._json_seq_query(sequence, param_dict, "search")
@@ -48,8 +51,10 @@ class GraphClientJson:
     def align(self, sequence: Union[str, Iterable[str]],
               discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
+              max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> Tuple[JsonDict, str]:
         params = {'max_alternative_alignments': max_alternative_alignments,
+                  'max_ram_per_alignment': max_ram_per_alignment,
                   'max_num_nodes_per_seq_char': max_num_nodes_per_seq_char,
                   'discovery_fraction': discovery_threshold}
         return self._json_seq_query(sequence, params, "align")
@@ -106,9 +111,12 @@ class GraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                align: bool = False,
+               max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
                max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> pd.DataFrame:
+        # TODO: detect if max_ram_per_alignment is too low
         (json_obj, err) = self._json_client.search(sequence, top_labels,
                                                    discovery_threshold, align,
+                                                   max_ram_per_alignment,
                                                    max_num_nodes_per_seq_char)
 
         if err:
@@ -150,9 +158,13 @@ class GraphClient:
     def align(self, sequence: Union[str, Iterable[str]],
               discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
+              max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> pd.DataFrame:
+        # TODO: detect if max_ram_per_alignment is too low
         json_obj, err = self._json_client.align(sequence, discovery_threshold,
-                                                max_alternative_alignments, max_num_nodes_per_seq_char)
+                                                max_alternative_alignments,
+                                                max_ram_per_alignment,
+                                                max_num_nodes_per_seq_char)
 
         if err:
             raise RuntimeError(f"Error while calling the server API {str(err)}")
@@ -201,14 +213,17 @@ class MultiGraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                align: bool = False,
+               max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
                max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> \
             Dict[str, pd.DataFrame]:
 
         result = {}
         for label, graph_client in self.graphs.items():
+            # TODO: detect if max_ram_per_alignment is too low
             result[label] = graph_client.search(sequence, top_labels,
                                                 discovery_threshold,
                                                 align,
+                                                max_ram_per_alignment,
                                                 max_num_nodes_per_seq_char)
 
         return result
@@ -216,13 +231,16 @@ class MultiGraphClient:
     def align(self, sequence: Union[str, Iterable[str]],
               discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
+              max_ram_per_alignment: float = DEFAULT_MAX_RAM_PER_ALIGNMENT,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> Dict[
         str, pd.DataFrame]:
         result = {}
         for label, graph_client in self.graphs.items():
             # TODO: do this async
+            # TODO: detect if max_ram_per_alignment is too low
             result[label] = graph_client.align(sequence, discovery_threshold,
                                                max_alternative_alignments,
+                                               max_ram_per_alignment,
                                                max_num_nodes_per_seq_char)
 
         return result

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -34,6 +34,7 @@ DBGAlignerConfig initialize_aligner_config(size_t k, const Config &config) {
     aligner_config.max_seed_length = config.alignment_max_seed_length;
     aligner_config.max_num_seeds_per_locus = config.alignment_max_num_seeds_per_locus;
     aligner_config.max_nodes_per_seq_char = config.alignment_max_nodes_per_seq_char;
+    aligner_config.max_ram_per_alignment = config.alignment_max_ram;
     aligner_config.min_cell_score = config.alignment_min_cell_score;
     aligner_config.min_path_score = config.alignment_min_path_score;
     aligner_config.xdrop = config.alignment_xdrop;
@@ -59,6 +60,7 @@ DBGAlignerConfig initialize_aligner_config(size_t k, const Config &config) {
     logger->trace("\t Max seed length: {}", aligner_config.max_seed_length);
     logger->trace("\t Max num seeds per locus: {}", aligner_config.max_num_seeds_per_locus);
     logger->trace("\t Max num nodes per sequence char: {}", aligner_config.max_nodes_per_seq_char);
+    logger->trace("\t Max RAM per alignment: {}", aligner_config.max_ram_per_alignment);
     logger->trace("\t Gap opening penalty: {}", int64_t(aligner_config.gap_opening_penalty));
     logger->trace("\t Gap extension penalty: {}", int64_t(aligner_config.gap_extension_penalty));
     logger->trace("\t Min DP table cell score: {}", int64_t(aligner_config.min_cell_score));

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -224,6 +224,8 @@ Config::Config(int argc, char *argv[]) {
             alignment_max_nodes_per_seq_char = std::stof(get_value(i++));
         } else if (!strcmp(argv[i], "--max-hull-forks")) {
             max_hull_forks = atoi(get_value(i++));
+        } else if (!strcmp(argv[i], "--align-max-ram")) {
+            alignment_max_ram = std::stof(get_value(i++));
         } else if (!strcmp(argv[i], "-f") || !strcmp(argv[i], "--frequency")) {
             frequency = atoi(get_value(i++));
         } else if (!strcmp(argv[i], "-d") || !strcmp(argv[i], "--distance")) {
@@ -837,6 +839,7 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\t   --align-queue-size [INT]\t\t\tmaximum size of the priority queue for alignment [20]\n");
             fprintf(stderr, "\t   --align-vertical-bandwidth [INT]\t\tmaximum width of a window to consider in alignment step [inf]\n");
             fprintf(stderr, "\t   --align-max-nodes-per-seq-char [FLOAT]\t\tmaximum number of nodes to consider per sequence character [10.0]\n");
+            fprintf(stderr, "\t   --align-max-ram [FLOAT]\t\tmaximum amount of RAM used per alignment in MB [200.0]\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "Advanced options for scoring:\n");
             fprintf(stderr, "\t   --align-match-score [INT]\t\t\tpositive match score [2]\n");
@@ -1048,6 +1051,7 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\t   --align-queue-size [INT]\t\t\tmaximum size of the priority queue for alignment [20]\n");
             fprintf(stderr, "\t   --align-vertical-bandwidth [INT]\t\tmaximum width of a window to consider in alignment step [inf]\n");
             fprintf(stderr, "\t   --align-max-nodes-per-seq-char [FLOAT]\tmaximum number of nodes to consider per sequence character [10.0]\n");
+            fprintf(stderr, "\t   --align-max-ram [FLOAT]\t\tmaximum amount of RAM used per alignment in MB [200.0]\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --batch-align \t\talign against query graph [off]\n");
             fprintf(stderr, "\t   --max-hull-forks [INT]\tmaximum number of forks to take when expanding query graph [4]\n");

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -122,6 +122,7 @@ class Config {
     double bloom_fpp = 1.0;
     double bloom_bpk = 4.0;
     double alignment_max_nodes_per_seq_char = 10.0;
+    double alignment_max_ram = std::numeric_limits<double>::max();
     std::vector<double> count_slice_quantiles;
 
     std::vector<std::string> fnames;

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -122,7 +122,7 @@ class Config {
     double bloom_fpp = 1.0;
     double bloom_bpk = 4.0;
     double alignment_max_nodes_per_seq_char = 10.0;
-    double alignment_max_ram = std::numeric_limits<double>::max();
+    double alignment_max_ram = 200;
     std::vector<double> count_slice_quantiles;
 
     std::vector<std::string> fnames;

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -130,6 +130,8 @@ std::string process_search_request(const std::string &received_message,
     config.alignment_max_nodes_per_seq_char = json.get(
         "max_num_nodes_per_seq_char",
         config.alignment_max_nodes_per_seq_char).asDouble();
+    config.alignment_max_ram = json.get("max_ram_per_alignment",
+                                        config.alignment_max_ram).asDouble();
 
     if (config.discovery_fraction < 0.0 || config.discovery_fraction > 1.0) {
         throw std::domain_error(
@@ -201,6 +203,8 @@ std::string process_align_request(const std::string &received_message,
     config.alignment_max_nodes_per_seq_char = json.get(
         "max_num_nodes_per_seq_char",
         config.alignment_max_nodes_per_seq_char).asDouble();
+    config.alignment_max_ram = json.get("max_ram_per_alignment",
+                                        config.alignment_max_ram).asDouble();
 
     std::unique_ptr<graph::align::IDBGAligner> aligner = build_aligner(graph, config);
 

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -130,8 +130,6 @@ std::string process_search_request(const std::string &received_message,
     config.alignment_max_nodes_per_seq_char = json.get(
         "max_num_nodes_per_seq_char",
         config.alignment_max_nodes_per_seq_char).asDouble();
-    config.alignment_max_ram = json.get("max_ram_per_alignment",
-                                        config.alignment_max_ram).asDouble();
 
     if (config.discovery_fraction < 0.0 || config.discovery_fraction > 1.0) {
         throw std::domain_error(
@@ -203,8 +201,6 @@ std::string process_align_request(const std::string &received_message,
     config.alignment_max_nodes_per_seq_char = json.get(
         "max_num_nodes_per_seq_char",
         config.alignment_max_nodes_per_seq_char).asDouble();
-    config.alignment_max_ram = json.get("max_ram_per_alignment",
-                                        config.alignment_max_ram).asDouble();
 
     std::unique_ptr<graph::align::IDBGAligner> aligner = build_aligner(graph, config);
 

--- a/metagraph/src/graph/alignment/aligner_helper.hpp
+++ b/metagraph/src/graph/alignment/aligner_helper.hpp
@@ -172,6 +172,7 @@ class DBGAlignerConfig {
 
     double exact_kmer_match_fraction = 0.0;
     double max_nodes_per_seq_char = std::numeric_limits<double>::max();
+    double max_ram_per_alignment = std::numeric_limits<double>::max();
 
     int8_t gap_opening_penalty;
     int8_t gap_extension_penalty;
@@ -521,6 +522,21 @@ class DPTable {
 
         bool operator<(const Column &other) const {
             return best_score() < other.best_score();
+        }
+
+        size_t cell_size() const {
+            return sizeof(score_t) * 2 + sizeof(Cigar::Operator)
+                 + sizeof(uint8_t) * 2 + sizeof(int32_t);
+        }
+
+        size_t bytes_taken() const {
+            return sizeof(Column)
+                + sizeof(score_t) * scores.capacity()
+                + sizeof(score_t) * gap_scores.capacity()
+                + sizeof(Cigar::Operator) * ops.capacity()
+                + sizeof(uint8_t) * prev_nodes.capacity()
+                + sizeof(uint8_t) * gap_prev_nodes.capacity()
+                + sizeof(int32_t) * gap_count.capacity();
         }
 
         size_t size() const { return size_; }

--- a/metagraph/src/graph/alignment/aligner_helper.hpp
+++ b/metagraph/src/graph/alignment/aligner_helper.hpp
@@ -536,7 +536,8 @@ class DPTable {
                 + sizeof(Cigar::Operator) * ops.capacity()
                 + sizeof(uint8_t) * prev_nodes.capacity()
                 + sizeof(uint8_t) * gap_prev_nodes.capacity()
-                + sizeof(int32_t) * gap_count.capacity();
+                + sizeof(int32_t) * gap_count.capacity()
+                + sizeof(NodeType) * incoming_nodes.capacity();
         }
 
         size_t size() const { return size_; }


### PR DESCRIPTION
This introduces a new parameter for limiting the amount of RAM that can be taken by an alignment. It also adds some members to the Alignment and QueryAlignment classes for storing alignment RAM statistics.