### PR TITLE
precompute dummy k-mers in call_sequences_row_diff

### DIFF
--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -51,8 +51,7 @@ void build_successor(const std::string &graph_fname,
     const BOSS &boss = graph.get_boss();
     sdsl::bit_vector terminal;
     sdsl::bit_vector dummy;
-    boss.call_sequences_row_diff([&](const vector<uint64_t> &, std::optional<uint64_t>) {},
-                                 num_threads, max_length, &terminal, &dummy);
+    boss.row_diff_traverse(num_threads, max_length, &terminal, &dummy);
 
     // terminal uses BOSS edges as indices, so we need to map it to annotation indices
     sdsl::bit_vector term(graph.num_nodes(), 0);

--- a/metagraph/src/cli/stats.cpp
+++ b/metagraph/src/cli/stats.cpp
@@ -26,8 +26,7 @@ typedef annot::MultiLabelEncoded<std::string> Annotator;
 
 void print_boss_stats(const graph::boss::BOSS &boss_graph,
                       bool count_dummy,
-                      size_t num_threads,
-                      bool verbose) {
+                      size_t num_threads) {
     std::cout << "====================== BOSS STATS ======================" << std::endl;
     std::cout << "k: " << boss_graph.get_k() + 1 << std::endl;
     std::cout << "nodes (k-1): " << boss_graph.num_nodes() << std::endl;
@@ -57,7 +56,7 @@ void print_boss_stats(const graph::boss::BOSS &boss_graph,
 
     if (count_dummy) {
         uint64_t num_source_dummy_edges
-            = boss_graph.mark_source_dummy_edges(NULL, num_threads, verbose);
+            = boss_graph.mark_source_dummy_edges(NULL, num_threads);
         uint64_t num_sink_dummy_edges = boss_graph.mark_sink_dummy_edges(NULL);
 
         std::cout << "dummy source edges: " << num_source_dummy_edges << std::endl;
@@ -182,10 +181,7 @@ int print_stats(Config *config) {
         if (auto dbg_succ = dynamic_cast<graph::DBGSuccinct*>(graph.get())) {
             const auto &boss_graph = dbg_succ->get_boss();
 
-            print_boss_stats(boss_graph,
-                             config->count_dummy,
-                             get_num_threads(),
-                             get_verbose());
+            print_boss_stats(boss_graph, config->count_dummy, get_num_threads());
 
             if (config->print_graph_internal_repr) {
                 logger->info("Printing internal representation");

--- a/metagraph/src/cli/stats.hpp
+++ b/metagraph/src/cli/stats.hpp
@@ -21,8 +21,7 @@ void print_stats(const graph::DeBruijnGraph &graph);
 
 void print_boss_stats(const graph::boss::BOSS &boss_graph,
                       bool count_dummy = false,
-                      size_t num_threads = 0,
-                      bool verbose = false);
+                      size_t num_threads = 0);
 
 int print_stats(Config *config);
 

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -199,12 +199,10 @@ class BOSS {
      * @param[out] mask a bit mask where sink dummy edges are marked. Must have the same
      * size as #W_ or must be nullptr.
      * @param[in] num_threads number of threads to use in the traversal (1 thread if <=1).
-     * @param[in] verbose logging verbosity
      * @return the number of source dummy edges
      */
     uint64_t mark_source_dummy_edges(sdsl::bit_vector *mask = NULL,
-                                     size_t num_threads = 0,
-                                     bool verbose = false) const;
+                                     size_t num_threads = 0) const;
 
     /**
      * Mark sink dummy edges into mask. Does not include the main dummy edge (with

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -137,23 +137,19 @@ class BOSS {
                         const bitmap *subgraph_mask = NULL) const;
 
     /**
-     * Generate contigs that cover the graph and invoke #callback for each contig.
      * Traversal starts at dummy source edges, then at forks and in the end at cycles.
      * A contig is terminated when we reach dead end or a fork where the first edge
      * is visited, but not marked as being near a terminal edge.
      *
-     * @param callback invoke this for each generated contig
      * @param num_threads parallelize the graph traversal on this many threads
      * @param max_length maximum distance between two terminal nodes; this is a soft
      *        limit - in the worst case the distance between to terminal nodes can
      *        be 2*max_length
      */
-    void call_sequences_row_diff(
-            Call<const std::vector<edge_index> &, std::optional<edge_index>> callback,
-            size_t num_threads,
-            size_t max_length,
-            sdsl::bit_vector *terminal,
-            sdsl::bit_vector *dummy) const;
+    void row_diff_traverse(size_t num_threads,
+                           size_t max_length,
+                           sdsl::bit_vector *terminal,
+                           sdsl::bit_vector *dummy) const;
 
     /**
      * Call unitigs (dummy edges are skipped).

--- a/metagraph/tests/graph/succinct/test_boss.cpp
+++ b/metagraph/tests/graph/succinct/test_boss.cpp
@@ -953,9 +953,9 @@ TEST(BOSS, CallSequencesRowDiff_EmptyGraph) {
 
             sdsl::bit_vector terminal;
             sdsl::bit_vector dummy;
-            empty.call_sequences_row_diff([&](const auto &, const std::optional<uint64_t> &) {
-                FAIL() << "Empty graph should not have any sequences!";
-            }, num_threads, 1, &terminal, &dummy);
+            empty.row_diff_traverse(num_threads, 1, &terminal, &dummy);
+            ASSERT_EQ(sdsl::bit_vector(2, false), terminal)
+                << "Empty graph must have no anchors";
         }
     }
 }
@@ -1069,15 +1069,10 @@ TEST(BOSS, CallSequenceRowDiff_TwoLoops) {
 
             sdsl::bit_vector terminal;
             sdsl::bit_vector dummy;
-            std::atomic<size_t> num_sequences = 0;
-            graph.call_sequences_row_diff([&](const std::vector<uint64_t> &path, const std::optional<uint64_t> &anchor) {
-              num_sequences++;
-              ASSERT_FALSE(anchor.has_value());
-              ASSERT_EQ(1U, path.size());
-              ASSERT_EQ(std::string(k, 'A'), graph.get_node_str(path[0]));
-            }, num_threads, 1, &terminal, &dummy);
-
-            ASSERT_EQ(1, num_sequences);
+            graph.row_diff_traverse(num_threads, 1, &terminal, &dummy);
+            ASSERT_EQ(graph.num_edges() + 1, dummy.size());
+            ASSERT_EQ(graph.num_edges() + 1, terminal.size());
+            ASSERT_EQ(sdsl::bit_vector({ 0, 0, 1 }), terminal);
         }
     }
 }
@@ -1133,31 +1128,17 @@ TEST(BOSS, CallSequenceRowDiff_TwoBigLoops) {
         constructor.add_sequences(std::vector<std::string>(sequences));
         BOSS graph(&constructor);
 
-        for (uint32_t max_length = 1; max_length <20; ++max_length) {
-            sdsl::bit_vector terminal;
-            sdsl::bit_vector dummy;
-            std::atomic<size_t> num_sequences = 0;
-            std::atomic<size_t> visited_nodes = 0;
-            graph.call_sequences_row_diff(
-                    [&](const std::vector<uint64_t> &path,
-                        const std::optional<uint64_t> &anchor) {
-                        num_sequences++;
-                        visited_nodes += path.size();
+        sdsl::bit_vector terminal;
+        sdsl::bit_vector dummy;
+        graph.row_diff_traverse(num_threads, 100, &terminal, &dummy);
+        ASSERT_EQ(graph.num_edges() + 1, dummy.size());
+        ASSERT_EQ(graph.num_edges() + 1, terminal.size());
+        ASSERT_EQ(2, std::accumulate(terminal.begin() + 1, terminal.end(), 0U));
 
-                        for (uint32_t idx = max_length; idx <= path.size(); idx += max_length) {
-                            ASSERT_TRUE(terminal[path[idx - 1]]);
-                        }
-                        ASSERT_TRUE(terminal[path.back()] ^ anchor.has_value());
-                    },
-                    num_threads, max_length, &terminal, &dummy);
-            ASSERT_EQ(graph.num_edges() + 1, terminal.size());
-            ASSERT_EQ(graph.num_edges() + 1, dummy.size());
-
-            ASSERT_EQ(2, num_sequences);
-
-            uint64_t count_dummy = std::accumulate(dummy.begin() + 1, dummy.end(), 0U);
-            ASSERT_EQ(graph.num_edges(), visited_nodes + count_dummy);
-        }
+        graph.row_diff_traverse(num_threads, 1, &terminal, &dummy);
+        ASSERT_EQ(graph.num_edges() + 1, dummy.size());
+        ASSERT_EQ(graph.num_edges() + 1, terminal.size());
+        ASSERT_EQ(104, std::accumulate(terminal.begin() + 1, terminal.end(), 0U));
     }
 }
 
@@ -1228,17 +1209,10 @@ TEST(BOSS, CallSequenceRowDiff_FourLoops) {
 
             sdsl::bit_vector terminal;
             sdsl::bit_vector dummy;
-            std::atomic<size_t> num_sequences = 0;
-            graph.call_sequences_row_diff(
-                    [&](const std::vector<uint64_t> &path,
-                        const std::optional<uint64_t> &anchor) {
-                        num_sequences++;
-                        ASSERT_EQ(path.size(), 1);
-                        ASSERT_FALSE(anchor.has_value());
-                    },
-                    num_threads, 1, &terminal, &dummy);
+            graph.row_diff_traverse(num_threads, 1, &terminal, &dummy);
+            ASSERT_EQ(graph.num_edges() + 1, dummy.size());
             ASSERT_EQ(graph.num_edges() + 1, terminal.size());
-            ASSERT_EQ(4, num_sequences);
+            ASSERT_EQ(4, std::accumulate(terminal.begin() + 1, terminal.end(), 0U));
         }
     }
 }
@@ -1254,24 +1228,15 @@ TEST(BOSS, CallSequenceRowDiff_FourPaths) {
     for (size_t num_threads : { 1, 4 }) {
         sdsl::bit_vector terminal;
         sdsl::bit_vector dummy;
-        std::atomic<size_t> num_sequences = 0;
-        std::vector<std::string> found_sequences(4);
-        graph.call_sequences_row_diff(
-                [&](const std::vector<uint64_t> &path, const std::optional<uint64_t> &) {
-                  std::string sequence(path.size(), '\0');
-                  std::transform(path.begin(), path.end(), sequence.begin(),
-                                 [&](uint64_t edge) { return graph.decode(graph.get_W(edge)); });
-                  {
-                      std::unique_lock<std::mutex> lock(mu);
-                      found_sequences[num_sequences] = graph.get_node_str(path[0]) + sequence;
-                      num_sequences++;
-                  }
-                },
-                num_threads, 1, &terminal, &dummy);
-
+        graph.row_diff_traverse(num_threads, 20, &terminal, &dummy);
+        ASSERT_EQ(graph.num_edges() + 1, dummy.size());
         ASSERT_EQ(graph.num_edges() + 1, terminal.size());
-        ASSERT_EQ(4, num_sequences);
-        ASSERT_THAT(found_sequences, ::testing::UnorderedElementsAreArray(sequences));
+        ASSERT_EQ(4, std::accumulate(terminal.begin() + 1, terminal.end(), 0U));
+
+        graph.row_diff_traverse(num_threads, 1, &terminal, &dummy);
+        ASSERT_EQ(graph.num_edges() + 1, dummy.size());
+        ASSERT_EQ(graph.num_edges() + 1, terminal.size());
+        ASSERT_EQ(19, std::accumulate(terminal.begin() + 1, terminal.end(), 0U));
     }
 }
 


### PR DESCRIPTION
This should make the traversal slightly faster.
Also prepares for another optimization in row-diff where we start traversal from the sink nodes and must have source dummy nodes precomputed to know where to stop.