### PR TITLE
Various minor fixes

### DIFF
--- a/metagraph/src/graph/alignment/aligner_helper.cpp
+++ b/metagraph/src/graph/alignment/aligner_helper.cpp
@@ -210,7 +210,7 @@ Alignment<NodeType>::Alignment(const DPTable<NodeType> &dp_table,
     if (op == Cigar::INSERTION)
         prev_node = prev_gap_node;
 
-    uint8_t gap_count = op == Cigar::INSERTION ? column->second.gap_count.at(i) - 1 : 0;
+    uint32_t gap_count = op == Cigar::INSERTION ? column->second.gap_count.at(i) - 1 : 0;
 
     if (!i && prev_node == SequenceGraph::npos)
         return;

--- a/metagraph/src/graph/alignment/aligner_seeder_methods.cpp
+++ b/metagraph/src/graph/alignment/aligner_seeder_methods.cpp
@@ -59,6 +59,7 @@ void ExactSeeder<NodeType>::call_seeds(std::function<void(Seed&&)> callback) con
         size_t seed_length = k - offsets[i];
 
         assert(i + seed_length <= query.size());
+        assert(seed_length >= config.min_seed_length);
 
         score_t match_score = partial_sum[i + seed_length] - partial_sum[i];
 
@@ -244,6 +245,7 @@ template <typename NodeType>
 void MEMSeeder<NodeType>::call_seeds(std::function<void(Seed&&)> callback) const {
     const auto &graph = this->get_graph();
     size_t k = graph.get_k();
+
     auto query = this->get_query();
     const auto &query_nodes = this->get_query_nodes();
     const auto &offsets = this->get_offsets();
@@ -280,6 +282,8 @@ void MEMSeeder<NodeType>::call_seeds(std::function<void(Seed&&)> callback) const
 
         const char *begin_it = query.data() + i;
         const char *end_it = begin_it + mem_length;
+
+        assert(end_it >= begin_it + config.min_seed_length);
 
         score_t match_score = partial_sum[end_it - query.data()]
             - partial_sum[begin_it - query.data()];

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -148,17 +148,17 @@ void CanonicalDBG
         }
 
     } catch (...) {
-        size_t alph_size = alphabet.size();
-        std::vector<node_index> children(alph_size);
+        size_t max_num_edges_left = alphabet.size();
+        std::vector<node_index> children(max_num_edges_left);
 
         graph_.call_outgoing_kmers(node, [&](node_index next, char c) {
             if (c != boss::BOSS::kSentinel)
                 children[alphabet_encoder_[c]] = next;
 
-            --alph_size;
+            --max_num_edges_left;
         });
 
-        if (!graph_.is_canonical_mode() && alph_size) {
+        if (!graph_.is_canonical_mode() && max_num_edges_left) {
             node_index next;
             std::string rev_seq = get_node_sequence(node).substr(1) + std::string(1, '\0');
             ::reverse_complement(rev_seq.begin(), rev_seq.end());
@@ -214,17 +214,17 @@ void CanonicalDBG
         }
 
     } catch (...) {
-        size_t alph_size = alphabet.size();
-        std::vector<node_index> parents(alph_size);
+        size_t max_num_edges_left = alphabet.size();
+        std::vector<node_index> parents(max_num_edges_left);
 
         graph_.call_incoming_kmers(node, [&](node_index prev, char c) {
             if (c != boss::BOSS::kSentinel)
                 parents[alphabet_encoder_[c]] = prev;
 
-            --alph_size;
+            --max_num_edges_left;
         });
 
-        if (!graph_.is_canonical_mode() && alph_size) {
+        if (!graph_.is_canonical_mode() && max_num_edges_left) {
             node_index prev;
             std::string rev_seq = std::string(1, '\0') + get_node_sequence(node).substr(0, get_k() - 1);
             ::reverse_complement(rev_seq.begin(), rev_seq.end());

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -18,14 +18,14 @@ CanonicalDBG::CanonicalDBG(std::shared_ptr<const DeBruijnGraph> graph,
                            size_t cache_size)
       : const_graph_ptr_(graph),
         offset_(graph_.max_index()),
-        alph_map_({ graph_.alphabet().size() }),
+        alphabet_encoder_({ graph_.alphabet().size() }),
         primary_(primary && !graph->is_canonical_mode()),
         child_node_cache_(cache_size),
         parent_node_cache_(cache_size),
         rev_comp_cache_(primary_ ? 0 : cache_size),
         is_palindrome_cache_(graph_.get_k() % 2 || !primary_ ? 0 : cache_size) {
     for (size_t i = 0; i < graph_.alphabet().size(); ++i) {
-        alph_map_[graph_.alphabet()[i]] = i;
+        alphabet_encoder_[graph_.alphabet()[i]] = i;
     }
 }
 
@@ -153,7 +153,7 @@ void CanonicalDBG
 
         graph_.call_outgoing_kmers(node, [&](node_index next, char c) {
             if (c != boss::BOSS::kSentinel)
-                children[alph_map_[c]] = next;
+                children[alphabet_encoder_[c]] = next;
 
             --alph_size;
         });
@@ -219,7 +219,7 @@ void CanonicalDBG
 
         graph_.call_incoming_kmers(node, [&](node_index prev, char c) {
             if (c != boss::BOSS::kSentinel)
-                parents[alph_map_[c]] = prev;
+                parents[alphabet_encoder_[c]] = prev;
 
             --alph_size;
         });

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -160,7 +160,7 @@ class CanonicalDBG : public DeBruijnGraph {
 
     std::shared_ptr<DeBruijnGraph> graph_ptr_;
 
-    std::array<size_t, 256> alph_map_;
+    std::array<size_t, 256> alphabet_encoder_;
 
     mutable bool primary_;
 

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -3043,14 +3043,11 @@ void BOSS::index_suffix_ranges(size_t suffix_length) {
         for (const auto &[idx, rl, ru] : suffix_ranges) {
             // prepend the suffix with one of the |alph_size - 1| possible characters
             for (TAlphabet c = 1; c < alph_size; ++c) {
-                // tighten the range for nodes ending with |c|
-                uint64_t rk_rl = rank_W(rl - 1, c) + 1;
-                uint64_t rk_ru = rank_W(ru, c);
-                if (rk_rl > rk_ru)
+                edge_index rl_next = rl;
+                edge_index ru_next = ru;
+                if (!tighten_range(&rl_next, &ru_next, c))
                     continue;
 
-                edge_index rl_next = select_last(NF_[c] + rk_rl - 1) + 1;
-                edge_index ru_next = select_last(NF_[c] + rk_ru);
                 assert(idx < num_suffixes);
                 narrowed.emplace_back(num_suffixes * (c - 1) + idx,
                                       rl_next, ru_next);
@@ -3068,20 +3065,18 @@ void BOSS::index_suffix_ranges(size_t suffix_length) {
         // prepend the suffix with one of the |alph_size - 1| possible characters
         for (TAlphabet c = 1; c < alph_size; ++c) {
             // tighten the range
-            uint64_t rk_rl = rank_W(rl - 1, c) + 1;
-            uint64_t rk_ru = rank_W(ru, c);
-            if (rk_rl > rk_ru)
+            edge_index rl_next = rl;
+            edge_index ru_next = ru;
+            if (!tighten_range(&rl_next, &ru_next, c))
                 continue;
 
-            edge_index rl_next = select_last(NF_[c] + rk_rl - 1) + 1;
-            edge_index ru_next = select_last(NF_[c] + rk_ru);
             assert(idx < num_suffixes);
             indexed_suffix_ranges_[num_suffixes * (c - 1) + idx]
                 = std::make_pair(rl_next, ru_next);
         }
     }
 
-    // aline the upper bounds to enable the binary search on them
+    // align the upper bounds to enable the binary search on them
     for (size_t i = 1; i < indexed_suffix_ranges_.size(); ++i) {
         if (!indexed_suffix_ranges_[i].second) {
             // shift the upper bounds of the empty ranges but still keep them empty

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -438,6 +438,8 @@ class BOSS {
     inline std::tuple<edge_index, edge_index, RandomAccessIt>
     index_range(RandomAccessIt begin, RandomAccessIt end) const;
 
+    inline bool tighten_range(edge_index *rl, edge_index *ru, TAlphabet s) const;
+
     /**
      * The size of the alphabet for kmers that this graph encodes.
      * For DNA, this value is 5 ($,A,C,G,T).
@@ -613,6 +615,19 @@ BOSS::get_initial_range(RandomAccessIt begin, RandomAccessIt end) const {
     return std::make_tuple(rl, ru, offset);
 }
 
+inline bool BOSS::tighten_range(edge_index *rl, edge_index *ru, TAlphabet s) const {
+    // Tighten the range of edges including only those ending with |s| and do fwd.
+    uint64_t rk_rl = rank_W(*rl - 1, s) + 1;
+    uint64_t rk_ru = rank_W(*ru, s);
+    if (rk_rl > rk_ru)
+        return false;
+
+    // select the index of the position in last that is rank many positions after offset
+    *rl = select_last(NF_[s] + rk_rl - 1) + 1;
+    *ru = select_last(NF_[s] + rk_ru);
+    return true;
+}
+
 template <typename RandomAccessIt>
 BOSS::edge_index BOSS::index(RandomAccessIt begin, RandomAccessIt end) const {
     static_assert(std::is_same_v<std::decay_t<decltype(*begin)>, TAlphabet>,
@@ -631,18 +646,8 @@ BOSS::edge_index BOSS::index(RandomAccessIt begin, RandomAccessIt end) const {
 
     // update range iteratively while scanning through s
     for (auto it = begin + offset; it != end; ++it) {
-        TAlphabet s = *it;
-
-        // Tighten the range including all edges where
-        // the source nodes have the given suffix.
-        uint64_t rk_rl = rank_W(rl - 1, s) + 1;
-        uint64_t rk_ru = rank_W(ru, s);
-        if (rk_rl > rk_ru)
+        if (!tighten_range(&rl, &ru, *it))
             return npos;
-
-        // select the index of the position in last that is rank many positions after offset
-        ru = select_last(NF_[s] + rk_ru);
-        rl = select_last(NF_[s] + rk_rl - 1) + 1;
     }
     assert(succ_last(rl) <= ru);
     return ru;
@@ -687,18 +692,8 @@ BOSS::index_range(RandomAccessIt begin, RandomAccessIt end) const {
     auto it = begin + offset;
     // update range iteratively while scanning through s
     for (; it != end; ++it) {
-        TAlphabet s = *it;
-
-        // Tighten the range including all edges where
-        // the source nodes have the given suffix.
-        uint64_t rk_rl = rank_W(rl - 1, s) + 1;
-        uint64_t rk_ru = rank_W(ru, s);
-        if (rk_rl > rk_ru)
+        if (!tighten_range(&rl, &ru, *it))
             return std::make_tuple(succ_last(rl), ru, it);
-
-        // select the index of the position in last that is rank many positions after offset
-        ru = select_last(NF_[s] + rk_ru);
-        rl = select_last(NF_[s] + rk_rl - 1) + 1;
     }
     assert(succ_last(rl) <= ru);
     return std::make_tuple(succ_last(rl), ru, it);


### PR DESCRIPTION
1) Added `BOSS::tighten_range` to clean up some of the BOSS internal functions
2) Discovered a legitimate case where an alignment can lead to an assertion failure, but without breaking the rest of the alignment. Fixing it properly requires some structural changes, so the assertion has been replaced with a warning.
3) Added some more asserts to the seeder

Details about 2)
Basically, if a deletion was extended, but then the optimal operation at that position is no longer a deletion, the score of the subsequent position becomes incorrect since it used the gap extension instead of the opening penalty.