### PR TITLE
don't keep graph in memory during row-diff transform

### DIFF
--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1084,15 +1084,10 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                          size_t mem_bytes,
                          uint32_t max_path_length,
                          const std::filesystem::path &dest_dir) {
-    if (files.size()) {
-        graph::DBGSuccinct graph(2);
-        logger->trace("Loading graph...");
-        if (!graph.load(graph_fname)) {
-            logger->error("Cannot load graph from {}", graph_fname);
-            std::exit(1);
-        }
-        build_successor(graph, graph_fname, max_path_length, get_num_threads());
-    }
+    if (!files.size())
+        return;
+
+    build_successor(graph_fname, graph_fname, max_path_length, get_num_threads());
 
     // load as many columns as we can fit in memory, and convert them
     for (uint32_t i = 0; i < files.size(); ) {
@@ -1121,7 +1116,6 @@ void convert_to_row_diff(const std::vector<std::string> &files,
         convert_batch_to_row_diff(graph_fname, file_batch, dest_dir);
         logger->trace("Batch transformed in {} sec", timer.elapsed());
     }
-
 }
 
 void convert_row_diff_to_col_compressed(const std::vector<std::string> &files,

--- a/metagraph/src/annotation/annotation_converters.hpp
+++ b/metagraph/src/annotation/annotation_converters.hpp
@@ -104,7 +104,7 @@ void convert_to_row_annotator(const ColumnCompressed<Label> &annotator,
  * kept, extension is changed from 'column.annodbg' to 'row_diff.annodbg'
  */
 void convert_to_row_diff(const std::vector<std::string> &files,
-                         const std::string& graph_fname,
+                         const std::string &graph_fname,
                          size_t mem_bytes,
                          uint32_t max_path_length,
                          const std::filesystem::path &dest_dir);

--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
@@ -31,7 +31,7 @@ bool RowDiff<BaseMatrix>::load(const std::string &filename) {
 template
 class RowDiff<ColumnMajor>;
 
-void build_successor(const graph::DBGSuccinct &graph,
+void build_successor(const std::string &graph_fname,
                      const std::string &outfbase,
                      uint32_t max_length,
                      uint32_t num_threads) {
@@ -48,6 +48,13 @@ void build_successor(const graph::DBGSuccinct &graph,
     if (!must_build) {
         common::logger->trace("Using existing pred/succ/terminal files in {}.*", outfbase);
         return;
+    }
+
+    graph::DBGSuccinct graph(2);
+    common::logger->trace("Loading graph...");
+    if (!graph.load(graph_fname)) {
+        common::logger->error("Cannot load graph from {}", graph_fname);
+        std::exit(1);
     }
 
     using graph::boss::BOSS;

--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
@@ -20,7 +20,7 @@ namespace mtg {
 namespace annot {
 namespace binmat {
 
-void build_successor(const graph::DBGSuccinct &graph,
+void build_successor(const std::string &graph_filename,
                      const std::string &outfbase,
                      uint32_t max_length,
                      uint32_t num_threads);

--- a/metagraph/src/annotation/row_diff_builder.hpp
+++ b/metagraph/src/annotation/row_diff_builder.hpp
@@ -59,11 +59,9 @@ void traverse_anno_chunked(
         const CallOnes &call_ones,
         const std::function<void(node_index start, uint64_t size)> &after_chunk);
 
-void convert_batch_to_row_diff(const graph::DBGSuccinct &graph,
-                               const std::string &graph_fname,
+void convert_batch_to_row_diff(const std::string &graph_fname,
                                const std::vector<std::string> &source_files,
-                               const std::filesystem::path &dest_dir,
-                               uint32_t max_depth);
+                               const std::filesystem::path &dest_dir);
 
-}
-}
+} // namespace annot
+} // namespace mtg


### PR DESCRIPTION
small patch:
* release graph right after successors are computed
* various minor cleanups