### PR TITLE
Anchor optimization with support for batched construction

### DIFF
--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -63,32 +63,40 @@ def build_annotation(graph_filename, input_fasta, anno_repr, output_filename, ex
     res = subprocess.run([annotate_command], shell=True)
     assert(res.returncode == 0)
 
-    if target_anno != anno_repr:
-        final_anno = target_anno
-        if final_anno == 'row_diff_brwt':
-            target_anno = 'row_diff'
+    if target_anno == anno_repr:
+        return
 
-        annotate_command = '{exe} transform_anno \
-                --anno-type {target_anno} -o {outfile} {input}'.format(
-            exe=METAGRAPH,
-            graph=graph_filename,
-            target_anno=target_anno,
-            outfile=output_filename,
-            input=output_filename + anno_file_extension[anno_repr]
-        )
-        if target_anno == 'row_diff':
-            parts = annotate_command.split('transform_anno', 1)
-            annotate_command = parts[0] + f' transform_anno -i {graph_filename} '  + parts[1]
+    final_anno = target_anno
+    if final_anno == 'row_diff_brwt':
+        target_anno = 'row_diff'
+
+    annotate_command = '{exe} transform_anno \
+            --anno-type {target_anno} -o {outfile} {input}'.format(
+        exe=METAGRAPH,
+        graph=graph_filename,
+        target_anno=target_anno,
+        outfile=output_filename,
+        input=output_filename + anno_file_extension[anno_repr]
+    )
+    if target_anno == 'row_diff':
+        annotate_command += ' -i ' + graph_filename
+
+    res = subprocess.run([annotate_command], shell=True)
+    assert(res.returncode == 0)
+
+    if target_anno == 'row_diff':
+        annotate_command += ' --optimize'
         res = subprocess.run([annotate_command], shell=True)
         assert(res.returncode == 0)
-        os.remove(output_filename + anno_file_extension[anno_repr])
-        if final_anno == 'row_diff_brwt':
-            annotate_command = f'{METAGRAPH} transform_anno --anno-type {final_anno} -o {output_filename} ' \
-                               f'{output_filename}.row_diff.annodbg'
-            res = subprocess.run([annotate_command], shell=True)
-            assert (res.returncode == 0)
-            os.remove(output_filename + anno_file_extension['row_diff'])
 
+    os.remove(output_filename + anno_file_extension[anno_repr])
+
+    if final_anno == 'row_diff_brwt':
+        annotate_command = f'{METAGRAPH} transform_anno --anno-type {final_anno} -o {output_filename} ' \
+                           f'{output_filename}.row_diff.annodbg'
+        res = subprocess.run([annotate_command], shell=True)
+        assert (res.returncode == 0)
+        os.remove(output_filename + anno_file_extension['row_diff'])
 
 
 @parameterized_class(('graph_repr', 'anno_repr'),

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1139,8 +1139,11 @@ void convert_to_row_diff(const std::vector<std::string> &files,
         Timer timer;
         logger->trace("Annotations for row-diff transform in batch: {}",
                       file_batch.size());
-        convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, row_reduction_fname,
-                                  optimize ? ".terminal" : ".terminal.unopt");
+
+        convert_batch_to_row_diff(
+                graph_fname, graph_fname + (optimize ? ".terminal" : ".terminal.unopt"),
+                file_batch, dest_dir, row_reduction_fname);
+
         logger->trace("Batch transformed in {} sec", timer.elapsed());
     }
 }

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1129,7 +1129,7 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                     row_reduction_fname += ".unopt";
 
                 if (std::filesystem::exists(row_reduction_fname)) {
-                    logger->warn("Found row reduction vector {}. Removing...",
+                    logger->warn("Found row reduction vector {}, will be overwritten",
                                  row_reduction_fname);
                     std::filesystem::remove(row_reduction_fname);
                 }

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1137,7 +1137,7 @@ void convert_to_row_diff(const std::vector<std::string> &files,
         }
 
         Timer timer;
-        logger->trace("Starting transforming batch of {} annotations ...",
+        logger->trace("Annotations for row-diff transform in batch: {}",
                       file_batch.size());
         convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname,
                                   optimize ? ".terminal" : ".terminal.unopt");

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1083,10 +1083,13 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                          const std::string &graph_fname,
                          size_t mem_bytes,
                          uint32_t max_path_length,
-                         const std::filesystem::path &dest_dir,
+                         std::filesystem::path dest_dir,
                          bool optimize) {
     if (!files.size())
         return;
+
+    if (dest_dir.empty())
+        dest_dir = "./";
 
     build_successor(graph_fname, graph_fname, max_path_length, get_num_threads());
 

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1090,6 +1090,9 @@ void convert_to_row_diff(const std::vector<std::string> &files,
 
     build_successor(graph_fname, graph_fname, max_path_length, get_num_threads());
 
+    if (optimize)
+        optimize_anchors_in_row_diff(graph_fname, dest_dir);
+
     std::filesystem::path delta_nbits_fname;
 
     // load as many columns as we can fit in memory, and convert them
@@ -1119,6 +1122,9 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                                                 .filename()
                                                 .replace_extension()
                                                 .replace_extension(".delta_nbits");
+                if (optimize)
+                    delta_nbits_fname += ".opt";
+
                 if (std::filesystem::exists(delta_nbits_fname)) {
                     logger->warn("File {} with row bit counts already exists. Removing...",
                                  delta_nbits_fname);
@@ -1128,13 +1134,10 @@ void convert_to_row_diff(const std::vector<std::string> &files,
         }
 
         Timer timer;
-        logger->trace("Starting transforming batch of {} columns ...",
+        logger->trace("Starting transforming batch of {} annotations ...",
                       file_batch.size());
-        if (optimize) {
-            optimize_anchors_in_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname);
-        } else {
-            convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname);
-        }
+        convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname,
+                                  optimize ? ".terminal" : ".terminal.unopt");
         logger->trace("Batch transformed in {} sec", timer.elapsed());
     }
 }

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1094,9 +1094,9 @@ void convert_to_row_diff(const std::vector<std::string> &files,
     build_successor(graph_fname, graph_fname, max_path_length, get_num_threads());
 
     if (optimize)
-        optimize_anchors_in_row_diff(graph_fname, dest_dir);
+        optimize_anchors_in_row_diff(graph_fname, dest_dir, ".row_reduction.unopt");
 
-    std::filesystem::path delta_nbits_fname;
+    std::filesystem::path row_reduction_fname;
 
     // load as many columns as we can fit in memory, and convert them
     for (uint32_t i = 0; i < files.size(); ) {
@@ -1120,18 +1120,18 @@ void convert_to_row_diff(const std::vector<std::string> &files,
             file_batch.push_back(files[i]);
 
             // derive name from first file in batch
-            if (delta_nbits_fname.empty()) {
-                delta_nbits_fname = dest_dir/std::filesystem::path(file_batch.back())
+            if (row_reduction_fname.empty()) {
+                row_reduction_fname = dest_dir/std::filesystem::path(file_batch.back())
                                                 .filename()
                                                 .replace_extension()
-                                                .replace_extension(".delta_nbits");
-                if (optimize)
-                    delta_nbits_fname += ".opt";
+                                                .replace_extension(".row_reduction");
+                if (!optimize)
+                    row_reduction_fname += ".unopt";
 
-                if (std::filesystem::exists(delta_nbits_fname)) {
-                    logger->warn("File {} with row bit counts already exists. Removing...",
-                                 delta_nbits_fname);
-                    std::filesystem::remove(delta_nbits_fname);
+                if (std::filesystem::exists(row_reduction_fname)) {
+                    logger->warn("Found row reduction vector {}. Removing...",
+                                 row_reduction_fname);
+                    std::filesystem::remove(row_reduction_fname);
                 }
             }
         }
@@ -1139,7 +1139,7 @@ void convert_to_row_diff(const std::vector<std::string> &files,
         Timer timer;
         logger->trace("Annotations for row-diff transform in batch: {}",
                       file_batch.size());
-        convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname,
+        convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, row_reduction_fname,
                                   optimize ? ".terminal" : ".terminal.unopt");
         logger->trace("Batch transformed in {} sec", timer.elapsed());
     }

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1083,7 +1083,8 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                          const std::string &graph_fname,
                          size_t mem_bytes,
                          uint32_t max_path_length,
-                         const std::filesystem::path &dest_dir) {
+                         const std::filesystem::path &dest_dir,
+                         bool optimize) {
     if (!files.size())
         return;
 
@@ -1129,7 +1130,11 @@ void convert_to_row_diff(const std::vector<std::string> &files,
         Timer timer;
         logger->trace("Starting transforming batch of {} columns ...",
                       file_batch.size());
-        convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname);
+        if (optimize) {
+            optimize_anchors_in_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname);
+        } else {
+            convert_batch_to_row_diff(graph_fname, file_batch, dest_dir, delta_nbits_fname);
+        }
         logger->trace("Batch transformed in {} sec", timer.elapsed());
     }
 }

