### PR TITLE
traverse row-diff paths backwards for initial anchor assignment

### DIFF
--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -26,7 +26,7 @@ void build_successor(const std::string &graph_fname,
                      uint32_t max_length,
                      uint32_t num_threads) {
     bool must_build = false;
-    for (const auto &suffix : { ".succ", ".pred", ".pred_boundary", ".terminal" }) {
+    for (const auto &suffix : { ".succ", ".pred", ".pred_boundary", ".terminal.unopt" }) {
         if (!std::filesystem::exists(outfbase + suffix)) {
             logger->trace(
                     "Building and writing successor, predecessor and terminal files to {}.*",
@@ -68,7 +68,7 @@ void build_successor(const std::string &graph_fname,
     std::ofstream fterm(outfbase + ".terminal.unopt", ios::binary);
     term.serialize(fterm);
     fterm.close();
-    logger->trace("Anchor nodes written to {}.terminal", outfbase);
+    logger->trace("Anchor nodes written to {}.terminal.unopt", outfbase);
 
     // create the succ file, indexed using annotation indices
     uint32_t width = sdsl::bits::hi(graph.num_nodes()) + 1;

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -2819,24 +2819,16 @@ void BOSS::row_diff_traverse(size_t num_threads,
         if (fetch_and_set_bit(visited.data(), rep, async))
             return;
 
-        ++progress_bar;
-
         for (edge_index idx : path) {
             std::ignore = idx;
             assert(idx == rep || !fetch_bit(visited.data(), idx, async));
             set_bit(visited.data(), idx, async);
-            ++progress_bar;
         }
 
-        std::optional<edge_index> anchor;
-        for (uint64_t i = 0; i + max_length <= path.size(); i += max_length) {
-            set_bit(terminal->data(), path[i + max_length - 1], async);
-        }
+        progress_bar += path.size();
 
-        if (path.size() < max_length) { // set a terminal node every max_length nodes
-            set_bit(terminal->data(), path.back(), async);
-        } else if (path.size() > 1 && path.size() % max_length != 0) {
-            anchor = path[0];
+        for (uint64_t i = 0; i < path.size(); i += max_length) {
+            set_bit(terminal->data(), path[i], async);
         }
     };
 

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -2369,6 +2369,7 @@ void update_terminal_bits(uint64_t max_length,
     for (i = 0; i + max_length <= path.size(); i += max_length) {
         for (uint64_t j = i; j + 1 < i + max_length; ++j) {
             assert(!fetch_bit(terminal->data(), path[j], async));
+            assert(!fetch_bit(near_terminal->data(), path[j], async));
             set_bit(near_terminal->data(), path[j], async);
         }
         assert(!fetch_bit(near_terminal->data(), path[i + max_length - 1], async));
@@ -2383,8 +2384,9 @@ void update_terminal_bits(uint64_t max_length,
     //                      ^   ^
     //                      i next_edge
 
-    // skip the path if the next node is close to an anchor and, therefore,
-    // this last segment is close to that anchor too (at most 2 * max_length)
+    // If the next node is close to an existing anchor and, therefore, every
+    // node in this last segment is close to it too (at most 2 * max_length),
+    // there is no need to set another anchor at the end of the path.
     if (fetch_bit(near_terminal->data(), next_edge, async)) {
         assert(!fetch_bit(terminal->data(), next_edge, async));
         return;
@@ -2395,7 +2397,8 @@ void update_terminal_bits(uint64_t max_length,
         path.pop_back();
     }
 
-    // we set a new anchor, thus will mark its predecessors as close to it
+    // The last node of |path| is an anchor, so all its predecessors must be
+    // marked as near-anchor.
     while (i < path.size()) {
         set_bit(near_terminal->data(), path[i++], async);
     }

--- a/metagraph/tests/annotation/test_converters.cpp
+++ b/metagraph/tests/annotation/test_converters.cpp
@@ -157,22 +157,40 @@ std::unique_ptr<graph::DBGSuccinct> create_graph(uint32_t k, std::vector<string>
 
 TEST(RowDiff, succ) {
     const auto dst_dir = std::filesystem::path(test_dump_basename)/"row_diff_succ/";
+    const std::string graph_fname = dst_dir/(std::string("ACGTCAG") + graph::DBGSuccinct::kExtension);
+    const std::string succ_file = graph_fname + ".succ";
+    const std::string pred_file = graph_fname + ".pred";
+    const std::string pred_boundary_file = graph_fname + ".pred_boundary";
+
+    /**
+     * Graph:
+     *
+     * 1: CAG
+     * 2: ACG
+     * 3: TCA
+     * 4: CGT
+     * 5: GTC
+     *
+     * 2 -> 4 -> 5 -> 3 -> 1
+     */
+
+    const std::vector<std::vector<uint64_t>> expected_succ = {
+        { 0, 0, 0, 0, 0 },
+        { 0, 4, 1, 0, 3 },
+        { 0, 4, 1, 5, 3 } };
+    const std::vector<std::vector<uint64_t>> expected_pred = {
+        {},
+        { 3, 5, 2 },
+        { 3, 5, 2, 4 } };
+    const std::vector<std::vector<bool>> expected_boundary = {
+        { 1, 1, 1, 1, 1 },
+        { 0, 1, 1, 0, 1, 0, 1, 1 },
+        { 0, 1, 1, 0, 1, 0, 1, 0, 1 }
+    };
 
     for (uint32_t max_depth : { 1, 3, 5 }) {
         std::filesystem::remove_all(dst_dir);
         std::filesystem::create_directories(dst_dir);
-
-        const std::string graph_fname = dst_dir/(std::string("ACGTCAG") + graph::DBGSuccinct::kExtension);
-        const std::string succ_file = graph_fname + ".succ";
-        const std::string pred_file = graph_fname + ".pred";
-        const std::string pred_boundary_file = graph_fname + ".pred_boundary";
-        const std::vector<std::vector<uint64_t>> expected_succ
-                = { { 0, 0, 0, 0, 0 }, { 0, 4, 1, 5, 0 }, { 0, 4, 1, 5, 3 } };
-        const std::vector<std::vector<uint64_t>> expected_pred
-                = { {}, { 3, 2, 4 }, { 3, 5, 2, 4 } };
-        const std::vector<std::vector<bool>> expected_boundary = {
-            { 1, 1, 1, 1, 1 }, { 0, 1, 1, 1, 0, 1, 0, 1 }, { 0, 1, 1, 0, 1, 0, 1, 0, 1 }
-        };
 
         std::unique_ptr<graph::DBGSuccinct> graph = create_graph(3, { "ACGTCAG" });
         graph->serialize(graph_fname);
@@ -194,7 +212,7 @@ TEST(RowDiff, succ) {
         uint32_t idx = max_depth / 2;
         ASSERT_EQ(5, succ.size());
         for (uint32_t i = 0; i < succ.size(); ++i) {
-            EXPECT_EQ(expected_succ[idx][i], succ[i]);
+            EXPECT_EQ(expected_succ[idx][i], succ[i]) << max_depth << " " << i;;
         }
 
         sdsl::int_vector_buffer pred(pred_file, std::ios::in);
@@ -210,7 +228,7 @@ TEST(RowDiff, succ) {
 
         ASSERT_EQ(expected_boundary[idx].size(), boundary.size());
         for(uint32_t i = 0; i < expected_boundary[idx].size(); ++i) {
-            EXPECT_EQ(expected_boundary[idx][i], boundary[i]);
+            EXPECT_EQ(expected_boundary[idx][i], boundary[i]) << max_depth << " " << i;
         }
     }
 


### PR DESCRIPTION
This should significantly reduce the number of initially assigned anchors and make it closer to the desired value.

---
Result of an experiment:
The backward traversal processes more than 98% of the graph (24750k subset of Microbe), which is very good, because for this part the anchors are assigned optimally.
```
...
[2020-10-25 22:25:19.928]  98.7%, 6170180163/6251449537
[2020-10-25 22:25:20.676] [info] Backward traversal from sinks is done. Finishing up the rest...
[2020-10-25 22:25:21.572]  98.8%, 6176431612/6251449537
...
[2020-10-25 22:26:03.158] 100.0%, 6251449537/6251449537
```
