### PR TITLE
New compressed graph state

### DIFF
--- a/metagraph/scripts/cloud/build.sh
+++ b/metagraph/scripts/cloud/build.sh
@@ -39,7 +39,7 @@ fi
 
 exit_code=0
 set +e
-if execute metagraph build -v -p "$cores" -k 31 --canonical --state small --count-kmers -o "${output_dir}/${sra_id}" --mem-cap-gb ${mem_cap_gb} --disk-swap ${tmp_dir} --disk-cap-gb 400 --count-width 16 ${input_dir}/${sra_id}.kmc.kmc_pre; then
+if execute metagraph build -v -p "$cores" -k 31 --canonical --count-kmers -o "${output_dir}/${sra_id}" --mem-cap-gb ${mem_cap_gb} --disk-swap ${tmp_dir} --disk-cap-gb 400 --count-width 16 ${input_dir}/${sra_id}.kmc.kmc_pre; then
   exit_code=0
 else
   exit_code=1

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -592,15 +592,13 @@ using mtg::graph::boss::BOSS;
 std::string Config::state_to_string(BOSS::State state) {
     switch (state) {
         case BOSS::State::STAT:
-            return "stat-obsolete";
+            return "stat";
         case BOSS::State::DYN:
             return "dynamic";
         case BOSS::State::SMALL:
             return "small";
         case BOSS::State::FAST:
             return "fast";
-        case BOSS::State::COMPR:
-            return "compr";
         default:
             assert(false);
             return "Never happens";
@@ -608,7 +606,7 @@ std::string Config::state_to_string(BOSS::State state) {
 }
 
 BOSS::State Config::string_to_state(const std::string &string) {
-    if (string == "stat-obsolete") {
+    if (string == "stat") {
         return BOSS::State::STAT;
     } else if (string == "dynamic") {
         return BOSS::State::DYN;
@@ -616,8 +614,6 @@ BOSS::State Config::string_to_state(const std::string &string) {
         return BOSS::State::SMALL;
     } else if (string == "fast") {
         return BOSS::State::FAST;
-    } else if (string == "compr") {
-        return BOSS::State::COMPR;
     } else {
         throw std::runtime_error("Error: unknown graph state");
     }
@@ -909,7 +905,7 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\t   --index-ranges [INT]\tindex all node ranges in BOSS for suffixes of given length [10]\n");
             fprintf(stderr, "\t   --clear-dummy \terase all redundant dummy edges and build an edgemask for non-redundant [off]\n");
             fprintf(stderr, "\t   --prune-tips [INT] \tprune all dead ends of this length and shorter [0]\n");
-            fprintf(stderr, "\t   --state [STR] \tchange state of succinct graph: small / dynamic / fast / compr [small]\n");
+            fprintf(stderr, "\t   --state [STR] \tchange state of succinct graph: small / dynamic / fast [stat]\n");
             fprintf(stderr, "\t   --to-adj-list \twrite adjacency list to file [off]\n");
             fprintf(stderr, "\t   --to-fasta \t\textract sequences from graph and dump to compressed FASTA file [off]\n");
             fprintf(stderr, "\t   --enumerate \t\tenumerate sequences in FASTA [off]\n");

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -599,6 +599,8 @@ std::string Config::state_to_string(BOSS::State state) {
             return "small";
         case BOSS::State::FAST:
             return "fast";
+        case BOSS::State::COMPR:
+            return "compr";
         default:
             assert(false);
             return "Never happens";
@@ -614,6 +616,8 @@ BOSS::State Config::string_to_state(const std::string &string) {
         return BOSS::State::SMALL;
     } else if (string == "fast") {
         return BOSS::State::FAST;
+    } else if (string == "compr") {
+        return BOSS::State::COMPR;
     } else {
         throw std::runtime_error("Error: unknown graph state");
     }
@@ -905,7 +909,7 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\t   --index-ranges [INT]\tindex all node ranges in BOSS for suffixes of given length [10]\n");
             fprintf(stderr, "\t   --clear-dummy \terase all redundant dummy edges and build an edgemask for non-redundant [off]\n");
             fprintf(stderr, "\t   --prune-tips [INT] \tprune all dead ends of this length and shorter [0]\n");
-            fprintf(stderr, "\t   --state [STR] \tchange state of succinct graph: small / dynamic / fast [small]\n");
+            fprintf(stderr, "\t   --state [STR] \tchange state of succinct graph: small / dynamic / fast / compr [small]\n");
             fprintf(stderr, "\t   --to-adj-list \twrite adjacency list to file [off]\n");
             fprintf(stderr, "\t   --to-fasta \t\textract sequences from graph and dump to compressed FASTA file [off]\n");
             fprintf(stderr, "\t   --enumerate \t\tenumerate sequences in FASTA [off]\n");

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -170,7 +170,7 @@ class Config {
     };
     IdentityType identity = NO_IDENTITY;
 
-    graph::boss::BOSS::State state = graph::boss::BOSS::State::SMALL;
+    graph::boss::BOSS::State state = graph::boss::BOSS::State::STAT;
 
     static std::string state_to_string(graph::boss::BOSS::State state);
     static graph::boss::BOSS::State string_to_state(const std::string &string);

--- a/metagraph/src/common/vectors/wavelet_tree.cpp
+++ b/metagraph/src/common/vectors/wavelet_tree.cpp
@@ -512,9 +512,8 @@ template wavelet_tree_dyn wavelet_tree::convert_to<wavelet_tree_dyn>();
     template class wt; \
     template wt wavelet_tree::convert_to<wt>(); \
 
-INSTANTIATE_WT(wavelet_tree_sdsl_fast<sdsl::wt_huff<>>);
-
 INSTANTIATE_WT(wavelet_tree_sdsl<sdsl::wt_huff<>>);
+
 INSTANTIATE_WT(wavelet_tree_sdsl<sdsl::wt_huff<sdsl::rrr_vector<63>>>);
 
 INSTANTIATE_WT(partite_vector<bit_vector_stat>);

--- a/metagraph/src/common/vectors/wavelet_tree.cpp
+++ b/metagraph/src/common/vectors/wavelet_tree.cpp
@@ -206,6 +206,7 @@ template <class t_wt_sdsl>
 void wavelet_tree_sdsl_fast<t_wt_sdsl>::clear() {
     int_vector_ = sdsl::int_vector<>(0, 0, int_vector_.width());
     wwt_ = t_wt_sdsl();
+    count_.assign(count_.size(), 0);
 }
 
 

--- a/metagraph/src/common/vectors/wavelet_tree.cpp
+++ b/metagraph/src/common/vectors/wavelet_tree.cpp
@@ -515,5 +515,6 @@ template wavelet_tree_dyn wavelet_tree::convert_to<wavelet_tree_dyn>();
 INSTANTIATE_WT(wavelet_tree_sdsl_fast<sdsl::wt_huff<>>);
 
 INSTANTIATE_WT(wavelet_tree_sdsl<sdsl::wt_huff<>>);
+INSTANTIATE_WT(wavelet_tree_sdsl<sdsl::wt_huff<sdsl::rrr_vector<63>>>);
 
 INSTANTIATE_WT(partite_vector<bit_vector_stat>);

--- a/metagraph/src/common/vectors/wavelet_tree.hpp
+++ b/metagraph/src/common/vectors/wavelet_tree.hpp
@@ -218,11 +218,9 @@ class wavelet_tree_sdsl : public wavelet_tree {
 };
 
 
-typedef wavelet_tree_sdsl_fast<> wavelet_tree_stat;
+typedef wavelet_tree_sdsl<> wavelet_tree_stat;
 
-typedef wavelet_tree_sdsl<> wavelet_tree_small;
-
-typedef wavelet_tree_sdsl<sdsl::wt_huff<sdsl::rrr_vector<63>>> wavelet_tree_compr;
+typedef wavelet_tree_sdsl<sdsl::wt_huff<sdsl::rrr_vector<63>>> wavelet_tree_small;
 
 typedef partite_vector<> wavelet_tree_fast;
 

--- a/metagraph/src/common/vectors/wavelet_tree.hpp
+++ b/metagraph/src/common/vectors/wavelet_tree.hpp
@@ -207,7 +207,7 @@ class wavelet_tree_sdsl : public wavelet_tree {
     bool load(std::istream &in);
     void serialize(std::ostream &out) const;
 
-    void clear() { wwt_ = t_wt_sdsl(); }
+    void clear() { wwt_ = t_wt_sdsl(); count_.assign(count_.size(), 0); }
 
     sdsl::int_vector<> to_vector() const;
 

--- a/metagraph/src/common/vectors/wavelet_tree.hpp
+++ b/metagraph/src/common/vectors/wavelet_tree.hpp
@@ -222,6 +222,8 @@ typedef wavelet_tree_sdsl_fast<> wavelet_tree_stat;
 
 typedef wavelet_tree_sdsl<> wavelet_tree_small;
 
+typedef wavelet_tree_sdsl<sdsl::wt_huff<sdsl::rrr_vector<63>>> wavelet_tree_compr;
+
 typedef partite_vector<> wavelet_tree_fast;
 
 #endif // __WAVELET_TREE_HPP__

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -44,10 +44,10 @@ typedef BOSS::node_index node_index;
 typedef BOSS::edge_index edge_index;
 typedef BOSS::TAlphabet TAlphabet;
 
-const size_t MAX_ITER_WAVELET_TREE_STAT = 1000;
+const size_t MAX_ITER_WAVELET_TREE_FAST = 1000;
 const size_t MAX_ITER_WAVELET_TREE_DYN = 6;
-const size_t MAX_ITER_WAVELET_TREE_SMALL = 20;
-const size_t MAX_ITER_WAVELET_TREE_COMPR = 5; // TODO: tune
+const size_t MAX_ITER_WAVELET_TREE_STAT = 20;
+const size_t MAX_ITER_WAVELET_TREE_SMALL = 5; // TODO: tune
 
 static const uint64_t kBlockSize = 9'999'872;
 static_assert(!(kBlockSize & 0xFF));
@@ -279,10 +279,6 @@ bool BOSS::load(std::ifstream &instream) {
                 break;
             case State::SMALL:
                 W_ = new wavelet_tree_small(bits_per_char_W_);
-                last_ = new bit_vector_stat();
-                break;
-            case State::COMPR:
-                W_ = new wavelet_tree_compr(bits_per_char_W_);
                 last_ = new bit_vector_small();
                 break;
         }
@@ -397,10 +393,7 @@ edge_index BOSS::pred_W(edge_index i, TAlphabet c_first, TAlphabet c_second) con
             max_iter = MAX_ITER_WAVELET_TREE_SMALL;
             break;
         case FAST:
-            max_iter = MAX_ITER_WAVELET_TREE_STAT;
-            break;
-        case COMPR:
-            max_iter = MAX_ITER_WAVELET_TREE_COMPR;
+            max_iter = MAX_ITER_WAVELET_TREE_FAST;
             break;
     }
 
@@ -458,10 +451,7 @@ BOSS::succ_W(edge_index i, TAlphabet c_first, TAlphabet c_second) const {
             max_iter = MAX_ITER_WAVELET_TREE_SMALL;
             break;
         case FAST:
-            max_iter = MAX_ITER_WAVELET_TREE_STAT;
-            break;
-        case COMPR:
-            max_iter = MAX_ITER_WAVELET_TREE_COMPR;
+            max_iter = MAX_ITER_WAVELET_TREE_FAST;
             break;
     }
 
@@ -1059,7 +1049,7 @@ void BOSS::switch_state(State new_state) {
             break;
         }
         case State::SMALL: {
-            convert<wavelet_tree_small, bit_vector_stat>(&W_, &last_);
+            convert<wavelet_tree_small, bit_vector_small>(&W_, &last_);
             break;
         }
         case State::FAST: {
@@ -1068,10 +1058,6 @@ void BOSS::switch_state(State new_state) {
         }
         case State::DYN: {
             convert<wavelet_tree_dyn, bit_vector_dyn>(&W_, &last_);
-            break;
-        }
-        case State::COMPR: {
-            convert<wavelet_tree_compr, bit_vector_small>(&W_, &last_);
             break;
         }
     }

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -47,7 +47,7 @@ typedef BOSS::TAlphabet TAlphabet;
 const size_t MAX_ITER_WAVELET_TREE_FAST = 1000;
 const size_t MAX_ITER_WAVELET_TREE_DYN = 6;
 const size_t MAX_ITER_WAVELET_TREE_STAT = 20;
-const size_t MAX_ITER_WAVELET_TREE_SMALL = 5; // TODO: tune
+const size_t MAX_ITER_WAVELET_TREE_SMALL = 1;
 
 static const uint64_t kBlockSize = 9'999'872;
 static_assert(!(kBlockSize & 0xFF));

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -282,11 +282,12 @@ class BOSS {
     /**
      * Representation states of the BOSS table.
      *
-     * SMALL is the smallest
-     * STAT provides a good space/time tradeoff
+     * SMALL provides the best space/time trade-off
+     * STAT (deprecated) makes some special routines faster but takes more space
      * FAST is the fastest but large
+     * COMPR is the smallest
      */
-    enum State { STAT = 1, DYN, SMALL, FAST };
+    enum State { STAT = 1, DYN, SMALL, FAST, COMPR };
 
     State get_state() const { return state; }
     void switch_state(State state);

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -280,11 +280,27 @@ class BOSS {
     void print_internal_representation(std::ostream &os = std::cout) const;
 
     /**
-     * Representation states of the BOSS table.
+     * Alternative representation states of the BOSS table.
      *
-     * SMALL is the smallest
-     * STAT provides the best space/time trade-off
-     * FAST is the fastest but large
+     * STAT: provides the best space/time trade-off
+     *      Representation:
+     *          last -- bit_vector_stat
+     *             W -- wavelet_tree_stat
+     *
+     * SMALL: is the smallest, useful for storage or when RAM is limited
+     *      Representation:
+     *          last -- bit_vector_small
+     *             W -- wavelet_tree_small
+     *
+     * FAST: is the fastest but large
+     *      Representation:
+     *          last -- bit_vector_stat
+     *             W -- wavelet_tree_fast
+     *
+     * DYN: is a dynamic representation supporting insert and delete
+     *      Representation:
+     *          last -- bit_vector_dyn
+     *             W -- wavelet_tree_dyn
      */
     enum State { SMALL = 1, DYN, STAT, FAST };
 

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -282,12 +282,11 @@ class BOSS {
     /**
      * Representation states of the BOSS table.
      *
-     * SMALL provides the best space/time trade-off
-     * STAT (deprecated) makes some special routines faster but takes more space
+     * SMALL is the smallest
+     * STAT provides the best space/time trade-off
      * FAST is the fastest but large
-     * COMPR is the smallest
      */
-    enum State { STAT = 1, DYN, SMALL, FAST, COMPR };
+    enum State { SMALL = 1, DYN, STAT, FAST };
 
     State get_state() const { return state; }
     void switch_state(State state);

--- a/metagraph/src/graph/representation/succinct/boss_chunk.cpp
+++ b/metagraph/src/graph/representation/succinct/boss_chunk.cpp
@@ -259,7 +259,7 @@ void BOSS::Chunk::initialize_boss(BOSS *graph, sdsl::int_vector<> *weights) {
 
     assert(graph->W_);
     delete graph->W_;
-    graph->W_ = new wavelet_tree_small(get_W_width(), W_);
+    graph->W_ = new wavelet_tree_stat(get_W_width(), W_);
 
     assert(graph->last_);
     delete graph->last_;
@@ -274,7 +274,7 @@ void BOSS::Chunk::initialize_boss(BOSS *graph, sdsl::int_vector<> *weights) {
     // TODO:
     // graph->alph_size = alph_size_;
 
-    graph->state = BOSS::State::SMALL;
+    graph->state = BOSS::State::STAT;
 
     assert(graph->is_valid());
 

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -712,10 +712,6 @@ bool DBGSuccinct::load(const std::string &filename) {
             valid_edges_.reset(new bit_vector_small());
             break;
         }
-        case BOSS::State::COMPR: {
-            valid_edges_.reset(new bit_vector_small());
-            break;
-        }
     }
 
     // load the mask of valid edges (all non-dummy including npos 0)
@@ -790,8 +786,6 @@ void DBGSuccinct::serialize(const std::string &filename) const {
         || (boss_graph_->get_state() == BOSS::State::DYN
                 && dynamic_cast<const bit_vector_dyn*>(valid_edges_.get()))
         || (boss_graph_->get_state() == BOSS::State::SMALL
-                && dynamic_cast<const bit_vector_small*>(valid_edges_.get()))
-        || (boss_graph_->get_state() == BOSS::State::COMPR
                 && dynamic_cast<const bit_vector_small*>(valid_edges_.get())));
 
     const auto out_filename = prefix + kDummyMaskExtension;
@@ -840,12 +834,6 @@ void DBGSuccinct::switch_state(BOSS::State new_state) {
                 );
                 break;
             }
-            case BOSS::State::COMPR: {
-                valid_edges_ = std::make_unique<bit_vector_small>(
-                    valid_edges_->convert_to<bit_vector_small>()
-                );
-                break;
-            }
         }
     }
 
@@ -864,9 +852,6 @@ BOSS::State DBGSuccinct::get_state() const {
                 || dynamic_cast<const bit_vector_dyn*>(valid_edges_.get()));
     assert(!valid_edges_.get()
                 || boss_graph_->get_state() != BOSS::State::SMALL
-                || dynamic_cast<const bit_vector_small*>(valid_edges_.get()));
-    assert(!valid_edges_.get()
-                || boss_graph_->get_state() != BOSS::State::COMPR
                 || dynamic_cast<const bit_vector_small*>(valid_edges_.get()));
 
     return boss_graph_->get_state();
@@ -895,10 +880,6 @@ void DBGSuccinct::mask_dummy_kmers(size_t num_threads, bool with_pruning) {
             break;
         }
         case BOSS::State::SMALL: {
-            valid_edges_ = std::make_unique<bit_vector_small>(std::move(vector_mask));
-            break;
-        }
-        case BOSS::State::COMPR: {
             valid_edges_ = std::make_unique<bit_vector_small>(std::move(vector_mask));
             break;
         }

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -697,7 +697,7 @@ bool DBGSuccinct::load(const std::string &filename) {
     // initialize a new vector
     switch (get_state()) {
         case BOSS::State::STAT: {
-            valid_edges_.reset(new bit_vector_stat());
+            valid_edges_.reset(new bit_vector_small());
             break;
         }
         case BOSS::State::FAST: {
@@ -780,7 +780,7 @@ void DBGSuccinct::serialize(const std::string &filename) const {
         return;
 
     assert((boss_graph_->get_state() == BOSS::State::STAT
-                && dynamic_cast<const bit_vector_stat*>(valid_edges_.get()))
+                && dynamic_cast<const bit_vector_small*>(valid_edges_.get()))
         || (boss_graph_->get_state() == BOSS::State::FAST
                 && dynamic_cast<const bit_vector_stat*>(valid_edges_.get()))
         || (boss_graph_->get_state() == BOSS::State::DYN
@@ -811,8 +811,8 @@ void DBGSuccinct::switch_state(BOSS::State new_state) {
     if (valid_edges_.get()) {
         switch (new_state) {
             case BOSS::State::STAT: {
-                valid_edges_ = std::make_unique<bit_vector_stat>(
-                    valid_edges_->convert_to<bit_vector_stat>()
+                valid_edges_ = std::make_unique<bit_vector_small>(
+                    valid_edges_->convert_to<bit_vector_small>()
                 );
                 break;
             }
@@ -843,7 +843,7 @@ void DBGSuccinct::switch_state(BOSS::State new_state) {
 BOSS::State DBGSuccinct::get_state() const {
     assert(!valid_edges_.get()
                 || boss_graph_->get_state() != BOSS::State::STAT
-                || dynamic_cast<const bit_vector_stat*>(valid_edges_.get()));
+                || dynamic_cast<const bit_vector_small*>(valid_edges_.get()));
     assert(!valid_edges_.get()
                 || boss_graph_->get_state() != BOSS::State::FAST
                 || dynamic_cast<const bit_vector_stat*>(valid_edges_.get()));
@@ -868,7 +868,7 @@ void DBGSuccinct::mask_dummy_kmers(size_t num_threads, bool with_pruning) {
 
     switch (get_state()) {
         case BOSS::State::STAT: {
-            valid_edges_ = std::make_unique<bit_vector_stat>(std::move(vector_mask));
+            valid_edges_ = std::make_unique<bit_vector_small>(std::move(vector_mask));
             break;
         }
         case BOSS::State::FAST: {

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
@@ -129,25 +129,25 @@ class DBGSuccinct : public DeBruijnGraph {
      *      Representation:
      *            BOSS::last -- bit_vector_stat
      *               BOSS::W -- wavelet_tree_stat
-     *          valid_edges_ -- bit_vector_small
+     *           valid_edges -- bit_vector_small
      *
      *  SMALL: is the smallest, useful for storage or when RAM is limited
      *      Representation:
      *            BOSS::last -- bit_vector_small
      *               BOSS::W -- wavelet_tree_small
-     *          valid_edges_ -- bit_vector_small
+     *           valid_edges -- bit_vector_small
      *
      *  FAST: is the fastest but large
      *      Representation:
      *            BOSS::last -- bit_vector_stat
      *               BOSS::W -- wavelet_tree_fast
-     *          valid_edges_ -- bit_vector_stat
+     *           valid_edges -- bit_vector_stat
      *
      *  DYN: is a dynamic representation supporting insert and delete
      *      Representation:
      *            BOSS::last -- bit_vector_dyn
      *               BOSS::W -- wavelet_tree_dyn
-     *          valid_edges_ -- bit_vector_dyn
+     *           valid_edges -- bit_vector_dyn
      */
     virtual void switch_state(boss::BOSS::State new_state) final;
     virtual boss::BOSS::State get_state() const final;

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
@@ -125,29 +125,29 @@ class DBGSuccinct : public DeBruijnGraph {
 
     /*
      * Available representations:
-     *    STAT: provides the best space/time trade-off
-     *         Representation:
-     *             last -- bit_vector_stat
-     *                W -- wavelet_tree_stat
-     *     valid_edges_ -- bit_vector_small
+     *  STAT: provides the best space/time trade-off
+     *      Representation:
+     *            BOSS::last -- bit_vector_stat
+     *               BOSS::W -- wavelet_tree_stat
+     *          valid_edges_ -- bit_vector_small
      *
-     *    SMALL: is the smallest, useful for storage or when RAM is limited
-     *         Representation:
-     *             last -- bit_vector_small
-     *                W -- wavelet_tree_small
-     *     valid_edges_ -- bit_vector_small
+     *  SMALL: is the smallest, useful for storage or when RAM is limited
+     *      Representation:
+     *            BOSS::last -- bit_vector_small
+     *               BOSS::W -- wavelet_tree_small
+     *          valid_edges_ -- bit_vector_small
      *
-     *    FAST: is the fastest but large
-     *         Representation:
-     *             last -- bit_vector_stat
-     *                W -- wavelet_tree_fast
-     *     valid_edges_ -- bit_vector_stat
+     *  FAST: is the fastest but large
+     *      Representation:
+     *            BOSS::last -- bit_vector_stat
+     *               BOSS::W -- wavelet_tree_fast
+     *          valid_edges_ -- bit_vector_stat
      *
-     *    DYN: is a dynamic representation supporting insert and delete
-     *         Representation:
-     *             last -- bit_vector_dyn
-     *                W -- wavelet_tree_dyn
-     *     valid_edges_ -- bit_vector_dyn
+     *  DYN: is a dynamic representation supporting insert and delete
+     *      Representation:
+     *            BOSS::last -- bit_vector_dyn
+     *               BOSS::W -- wavelet_tree_dyn
+     *          valid_edges_ -- bit_vector_dyn
      */
     virtual void switch_state(boss::BOSS::State new_state) final;
     virtual boss::BOSS::State get_state() const final;

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
@@ -123,6 +123,32 @@ class DBGSuccinct : public DeBruijnGraph {
     virtual std::string file_extension() const override final { return kExtension; }
     std::string bloom_filter_file_extension() const { return kBloomFilterExtension; }
 
+    /*
+     * Available representations:
+     *    STAT: provides the best space/time trade-off
+     *         Representation:
+     *             last -- bit_vector_stat
+     *                W -- wavelet_tree_stat
+     *     valid_edges_ -- bit_vector_small
+     *
+     *    SMALL: is the smallest, useful for storage or when RAM is limited
+     *         Representation:
+     *             last -- bit_vector_small
+     *                W -- wavelet_tree_small
+     *     valid_edges_ -- bit_vector_small
+     *
+     *    FAST: is the fastest but large
+     *         Representation:
+     *             last -- bit_vector_stat
+     *                W -- wavelet_tree_fast
+     *     valid_edges_ -- bit_vector_stat
+     *
+     *    DYN: is a dynamic representation supporting insert and delete
+     *         Representation:
+     *             last -- bit_vector_dyn
+     *                W -- wavelet_tree_dyn
+     *     valid_edges_ -- bit_vector_dyn
+     */
     virtual void switch_state(boss::BOSS::State new_state) final;
     virtual boss::BOSS::State get_state() const final;
 

--- a/metagraph/tests/graph/succinct/test_boss.cpp
+++ b/metagraph/tests/graph/succinct/test_boss.cpp
@@ -75,11 +75,11 @@ void test_graph(BOSS *graph, const std::string &last,
                              const std::string &F) {
     test_graph(graph, last, W, F, BOSS::State::DYN);
     test_graph(graph, last, W, F, BOSS::State::DYN);
-    test_graph(graph, last, W, F, BOSS::State::STAT);
-    test_graph(graph, last, W, F, BOSS::State::STAT);
+    test_graph(graph, last, W, F, BOSS::State::COMPR);
+    test_graph(graph, last, W, F, BOSS::State::COMPR);
     test_graph(graph, last, W, F, BOSS::State::SMALL);
     test_graph(graph, last, W, F, BOSS::State::SMALL);
-    test_graph(graph, last, W, F, BOSS::State::STAT);
+    test_graph(graph, last, W, F, BOSS::State::COMPR);
     test_graph(graph, last, W, F, BOSS::State::DYN);
     test_graph(graph, last, W, F, BOSS::State::SMALL);
     test_graph(graph, last, W, F, BOSS::State::DYN);
@@ -1248,7 +1248,7 @@ TEST(BOSS, CallPaths) {
                 BOSS graph(k);
                 graph.add_sequence("AAACACTAG", true);
                 graph.add_sequence("AACGACATG", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1265,7 +1265,7 @@ TEST(BOSS, CallPaths) {
                 graph.add_sequence("AGACACTGA", true);
                 graph.add_sequence("GACTACGTA", true);
                 graph.add_sequence("ACTAACGTA", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1282,7 +1282,7 @@ TEST(BOSS, CallPaths) {
                 graph.add_sequence("AGACACAGT", true);
                 graph.add_sequence("GACTTGCAG", true);
                 graph.add_sequence("ACTAGTCAG", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1298,7 +1298,7 @@ TEST(BOSS, CallPaths) {
                 BOSS graph(k);
                 graph.add_sequence("AAACTCGTAGC", true);
                 graph.add_sequence("AAATGCGTAGC", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1314,7 +1314,7 @@ TEST(BOSS, CallPaths) {
                 BOSS graph(k);
                 graph.add_sequence("AAACT", false);
                 graph.add_sequence("AAATG", false);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1338,7 +1338,7 @@ TEST(BOSS, CallUnitigs) {
                 BOSS graph(k);
                 graph.add_sequence("AAACACTAG", true);
                 graph.add_sequence("AACGACATG", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1355,7 +1355,7 @@ TEST(BOSS, CallUnitigs) {
                 graph.add_sequence("AGACACTGA", true);
                 graph.add_sequence("GACTACGTA", true);
                 graph.add_sequence("ACTAACGTA", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1372,7 +1372,7 @@ TEST(BOSS, CallUnitigs) {
                 graph.add_sequence("AGACACAGT", true);
                 graph.add_sequence("GACTTGCAG", true);
                 graph.add_sequence("ACTAGTCAG", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1388,7 +1388,7 @@ TEST(BOSS, CallUnitigs) {
                 BOSS graph(k);
                 graph.add_sequence("AAACTCGTAGC", true);
                 graph.add_sequence("AAATGCGTAGC", true);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 
@@ -1404,7 +1404,7 @@ TEST(BOSS, CallUnitigs) {
                 BOSS graph(k);
                 graph.add_sequence("AAACT", false);
                 graph.add_sequence("AAATG", false);
-                graph.switch_state(BOSS::State::STAT);
+                graph.switch_state(BOSS::State::SMALL);
 
                 BOSS reconstructed(k);
 

--- a/metagraph/tests/graph/succinct/test_boss.cpp
+++ b/metagraph/tests/graph/succinct/test_boss.cpp
@@ -75,11 +75,11 @@ void test_graph(BOSS *graph, const std::string &last,
                              const std::string &F) {
     test_graph(graph, last, W, F, BOSS::State::DYN);
     test_graph(graph, last, W, F, BOSS::State::DYN);
-    test_graph(graph, last, W, F, BOSS::State::COMPR);
-    test_graph(graph, last, W, F, BOSS::State::COMPR);
+    test_graph(graph, last, W, F, BOSS::State::STAT);
+    test_graph(graph, last, W, F, BOSS::State::STAT);
     test_graph(graph, last, W, F, BOSS::State::SMALL);
     test_graph(graph, last, W, F, BOSS::State::SMALL);
-    test_graph(graph, last, W, F, BOSS::State::COMPR);
+    test_graph(graph, last, W, F, BOSS::State::STAT);
     test_graph(graph, last, W, F, BOSS::State::DYN);
     test_graph(graph, last, W, F, BOSS::State::SMALL);
     test_graph(graph, last, W, F, BOSS::State::DYN);
@@ -1248,7 +1248,7 @@ TEST(BOSS, CallPaths) {
                 BOSS graph(k);
                 graph.add_sequence("AAACACTAG", true);
                 graph.add_sequence("AACGACATG", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1265,7 +1265,7 @@ TEST(BOSS, CallPaths) {
                 graph.add_sequence("AGACACTGA", true);
                 graph.add_sequence("GACTACGTA", true);
                 graph.add_sequence("ACTAACGTA", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1282,7 +1282,7 @@ TEST(BOSS, CallPaths) {
                 graph.add_sequence("AGACACAGT", true);
                 graph.add_sequence("GACTTGCAG", true);
                 graph.add_sequence("ACTAGTCAG", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1298,7 +1298,7 @@ TEST(BOSS, CallPaths) {
                 BOSS graph(k);
                 graph.add_sequence("AAACTCGTAGC", true);
                 graph.add_sequence("AAATGCGTAGC", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1314,7 +1314,7 @@ TEST(BOSS, CallPaths) {
                 BOSS graph(k);
                 graph.add_sequence("AAACT", false);
                 graph.add_sequence("AAATG", false);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1338,7 +1338,7 @@ TEST(BOSS, CallUnitigs) {
                 BOSS graph(k);
                 graph.add_sequence("AAACACTAG", true);
                 graph.add_sequence("AACGACATG", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1355,7 +1355,7 @@ TEST(BOSS, CallUnitigs) {
                 graph.add_sequence("AGACACTGA", true);
                 graph.add_sequence("GACTACGTA", true);
                 graph.add_sequence("ACTAACGTA", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1372,7 +1372,7 @@ TEST(BOSS, CallUnitigs) {
                 graph.add_sequence("AGACACAGT", true);
                 graph.add_sequence("GACTTGCAG", true);
                 graph.add_sequence("ACTAGTCAG", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1388,7 +1388,7 @@ TEST(BOSS, CallUnitigs) {
                 BOSS graph(k);
                 graph.add_sequence("AAACTCGTAGC", true);
                 graph.add_sequence("AAATGCGTAGC", true);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 
@@ -1404,7 +1404,7 @@ TEST(BOSS, CallUnitigs) {
                 BOSS graph(k);
                 graph.add_sequence("AAACT", false);
                 graph.add_sequence("AAATG", false);
-                graph.switch_state(BOSS::State::SMALL);
+                graph.switch_state(BOSS::State::STAT);
 
                 BOSS reconstructed(k);
 


### PR DESCRIPTION
old `stat` -> deprecated
new `stat` = old `small` (same format)
new `small`: a new compressed representation (usually, `sd_vector` for `last` and `wt_huff<rrr63>` for `W`)

New `small` has about 2x smaller memory footprint than `stat`