--- a/metagraph/src/annotation/annotation_converters.hpp
+++ b/metagraph/src/annotation/annotation_converters.hpp
@@ -107,7 +107,8 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                          const std::string &graph_fname,
                          size_t mem_bytes,
                          uint32_t max_path_length,
-                         const std::filesystem::path &dest_dir);
+                         const std::filesystem::path &dest_dir,
+                         bool optimize = false);
 
 void convert_row_diff_to_col_compressed(const std::vector<std::string> &files,
                                         const std::string &outfbase);

--- a/metagraph/src/annotation/annotation_converters.hpp
+++ b/metagraph/src/annotation/annotation_converters.hpp
@@ -107,7 +107,7 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                          const std::string &graph_fname,
                          size_t mem_bytes,
                          uint32_t max_path_length,
-                         const std::filesystem::path &dest_dir,
+                         std::filesystem::path dest_dir,
                          bool optimize = false);
 
 void convert_row_diff_to_col_compressed(const std::vector<std::string> &files,

--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
@@ -18,12 +18,7 @@ void RowDiff<BaseMatrix>::serialize(const std::string &filename) const {
 template <class BaseMatrix>
 bool RowDiff<BaseMatrix>::load(const std::string &filename) {
     std::ifstream f(filename, ios::binary);
-    bool result = load(f);
-    f.close();
-
-    load_terminal(anchors_filename_, &terminal_);
-
-    return result;
+    return load(f);
 }
 
 template

--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
@@ -50,9 +50,11 @@ class RowDiff : public BinaryMatrix {
 
     RowDiff(const graph::DBGSuccinct *graph,
                BaseMatrix &&diffs,
-               const std::string &anchors_filename)
+               const std::string &anchors_filename,
+               bool load_anchors = true)
         : graph_(graph), diffs_(std::move(diffs)), anchors_filename_(anchors_filename) {
-        load_terminal(anchors_filename_, &terminal_);
+        if (load_anchors)
+            load_terminal(anchors_filename_, &terminal_);
     }
 
     uint64_t num_columns() const override { return diffs_.num_columns(); }

--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
@@ -7,9 +7,9 @@
 #include <sdsl/enc_vector.hpp>
 #include <sdsl/bit_vectors.hpp>
 #include <sdsl/util.hpp>
-#include <sdsl/rrr_vector.hpp>
 
 #include "annotation/binary_matrix/base/binary_matrix.hpp"
+#include "common/vectors/bit_vector_adaptive.hpp"
 #include "common/logger.hpp"
 #include "common/vector.hpp"
 #include "graph/annotated_dbg.hpp"
@@ -44,6 +44,8 @@ namespace binmat {
 template <class BaseMatrix>
 class RowDiff : public BinaryMatrix {
   public:
+    typedef bit_vector_small anchor_bv_type;
+
     RowDiff() {}
 
     RowDiff(const graph::DBGSuccinct *graph,
@@ -57,7 +59,7 @@ class RowDiff : public BinaryMatrix {
 
     const std::string& anchors_filename() const { return anchors_filename_; }
 
-    const graph::DBGSuccinct *graph() const { return graph_; }
+    const graph::DBGSuccinct* graph() const { return graph_; }
 
     /**
      * Returns the number of set bits in the matrix.
@@ -82,22 +84,22 @@ class RowDiff : public BinaryMatrix {
     void serialize(const std::string &filename) const;
     bool load(const std::string &filename);
 
-    const sdsl::rrr_vector<> &terminal() const { return terminal_; }
+    const anchor_bv_type& terminal() const { return terminal_; }
 
-    const BaseMatrix &diffs() const { return diffs_; }
-    BaseMatrix &diffs() { return diffs_; }
+    const BaseMatrix& diffs() const { return diffs_; }
+    BaseMatrix& diffs() { return diffs_; }
 
     Vector<uint64_t> get_diff(uint64_t node_id) const { return diffs_.get_row(node_id); }
 
   private:
-    static void load_terminal(const std::string &filename, sdsl::rrr_vector<> *terminal);
+    static void load_terminal(const std::string &filename, anchor_bv_type *terminal);
 
     static void merge(Vector<uint64_t> *result, const Vector<uint64_t> &diff2);
 
     const graph::DBGSuccinct *graph_ = nullptr;
 
     BaseMatrix diffs_;
-    sdsl::rrr_vector<> terminal_;
+    anchor_bv_type terminal_;
 
     std::string anchors_filename_;
 };
@@ -168,7 +170,7 @@ void RowDiff<BaseMatrix>::serialize(std::ostream &f) const {
 
 template <class BaseMatrix>
 void RowDiff<BaseMatrix>::load_terminal(const std::string &filename,
-                                        sdsl::rrr_vector<> *terminal) {
+                                        anchor_bv_type *terminal) {
     std::ifstream f(filename, ios::binary);
     if (!f.good()) {
         common::logger->error("Could not open anchor file {}", filename);

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -147,7 +147,7 @@ bool ColumnCompressed<Label>::merge_load(const std::vector<std::string> &filenam
                 }
             }
         },
-        get_num_threads()
+        filenames.size() > get_num_threads() ? get_num_threads() : 0
     );
 
     if (merge_successful && no_errors) {

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -471,155 +471,64 @@ void convert_batch_to_row_diff(const std::string &graph_fname,
 }
 
 void optimize_anchors_in_row_diff(const std::string &graph_fname,
-                                  const std::vector<std::string> &source_files,
-                                  const std::filesystem::path &dest_dir,
-                                  const std::string &delta_nbits_fname) {
-    if (source_files.empty())
+                                  const std::filesystem::path &dest_dir) {
+    if (std::filesystem::exists(graph_fname + ".terminal")) {
+        logger->info("Found optimized anchors {}", graph_fname + ".terminal");
         return;
-
-    if (!std::filesystem::exists(graph_fname + ".terminal")) {
-        logger->trace("Optimizing anchors");
-
-        std::vector<std::string> filenames;
-        for (const auto &p : std::filesystem::directory_iterator(dest_dir)) {
-            auto path = p.path();
-            if (utils::ends_with(path, ".delta_nbits")) {
-                logger->info("Found delta vector {}", path);
-                filenames.push_back(path);
-            }
-        }
-
-        if (!filenames.size()) {
-            logger->error("Didn't find any delta vectors to merge in {}", dest_dir);
-            exit(1);
-        }
-
-        logger->info("Start merging {} delta vectors", filenames.size());
-
-        while (filenames.size() > 1u) {
-            std::vector<std::string> filenames_new((filenames.size() + 1) / 2);
-
-            #pragma omp parallel for num_threads(get_num_threads()) schedule(dynamic)
-            for (size_t i = 0; i < filenames.size(); i += 2) {
-                filenames_new[i / 2] = fmt::format("{}.merged.{}", filenames[i], i / 2);
-                //TODO: merge (filenames_new[i / 2] = filenames[i] + filenames[i + 1])
-            }
-
-            if (filenames.size() % 2)
-                filenames_new.push_back(filenames.back());
-
-            filenames.swap(filenames_new);
-
-            logger->trace("Merged into {} delta vectors", filenames.size());
-        }
-
-        assert(filenames.size() == 1u && "All must be merged into one vector");
-
-        sdsl::int_vector_buffer deltas(filenames[0], std::ios::in, 1024 * 1024, DELTA_WIDTH);
-        sdsl::bit_vector anchors(deltas.size());
-        // TODO: load from ".terminal.unopt"
-        for (uint64_t i = 0; i < deltas.size(); ++i) {
-            // check if the delta is negative
-            if (deltas[i] >> (deltas.width() - 1))
-                anchors[i] = true;
-        }
-        logger->trace("Number of anchors after optimization: {}",
-                      sdsl::util::cnt_one_bits(anchors));
-
-        sdsl::rrr_vector ranchors(anchors);
-        std::ofstream f(graph_fname + ".terminal", ios::binary);
-        ranchors.serialize(f);
-        logger->trace("Serialized optimized anchors to {}", graph_fname + ".terminal");
     }
 
-    convert_batch_to_row_diff(graph_fname, source_files, dest_dir, delta_nbits_fname,
-                              ".terminal");
+    logger->trace("Optimizing anchors");
 
-/*
-    logger->trace("Using optimized anchors from {}", graph_fname + ".terminal");
-    std::ifstream f(graph_fname + ".terminal.delta", std::ios::binary);
-    sdsl::rrr_vector temp;
-    temp.load(f);
-    bit_vector_small new_anchors(std::move(temp));
-
-    logger->trace("Updating row_diff columns...");
-
-    ProgressBar progress_bar(graph_fname.size(), "Update row-diff",
-                             std::cerr, !common::get_verbose());
-    #pragma omp parallel for num_threads(num_threads) schedule(dynamic)
-    for (size_t l_idx = 0; l_idx < source_files.size(); ++l_idx) {
-        annot::ColumnCompressed<> original;
-        if (!original.load(source_files[l_idx])) {
-            logger->error("Can't load original annotation from {}", source_files[l_idx]);
-            exit(1);
+    std::vector<std::string> filenames;
+    for (const auto &p : std::filesystem::directory_iterator(dest_dir)) {
+        auto path = p.path();
+        if (utils::ends_with(path, ".delta_nbits")) {
+            logger->info("Found delta vector {}", path);
+            filenames.push_back(path);
         }
-
-        if (!original.num_labels())
-            continue;
-
-        auto fpath = dest_dir/std::filesystem::path(source_files[l_idx])
-                                .filename()
-                                .replace_extension()
-                                .replace_extension(RowDiffAnnotator::kExtension);
-        auto row_diff = std::make_unique<RowDiffAnnotator>();
-        if (row_diff->load(fpath)) {
-            logger->error("Can't load initial row-diff annotation from {}", fpath);
-            exit(1);
-        }
-
-        if (row_diff->get_label_encoder().get_labels()
-                != original.get_label_encoder().get_labels()) {
-            logger->error("Annotations {} and {} have different lists of labels",
-                          source_files[l_idx], fpath);
-        }
-
-        std::vector<std::unique_ptr<bit_vector>> columns
-                        = row_diff->release_matrix()->diffs().release_columns();
-
-        for (size_t j = 0; j < columns.size(); ++j) {
-            const bit_vector &original_col = *original.get_matrix().data()[j];
-            std::unique_ptr<bit_vector> old_rd_col = std::move(columns[j]);
-
-            if (original_col.size() != new_anchors.size()
-                    || old_rd_col->size() != new_anchors.size()) {
-                logger->error("Columns have incompatible sizes");
-                exit(1);
-            }
-
-            uint64_t num_set_bits = old_rd_col->num_set_bits();
-
-            new_anchors.call_ones([&](uint64_t i) {
-                if ((*old_rd_col)[i]) {
-                    if (!original_col[i])
-                        num_set_bits--;
-                } else {
-                    if (original_col[i])
-                        num_set_bits++;
-                }
-            });
-
-            auto call_ones = [&](const std::function<void(uint64_t)>& call) {
-                // TODO: merge two bitmaps
-            };
-
-            columns[j] = std::make_unique<bit_vector_sd>(call_ones, old_rd_col->size(),
-                                                         num_set_bits);
-        }
-
-        row_diff = std::make_unique<RowDiffAnnotator>(
-            std::make_unique<RowDiff<ColumnMajor>>(
-                nullptr,
-                ColumnMajor(std::move(columns)),
-                graph_fname + ".terminal"
-            ),
-            original.get_label_encoder()
-        );
-        row_diff->serialize(fpath);
-        logger->trace("Updated {}", fpath);
-
-        ++progress_bar;
     }
-*/
+
+    if (!filenames.size()) {
+        logger->error("Didn't find any delta vectors to merge in {}", dest_dir);
+        exit(1);
+    }
+
+    logger->info("Start merging {} delta vectors", filenames.size());
+
+    while (filenames.size() > 1u) {
+        std::vector<std::string> filenames_new((filenames.size() + 1) / 2);
+
+        #pragma omp parallel for num_threads(get_num_threads()) schedule(dynamic)
+        for (size_t i = 0; i < filenames.size(); i += 2) {
+            filenames_new[i / 2] = fmt::format("{}.merged.{}", filenames[i], i / 2);
+            //TODO: merge (filenames_new[i / 2] = filenames[i] + filenames[i + 1])
+        }
+
+        if (filenames.size() % 2)
+            filenames_new.push_back(filenames.back());
+
+        filenames.swap(filenames_new);
+
+        logger->trace("Merged into {} delta vectors", filenames.size());
+    }
+
+    assert(filenames.size() == 1u && "All must be merged into one vector");
+
+    sdsl::int_vector_buffer deltas(filenames[0], std::ios::in, 1024 * 1024, DELTA_WIDTH);
+    sdsl::bit_vector anchors(deltas.size());
+    // TODO: load from ".terminal.unopt"
+    for (uint64_t i = 0; i < deltas.size(); ++i) {
+        // check if the delta is negative
+        if (deltas[i] >> (deltas.width() - 1))
+            anchors[i] = true;
+    }
+    logger->trace("Number of anchors after optimization: {}",
+                  sdsl::util::cnt_one_bits(anchors));
+
+    sdsl::rrr_vector ranchors(anchors);
+    std::ofstream f(graph_fname + ".terminal", ios::binary);
+    ranchors.serialize(f);
+    logger->trace("Serialized optimized anchors to {}", graph_fname + ".terminal");
 }
 
 } // namespace annot

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -501,15 +501,15 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
         std::vector<std::string> filenames_new((filenames.size() + 1) / 2);
 
         #pragma omp parallel for num_threads(get_num_threads()) schedule(dynamic)
-        for (size_t i = 0; i + 1 < filenames.size(); i += 2) {
-            // compute sum of i and i+1
-            filenames_new[i / 2] = fmt::format("{}.merged.{}", filenames[i], i / 2);
-            sdsl::int_vector_buffer sum(filenames_new[i / 2], std::ios::out, 1024 * 1024, DELTA_WIDTH);
-            sdsl::int_vector_buffer first(filenames[i], std::ios::in, 1024 * 1024, DELTA_WIDTH);
-            sdsl::int_vector_buffer second(filenames[i + 1], std::ios::in, 1024 * 1024, DELTA_WIDTH);
+        for (size_t t = 1; t < filenames.size(); t += 2) {
+            // compute sum of t-1 and t.
+            filenames_new[t / 2] = fmt::format("{}.merged", filenames[t]);
+            sdsl::int_vector_buffer sum(filenames_new[t / 2], std::ios::out, 1024 * 1024, DELTA_WIDTH);
+            sdsl::int_vector_buffer first(filenames[t - 1], std::ios::in, 1024 * 1024, DELTA_WIDTH);
+            sdsl::int_vector_buffer second(filenames[t], std::ios::in, 1024 * 1024, DELTA_WIDTH);
             if (first.size() != second.size()) {
                 logger->error("Sizes of delta vectors are incompatible, {}: {}, {}: {}",
-                              filenames[i], first.size(), filenames[i + 1], second.size());
+                              filenames[t - 1], first.size(), filenames[t], second.size());
                 exit(1);
             }
             for (uint64_t i = 0; i < sum.size(); ++i) {

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -546,9 +546,8 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
     }
     sdsl::bit_vector anchors = old_anchors.convert_to<sdsl::bit_vector>();
     for (uint64_t i = 0; i < row_reduction.size(); ++i) {
-        // check if the reduction is negative or zero
-        uint64_t delta = row_reduction[i];
-        if (!delta || delta >> (row_reduction.width() - 1))
+        // check if the reduction is negative
+        if (row_reduction[i] >> (row_reduction.width() - 1))
             anchors[i] = true;
     }
     anchor_bv_type ranchors(std::move(anchors));

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -305,7 +305,7 @@ void convert_batch_to_row_diff(const std::string &graph_fname,
 
         uint64_t num_elements
                 = std::max((uint64_t)2,  //CWQ needs a buffer size of at least 2
-                           std::min(1'000'000ull, sources[i]->num_relations()));
+                           std::min((uint64_t)1'000'000, sources[i]->num_relations()));
         targets_size[i].assign(sources[i]->num_labels(), 0U);
         set_rows[i].resize(sources[i]->num_labels());
         for (size_t j = 0; j < sources[i]->num_labels(); ++j) {

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -420,7 +420,7 @@ void convert_batch_to_row_diff(const std::string &graph_fname,
 
         ColumnMajor matrix(std::move(columns));
         auto diff_annotation = std::make_unique<RowDiff<ColumnMajor>>(
-                nullptr, std::move(matrix), graph_fname + anchors_extension);
+                nullptr, std::move(matrix), graph_fname + anchors_extension, false);
         row_diff[l_idx] = std::make_unique<RowDiffAnnotator>(std::move(diff_annotation),
                                                              label_encoders[l_idx]);
         auto fname = std::filesystem::path(source_files[l_idx])

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -505,6 +505,7 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
             // compute sum of t-1 and t.
             filenames_new[t / 2] = fmt::format("{}.merged", filenames[t]);
             sdsl::int_vector_buffer sum(filenames_new[t / 2], std::ios::out, 1024 * 1024, DELTA_WIDTH);
+
             sdsl::int_vector_buffer first(filenames[t - 1], std::ios::in, 1024 * 1024, DELTA_WIDTH);
             sdsl::int_vector_buffer second(filenames[t], std::ios::in, 1024 * 1024, DELTA_WIDTH);
             if (first.size() != second.size()) {
@@ -512,7 +513,8 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
                               filenames[t - 1], first.size(), filenames[t], second.size());
                 exit(1);
             }
-            for (uint64_t i = 0; i < sum.size(); ++i) {
+
+            for (uint64_t i = 0; i < first.size(); ++i) {
                 sum.push_back(first[i] + second[i]);
             }
         }
@@ -520,9 +522,10 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
         if (filenames.size() % 2)
             filenames_new.back() = filenames.back();
 
-        filenames.swap(filenames_new);
+        logger->trace("Merged {} delta vectors into {}",
+                      filenames.size(), filenames_new.size());
 
-        logger->trace("Merged into {} delta vectors", filenames.size());
+        filenames.swap(filenames_new);
     }
 
     assert(filenames.size() == 1u && "All must be merged into one vector");

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -546,8 +546,9 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
     }
     sdsl::bit_vector anchors = old_anchors.convert_to<sdsl::bit_vector>();
     for (uint64_t i = 0; i < row_reduction.size(); ++i) {
-        // check if the reduction is negative
-        if (row_reduction[i] >> (row_reduction.width() - 1))
+        // check if the reduction is negative or zero
+        uint64_t delta = row_reduction[i];
+        if (!delta || delta >> (row_reduction.width() - 1))
             anchors[i] = true;
     }
     anchor_bv_type ranchors(std::move(anchors));

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -495,13 +495,13 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
         exit(1);
     }
 
-    logger->info("Start merging {} delta vectors", filenames.size());
+    logger->trace("Merging delta vectors");
 
     while (filenames.size() > 1u) {
         std::vector<std::string> filenames_new((filenames.size() + 1) / 2);
 
         #pragma omp parallel for num_threads(get_num_threads()) schedule(dynamic)
-        for (size_t i = 0; i < filenames.size(); i += 2) {
+        for (size_t i = 0; i + 1 < filenames.size(); i += 2) {
             // compute sum of i and i+1
             filenames_new[i / 2] = fmt::format("{}.merged.{}", filenames[i], i / 2);
             sdsl::int_vector_buffer sum(filenames_new[i / 2], std::ios::out, 1024 * 1024, DELTA_WIDTH);

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -498,7 +498,8 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
         exit(1);
     }
 
-    logger->trace("Merging row reduction vectors");
+    if (filenames.size() > 1u)
+        logger->trace("Merging row reduction vectors");
 
     while (filenames.size() > 1u) {
         std::vector<std::string> filenames_new((filenames.size() + 1) / 2);

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -26,7 +26,7 @@ void build_successor(const std::string &graph_fname,
                      uint32_t max_length,
                      uint32_t num_threads) {
     bool must_build = false;
-    for (const auto &suffix : { ".succ", ".pred", ".pred_boundary", ".terminal" }) {
+    for (const auto &suffix : { ".succ", ".pred", ".pred_boundary", ".terminal.unopt" }) {
         if (!std::filesystem::exists(outfbase + suffix)) {
             logger->trace(
                     "Building and writing successor, predecessor and terminal files to {}.*",
@@ -69,7 +69,7 @@ void build_successor(const std::string &graph_fname,
     std::ofstream fterm(outfbase + ".terminal.unopt", ios::binary);
     term.serialize(fterm);
     fterm.close();
-    logger->trace("Anchor nodes written to {}.terminal", outfbase);
+    logger->trace("Anchor nodes written to {}.terminal.unopt", outfbase);
 
     // create the succ file, indexed using annotation indices
     uint32_t width = sdsl::bits::hi(graph.num_nodes()) + 1;

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -240,7 +240,7 @@ void traverse_anno_chunked(
 
         assert(pred_chunk.size() == pred_chunk_idx.back());
 
-        #pragma omp parallel for num_threads(num_threads) schedule(dynamic) collapse(2)
+        #pragma omp parallel for num_threads(num_threads) schedule(dynamic)
         for (size_t l_idx = 0; l_idx < col_annotations.size(); ++l_idx) {
             for (size_t j = 0; j < col_annotations[l_idx].num_labels(); ++j) {
                 const std::unique_ptr<bit_vector> &source_col
@@ -364,7 +364,7 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
                     source_row_nbits.push_back(nbits);
                 }
 
-                #pragma omp parallel for num_threads(num_threads) collapse(2)
+                #pragma omp parallel for num_threads(num_threads)
                 for (size_t s = 0; s < sources.size(); ++s) {
                     for (size_t j = 0; j < set_rows[s].size(); ++j) {
                         targets[s][j]->insert(set_rows[s][j].begin(), set_rows[s][j].end());

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -21,6 +21,8 @@ using mtg::common::logger;
 /** Marker type to indicate a value represent a node index in a BOSS graph */
 using node_index = graph::boss::BOSS::node_index;
 
+typedef RowDiff<ColumnMajor>::anchor_bv_type anchor_bv_type;
+
 
 void build_successor(const std::string &graph_fname,
                      const std::string &outfbase,
@@ -68,7 +70,7 @@ void build_successor(const std::string &graph_fname,
     }
 
     std::ofstream fterm(outfbase + ".terminal.unopt", ios::binary);
-    sdsl::rrr_vector(term).serialize(fterm);
+    anchor_bv_type(term).serialize(fterm);
     term = sdsl::bit_vector();
     fterm.close();
     logger->trace("Anchor nodes written to {}.terminal.unopt", outfbase);
@@ -281,7 +283,7 @@ void convert_batch_to_row_diff(const std::string &graph_fname,
     }
     logger->trace("Done loading {} annotations", sources.size());
 
-    sdsl::rrr_vector rterminal;
+    anchor_bv_type rterminal;
     {
         std::ifstream f(graph_fname + anchors_extension, std::ios::binary);
         rterminal.load(f);
@@ -525,7 +527,7 @@ void optimize_anchors_in_row_diff(const std::string &graph_fname,
     logger->trace("Number of anchors after optimization: {}",
                   sdsl::util::cnt_one_bits(anchors));
 
-    sdsl::rrr_vector ranchors(anchors);
+    anchor_bv_type ranchors(anchors);
     std::ofstream f(graph_fname + ".terminal", ios::binary);
     ranchors.serialize(f);
     logger->trace("Serialized optimized anchors to {}", graph_fname + ".terminal");

--- a/metagraph/src/annotation/row_diff_builder.hpp
+++ b/metagraph/src/annotation/row_diff_builder.hpp
@@ -19,7 +19,8 @@ void build_successor(const std::string &graph_filename,
 
 void convert_batch_to_row_diff(const std::string &graph_fname,
                                const std::vector<std::string> &source_files,
-                               const std::filesystem::path &dest_dir);
+                               const std::filesystem::path &dest_dir,
+                               const std::string &delta_nbits_fname);
 
 } // namespace annot
 } // namespace mtg

--- a/metagraph/src/annotation/row_diff_builder.hpp
+++ b/metagraph/src/annotation/row_diff_builder.hpp
@@ -20,7 +20,13 @@ void build_successor(const std::string &graph_filename,
 void convert_batch_to_row_diff(const std::string &graph_fname,
                                const std::vector<std::string> &source_files,
                                const std::filesystem::path &dest_dir,
-                               const std::string &delta_nbits_fname);
+                               const std::string &delta_nbits_fname,
+                               const std::string &anchors_extension = ".terminal.unopt");
+
+void optimize_anchors_in_row_diff(const std::string &graph_fname,
+                                  const std::vector<std::string> &source_files,
+                                  const std::filesystem::path &dest_dir,
+                                  const std::string &delta_nbits_fname);
 
 } // namespace annot
 } // namespace mtg

--- a/metagraph/src/annotation/row_diff_builder.hpp
+++ b/metagraph/src/annotation/row_diff_builder.hpp
@@ -24,7 +24,8 @@ void convert_batch_to_row_diff(const std::string &graph_fname,
                                const std::string &anchors_extension = ".terminal.unopt");
 
 void optimize_anchors_in_row_diff(const std::string &graph_fname,
-                                  const std::filesystem::path &dest_dir);
+                                  const std::filesystem::path &dest_dir,
+                                  const std::string &row_reduction_extension);
 
 } // namespace annot
 } // namespace mtg

--- a/metagraph/src/annotation/row_diff_builder.hpp
+++ b/metagraph/src/annotation/row_diff_builder.hpp
@@ -24,9 +24,7 @@ void convert_batch_to_row_diff(const std::string &graph_fname,
                                const std::string &anchors_extension = ".terminal.unopt");
 
 void optimize_anchors_in_row_diff(const std::string &graph_fname,
-                                  const std::vector<std::string> &source_files,
-                                  const std::filesystem::path &dest_dir,
-                                  const std::string &delta_nbits_fname);
+                                  const std::filesystem::path &dest_dir);
 
 } // namespace annot
 } // namespace mtg

--- a/metagraph/src/annotation/row_diff_builder.hpp
+++ b/metagraph/src/annotation/row_diff_builder.hpp
@@ -17,11 +17,11 @@ void build_successor(const std::string &graph_filename,
                      uint32_t max_length,
                      uint32_t num_threads);
 
-void convert_batch_to_row_diff(const std::string &graph_fname,
+void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
+                               const std::string &anchors_fname,
                                const std::vector<std::string> &source_files,
                                const std::filesystem::path &dest_dir,
-                               const std::string &delta_nbits_fname,
-                               const std::string &anchors_extension = ".terminal.unopt");
+                               const std::string &row_reduction_fname);
 
 void optimize_anchors_in_row_diff(const std::string &graph_fname,
                                   const std::filesystem::path &dest_dir,

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -314,6 +314,8 @@ Config::Config(int argc, char *argv[]) {
         //    debug = true;
         } else if (!strcmp(argv[i], "--greedy")) {
             greedy_brwt = true;
+        } else if (!strcmp(argv[i], "--optimize")) {
+            optimize = true;
         } else if (!strcmp(argv[i], "--linkage")) {
             cluster_linkage = true;
         } else if (!strcmp(argv[i], "--subsample")) {
@@ -1017,6 +1019,7 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --parallel-nodes [INT] \tnumber of nodes processed in parallel in brwt tree [n_threads]\n");
             fprintf(stderr, "\t   --max-path-length [INT] \tmaximum path length in row_diff annotation [50]\n");
+            fprintf(stderr, "\t   --optimize \t\t\toptimize anchors in row_diff annotation [off]\n");
         } break;
         case RELAX_BRWT: {
             fprintf(stderr, "Usage: %s relax_brwt -o <annotation-basename> [options] ANNOTATOR\n\n", prog_name.c_str());

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -58,6 +58,7 @@ class Config {
     bool align_both_strands = false;
     bool filter_by_kmer = false;
     bool output_json = false;
+    bool optimize = false;
 
     unsigned int k = 3;
     // For succinct graphs by default, cache ranges of nodes

--- a/metagraph/src/cli/transform_annotation.cpp
+++ b/metagraph/src/cli/transform_annotation.cpp
@@ -371,7 +371,7 @@ int transform_annotation(Config *config) {
             case Config::RowDiff: {
                 auto out_dir = std::filesystem::path(config->outfbase).remove_filename();
                 convert_to_row_diff(files, config->infbase, config->memory_available * 1e9,
-                                    config->max_path_length, out_dir);
+                                    config->max_path_length, out_dir, config->optimize);
                 break;
             }
             case Config::RowCompressed: {

--- a/metagraph/tests/annotation/row_diff/test_row_diff.cpp
+++ b/metagraph/tests/annotation/row_diff/test_row_diff.cpp
@@ -15,6 +15,8 @@ using namespace mtg;
 using namespace testing;
 using ::testing::_;
 
+typedef annot::binmat::RowDiff<annot::binmat::ColumnMajor>::anchor_bv_type anchor_bv_type;
+
 TEST(RowDiff, Empty) {
     annot::binmat::RowDiff<annot::binmat::ColumnMajor> rowdiff;
     EXPECT_EQ(0, rowdiff.diffs().num_columns());
@@ -29,7 +31,7 @@ TEST(RowDiff, Empty) {
 
 TEST(RowDiff, Serialize) {
     sdsl::bit_vector bterminal = { 0, 0, 0, 1 };
-    sdsl::rrr_vector terminal(bterminal);
+    anchor_bv_type terminal(bterminal);
     utils::TempFile fterm_temp;
     std::ofstream fterm(fterm_temp.name(), ios::binary);
     terminal.serialize(fterm);
@@ -76,7 +78,7 @@ TEST(RowDiff, GetAnnotation) {
 
     // build annotation
     sdsl::bit_vector bterminal = { 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0 };
-    sdsl::rrr_vector terminal(bterminal);
+    anchor_bv_type terminal(bterminal);
     utils::TempFile fterm_temp;
     std::ofstream fterm(fterm_temp.name(), ios::binary);
     terminal.serialize(fterm);
@@ -131,7 +133,7 @@ TEST(RowDiff, GetAnnotationMasked) {
 
     // build annotation
     sdsl::bit_vector bterminal = { 0, 0, 0, 0, 1, 0, 1, 0 };
-    sdsl::rrr_vector terminal(bterminal);
+    anchor_bv_type terminal(bterminal);
     utils::TempFile fterm_temp;
     std::ofstream fterm(fterm_temp.name(), ios::binary);
     terminal.serialize(fterm);
@@ -185,7 +187,7 @@ TEST(RowDiff, GetAnnotationBifurcation) {
 
     // build annotation
     sdsl::bit_vector bterminal = { 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0 };
-    sdsl::rrr_vector terminal(bterminal);
+    anchor_bv_type terminal(bterminal);
     utils::TempFile fterm_temp;
     std::ofstream fterm(fterm_temp.name(), ios::binary);
     terminal.serialize(fterm);
@@ -241,7 +243,7 @@ TEST(RowDiff, GetAnnotationBifurcationMasked) {
 
     // build annotation
     sdsl::bit_vector bterminal = { 0, 1, 0, 0, 0, 0, 1, 0, 1, 0 };
-    sdsl::rrr_vector terminal(bterminal);
+    anchor_bv_type terminal(bterminal);
     utils::TempFile fterm_temp;
     std::ofstream fterm(fterm_temp.name(), ios::binary);
     terminal.serialize(fterm);

--- a/metagraph/tests/annotation/test_converters.cpp
+++ b/metagraph/tests/annotation/test_converters.cpp
@@ -167,9 +167,9 @@ TEST(RowDiff, succ) {
         const std::string pred_file = graph_fname + ".pred";
         const std::string pred_boundary_file = graph_fname + ".pred_boundary";
         const std::vector<std::vector<uint64_t>> expected_succ
-                = { { 0, 0, 0, 0, 0 }, { 0, 4, 1, 5, 0 }, { 0, 4, 1, 5, 3 } };
+                = { { 5, 5, 5, 5, 5 }, { 5, 3, 0, 4, 5 }, { 5, 3, 0, 4, 2 } };
         const std::vector<std::vector<uint64_t>> expected_pred
-                = { {}, { 3, 2, 4 }, { 3, 5, 2, 4 } };
+                = { {}, { 2, 1, 3 }, { 2, 4, 1, 3 } };
         const std::vector<std::vector<bool>> expected_boundary = {
             { 1, 1, 1, 1, 1 }, { 0, 1, 1, 1, 0, 1, 0, 1 }, { 0, 1, 1, 0, 1, 0, 1, 0, 1 }
         };


### PR DESCRIPTION
Algorithm:
* The first run `./transform --anno-type row_diff ...` uses the initial anchors and computes reduction for each row (supports batching columns).
* Second run with optimization `./transform --anno-type row_diff --optimize ...` (also supports small batches) merges the row reduction vectors from all batches from the first run and assigns new anchors. Then runs the transform again (for the given batch) as in the first run but using the anchors updated.