### PR TITLE
Support Multi-BRWT construction with linkage but without disk swap

### DIFF
--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
@@ -203,7 +203,38 @@ BRWT BRWTBottomUpBuilder::build(
     if (!linkage.size())
         return BRWT();
 
-    std::filesystem::path tmp_dir = utils::create_temp_dir(tmp_path, "brwt");
+    std::function<void(BinaryMatrix&& node, uint64_t id)> dump_node;
+    std::function<BRWT(uint64_t id)> get_node;
+
+    if (!tmp_path.empty()) {
+        // keep all temp nodes in |tmp_dir|
+        std::filesystem::path tmp_dir = utils::create_temp_dir(tmp_path, "brwt");
+        dump_node = [=](BinaryMatrix&& node, uint64_t id) {
+            std::ofstream out(tmp_dir/std::to_string(id), std::ios::binary);
+            node.serialize(out);
+            node = BRWT();
+        };
+        get_node = [=](uint64_t id) {
+            BRWT node;
+            auto filename = tmp_dir/std::to_string(id);
+            std::ifstream in(filename, std::ios::binary);
+            if (!node.load(in)) {
+                logger->error("Can't load temp BRWT node {}", filename);
+                exit(1);
+            }
+            std::filesystem::remove(filename);
+            return node;
+        };
+    } else {
+        // keep all temp nodes in memory
+        auto temp_nodes = std::make_shared<std::vector<BRWT>>(linkage.size());
+        dump_node = [=](BinaryMatrix&& node, uint64_t id) {
+            temp_nodes->at(id) = dynamic_cast<BRWT&&>(node);
+        };
+        get_node = [=](uint64_t id) {
+            return std::move(temp_nodes->at(id));
+        };
+    }
 
     std::vector<bool> done(linkage.size(), false);
     std::mutex done_mu;
@@ -223,8 +254,7 @@ BRWT BRWTBottomUpBuilder::build(
         node.nonzero_rows_ = std::make_unique<bit_vector_smart>(
                                 column->convert_to<bit_vector_smart>());
 
-        std::ofstream out(tmp_dir/std::to_string(i), std::ios::binary);
-        node.serialize(out);
+        dump_node(std::move(node), i);
 
         std::unique_lock<std::mutex> lock(done_mu);
         done[i] = true;
@@ -274,17 +304,11 @@ BRWT BRWTBottomUpBuilder::build(
         std::vector<BRWT> children(linkage[i].size());
         for (size_t r = 0; r < children.size(); ++r) {
             size_t j = linkage[i][r];
-            std::ifstream in;
             {
                 std::unique_lock<std::mutex> lock(done_mu);
                 done_cond.wait(lock, [&]() { return done[j]; });
-                in.open(tmp_dir/std::to_string(j), std::ios::binary);
             }
-            if (!children[r].load(in)) {
-                logger->error("Can't load internal node {}",
-                              tmp_dir/std::to_string(j));
-                exit(1);
-            }
+            children[r] = get_node(j);
         }
 
         // merge submatrices
@@ -301,10 +325,7 @@ BRWT BRWTBottomUpBuilder::build(
         // replace the child nodes with dummy empty matrices
         std::swap(child_nodes, node.child_nodes_);
         // serialize the node without its child nodes
-        {
-            std::ofstream out(tmp_dir/std::to_string(i), std::ios::binary);
-            node.serialize(out);
-        }
+        dump_node(std::move(node), i);
 
         // compute column assignments for the parent
         for (size_t j : linkage[i]) {
@@ -329,10 +350,7 @@ BRWT BRWTBottomUpBuilder::build(
         done_cond.notify_all();
 
         for (size_t r = 0; r < children.size(); ++r) {
-            size_t j = linkage[i][r];
-            std::filesystem::remove(tmp_dir/std::to_string(j));
-            std::ofstream out(tmp_dir/("index_" + std::to_string(j)), std::ios::binary);
-            child_nodes[r]->serialize(out);
+            dump_node(std::move(*child_nodes[r]), linkage[i][r]);
         }
 
         ++progress_bar;
@@ -352,28 +370,12 @@ BRWT BRWTBottomUpBuilder::build(
     std::vector<std::unique_ptr<BRWT>> nodes(linkage.size());
 
     #pragma omp parallel for num_threads(num_threads) schedule(dynamic)
-    for (size_t i = 0; i < linkage.size() - 1; ++i) {
-        nodes[i] = std::make_unique<BRWT>();
-        std::filesystem::path filename = tmp_dir/("index_" + std::to_string(i));
-        std::ifstream in(filename, std::ios::binary);
-        if (!nodes[i]->load(in)) {
-            logger->error("Can't load node {} from {}", i, filename);
-            exit(1);
-        }
-        std::filesystem::remove(filename);
+    for (size_t i = 0; i < linkage.size(); ++i) {
+        nodes[i] = std::make_unique<BRWT>(get_node(i));
     }
-
-    nodes.back() = std::make_unique<BRWT>();
 
     // make the root node in Multi-BRWT
     BRWT &root = *nodes.back();
-    std::filesystem::path filename = tmp_dir/std::to_string(linkage.size() - 1);
-    std::ifstream in(filename, std::ios::binary);
-    if (!root.load(in)) {
-        logger->error("Can't load the root from {}", filename);
-        exit(1);
-    }
-    std::filesystem::remove(filename);
 
     // compress the index vector
     root.nonzero_rows_ = std::make_unique<bit_vector_smallrank>(

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
@@ -209,12 +209,12 @@ BRWT BRWTBottomUpBuilder::build(
     if (!tmp_path.empty()) {
         // keep all temp nodes in |tmp_dir|
         std::filesystem::path tmp_dir = utils::create_temp_dir(tmp_path, "brwt");
-        dump_node = [=](BinaryMatrix&& node, uint64_t id) {
+        dump_node = [tmp_dir](BinaryMatrix&& node, uint64_t id) {
             std::ofstream out(tmp_dir/std::to_string(id), std::ios::binary);
             node.serialize(out);
             node = BRWT();
         };
-        get_node = [=](uint64_t id) {
+        get_node = [tmp_dir](uint64_t id) {
             BRWT node;
             auto filename = tmp_dir/std::to_string(id);
             std::ifstream in(filename, std::ios::binary);
@@ -228,10 +228,10 @@ BRWT BRWTBottomUpBuilder::build(
     } else {
         // keep all temp nodes in memory
         auto temp_nodes = std::make_shared<std::vector<BRWT>>(linkage.size());
-        dump_node = [=](BinaryMatrix&& node, uint64_t id) {
+        dump_node = [temp_nodes](BinaryMatrix&& node, uint64_t id) {
             temp_nodes->at(id) = dynamic_cast<BRWT&&>(node);
         };
-        get_node = [=](uint64_t id) {
+        get_node = [temp_nodes](uint64_t id) {
             return std::move(temp_nodes->at(id));
         };
     }

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -60,6 +60,7 @@ Config::Config(int argc, char *argv[]) {
         identity = TRANSFORM;
     } else if (!strcmp(argv[1], "transform_anno")) {
         identity = TRANSFORM_ANNOTATION;
+        tmp_dir = "OUTFBASE_TEMP_DIR";
     } else if (!strcmp(argv[1], "assemble")) {
         identity = ASSEMBLE;
     } else if (!strcmp(argv[1], "relax_brwt")) {
@@ -428,6 +429,9 @@ Config::Config(int argc, char *argv[]) {
         print_usage_and_exit = true;
     }
     #endif
+
+    if (tmp_dir == "OUTFBASE_TEMP_DIR")
+        tmp_dir = std::filesystem::path(outfbase).remove_filename();
 
     if (identity != CONCATENATE
             && identity != STATS
@@ -1027,7 +1031,7 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\t   --subsample [INT] \tnumber of rows subsampled for distance estimation in column clustering [1000000]\n");
             fprintf(stderr, "\t   --fast \t\ttransform annotation in memory without streaming [off]\n");
             fprintf(stderr, "\t   --dump-text-anno \tdump the columns of the annotator as separate text files [off]\n");
-            fprintf(stderr, "\t   --disk-swap [STR] \tdirectory for temporary files []\n");
+            fprintf(stderr, "\t   --disk-swap [STR] \tdirectory for temporary files [OUT_BASEDIR]\n");
             fprintf(stderr, "\t-p --parallel [INT] \tuse multiple threads for computation [1]\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --parallel-nodes [INT] \tnumber of nodes processed in parallel in brwt tree [n_threads]\n");

--- a/metagraph/src/cli/transform_annotation.cpp
+++ b/metagraph/src/cli/transform_annotation.cpp
@@ -423,9 +423,7 @@ int transform_annotation(Config *config) {
                         files, config->infbase,
                         config->parallel_nodes,
                         get_num_threads(),
-                        config->tmp_dir.empty()
-                            ? std::filesystem::path(config->outfbase).remove_filename()
-                            : config->tmp_dir)
+                        config->tmp_dir)
                     : (config->greedy_brwt
                         ? convert_to_greedy_BRWT(
                             std::move(*annotator),
@@ -514,12 +512,9 @@ int transform_annotation(Config *config) {
                                                      config->parallel_nodes,
                                                      get_num_threads());
                 } else {
-                    std::string tmp_dir = config->tmp_dir.empty()
-                            ? std::filesystem::path(config->outfbase).remove_filename()
-                            : config->tmp_dir;
                     brwt_annotator = convert_to_BRWT<RowDiffBRWTAnnotator>(
                             files, config->infbase, config->parallel_nodes,
-                            get_num_threads(), tmp_dir);
+                            get_num_threads(), config->tmp_dir);
                 }
                 logger->trace("Annotation converted in {} sec", timer.elapsed());
 


### PR DESCRIPTION
Might be useful for cases where the number of columns is too large (10M or more) but the total size is quite small, like RefSeq.

1. By default create a temp dir for the temp files in the base dir of the output file.
2. If `--disk-swap ""` is passed, keep all temp files in memory without using disk.