### PR TITLE
Generate the GFA 'P' lines in align.cpp

### DIFF
--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -246,10 +246,7 @@ std::string sequence_to_gfa_path(const std::string &seq,
                                  const std::shared_ptr<DeBruijnGraph> &graph,
                                  const tsl::ordered_set<uint64_t> &is_unitig_end_node,
                                  const Config *config) {
-    std::vector<uint64_t> path_nodes;
-    graph->map_to_nodes_sequentially(seq, [&](uint64_t node) {
-        path_nodes.push_back(node);
-    });
+    auto path_nodes = map_sequence_to_nodes(*graph, seq);
 
     std::string nodes_on_path;
     std::string cigars_on_path;

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -288,11 +288,11 @@ void gfa_map_files(const Config *config,
     tsl::ordered_set<uint64_t> is_unitig_end_node;
 
     graph->call_unitigs(
-        [&](const auto &unitig, const auto &path) {
-            (void)unitig;
+        [&](const auto &, const auto &path) {
             is_unitig_end_node.insert(path.back());
         }
     );
+    
     // Open gfa_file in append mode.
     std::ofstream gfa_file(utils::remove_suffix(config->gfa_mapping_path, ".gfa") + ".gfa",
                            std::ios_base::app);

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -248,7 +248,7 @@ std::string sequence_to_gfa_path(const std::string &seq,
                                  const Config *config) {
     std::vector<uint64_t> path_nodes;
     graph->map_to_nodes_sequentially(seq, [&](uint64_t node) {
-      path_nodes.push_back(node);
+        path_nodes.push_back(node);
     });
 
     std::string nodes_on_path;

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -267,10 +267,9 @@ std::string sequence_to_gfa_path(const std::string &seq,
     // this unitig is not completely covered by the query sequence.
     while(config->output_compacted && !is_unitig_end_node.count(last_node_to_print)) {
         uint64_t unique_next_node;
-        graph -> adjacent_outgoing_nodes(
-                last_node_to_print, [&](uint64_t node) {
-                  unique_next_node = node;
-                }
+        graph->adjacent_outgoing_nodes(
+            last_node_to_print,
+            [&](uint64_t node) { unique_next_node = node; }
         );
         last_node_to_print = unique_next_node;
     }

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -296,12 +296,9 @@ void gfa_map_files(const Config *config,
             is_unitig_end_node.insert(path.back());
         }
     );
-    std::ofstream gfa_file;
-    //  Open gfa_file in append mode.
-    gfa_file.open(
-        utils::remove_suffix(config->gfa_mapping_path, ".gfa") + ".gfa",
-        std::ios_base::app
-    );
+    // Open gfa_file in append mode.
+    std::ofstream gfa_file(utils::remove_suffix(config->gfa_mapping_path, ".gfa") + ".gfa",
+                           std::ios_base::app);
     std::mutex print_mutex;
     for (size_t i = 0; i < files.size(); ++i) {
         std::string file = files[i];

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -265,7 +265,7 @@ std::string sequence_to_gfa_path(const std::string &seq,
     uint64_t last_node_to_print = path_nodes.back();
     // We need to print the id of the last unitig even in the case that
     // this unitig is not completely covered by the query sequence.
-    while(config->output_compacted && !is_unitig_end_node.count(last_node_to_print)) {
+    while (config->output_compacted && !is_unitig_end_node.count(last_node_to_print)) {
         uint64_t unique_next_node;
         graph->adjacent_outgoing_nodes(
             last_node_to_print,

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -290,7 +290,8 @@ void gfa_map_files(const Config *config,
     graph->call_unitigs(
         [&](const auto &, const auto &path) {
             is_unitig_end_node.insert(path.back());
-        }
+        },
+        get_num_threads()
     );
     
     // Open gfa_file in append mode.

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -297,8 +297,7 @@ void gfa_map_files(const Config *config,
     std::ofstream gfa_file(utils::remove_suffix(config->gfa_mapping_path, ".gfa") + ".gfa",
                            std::ios_base::app);
     std::mutex print_mutex;
-    for (size_t i = 0; i < files.size(); ++i) {
-        const std::string &file = files[i];
+    for (const std::string &file : files) {
         logger->trace("Loading sequences from FASTA file '{}' to append gfa paths.", file);
 
         std::vector<string> seq_queries;

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -301,7 +301,7 @@ void gfa_map_files(const Config *config,
                            std::ios_base::app);
     std::mutex print_mutex;
     for (size_t i = 0; i < files.size(); ++i) {
-        std::string file = files[i];
+        const std::string &file = files[i];
         logger->trace("Loading sequences from FASTA file '{}' to append gfa paths.", file);
 
         std::vector<string> seq_queries;

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -275,7 +275,7 @@ std::string sequence_to_gfa_path(const std::string &seq,
     }
     nodes_on_path += fmt::format("{}+,", last_node_to_print);
 
-    //   Remove right trailing comma.
+    // Remove right trailing comma.
     nodes_on_path.pop_back();
     if (cigars_on_path.size()) {
         cigars_on_path.pop_back();

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -253,7 +253,7 @@ std::string sequence_to_gfa_path(const std::string &seq,
 
     std::string nodes_on_path;
     std::string cigars_on_path;
-    size_t overlap = graph->get_k() - 1;
+    const size_t overlap = graph->get_k() - 1;
 
     for (size_t i = 0; i < path_nodes.size() - 1; ++i) {
         if (config->output_compacted && !is_unitig_end_node.count(path_nodes[i])) {

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -302,10 +302,7 @@ void gfa_map_files(const Config *config,
     std::mutex print_mutex;
     for (size_t i = 0; i < files.size(); ++i) {
         std::string file = files[i];
-        logger->trace(
-            "Loading sequences from FASTA file '{}' to append gfa paths.",
-            file
-        );
+        logger->trace("Loading sequences from FASTA file '{}' to append gfa paths.", file);
 
         std::vector<string> seq_queries;
         seq_io::FastaParser fasta_parser(file, false);

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -361,6 +361,7 @@ int align_to_graph(Config *config) {
     Timer timer;
     ThreadPool thread_pool(get_num_threads());
     std::mutex print_mutex;
+
     if (config->map_sequences) {
         if (!config->alignment_length) {
             config->alignment_length = graph->get_k();

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -227,6 +227,8 @@ Config::Config(int argc, char *argv[]) {
             max_hull_forks = atoi(get_value(i++));
         } else if (!strcmp(argv[i], "--align-max-ram")) {
             alignment_max_ram = std::stof(get_value(i++));
+        } else if (!strcmp(argv[i], "--gfa-mapping-path")) {
+            gfa_mapping_path = std::string(get_value(i++));
         } else if (!strcmp(argv[i], "-f") || !strcmp(argv[i], "--frequency")) {
             frequency = atoi(get_value(i++));
         } else if (!strcmp(argv[i], "-d") || !strcmp(argv[i], "--distance")) {
@@ -841,6 +843,8 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --map \t\t\tmap k-mers to graph exactly instead of aligning.\n");
             fprintf(stderr, "\t         \t\t\t\tTurned on if --count-kmers or --query-presence are set [off]\n");
+            fprintf(stderr, "\t   --gfa-mapping-path [STR] \tpath to a gfa file where to append the mappings as 'P' lines []\n");
+            fprintf(stderr, "\t   --compacted \t\t\tdump the GFA's 'P' lines in a compacted mode [off]\n");
             fprintf(stderr, "\t-k --kmer-length [INT]\t\tlength of mapped k-mers (at most graph's k) [k]\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --count-kmers \t\tfor each sequence, report the number of k-mers discovered in graph [off]\n");

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -843,8 +843,8 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --map \t\t\tmap k-mers to graph exactly instead of aligning.\n");
             fprintf(stderr, "\t         \t\t\t\tTurned on if --count-kmers or --query-presence are set [off]\n");
-            fprintf(stderr, "\t   --gfa-mapping-path [STR] \tpath to a gfa file where to append the mappings as 'P' lines []\n");
-            fprintf(stderr, "\t   --compacted \t\t\tdump the GFA's 'P' lines in a compacted mode [off]\n");
+            fprintf(stderr, "\t   --gfa-mapping-path [STR]\tpath to a gfa file where to append the mappings as 'P' lines []\n");
+            fprintf(stderr, "\t   --compacted\t\t\tdump the GFA's 'P' lines in a compacted mode [off]\n");
             fprintf(stderr, "\t-k --kmer-length [INT]\t\tlength of mapped k-mers (at most graph's k) [k]\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --count-kmers \t\tfor each sequence, report the number of k-mers discovered in graph [off]\n");

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -143,6 +143,7 @@ class Config {
     std::string host_address;
     uint32_t max_path_length = 50;
     std::string anchors;
+    std::string gfa_mapping_path;
 
     std::filesystem::path tmp_dir;
 


### PR DESCRIPTION
Description:
The GFA format contains some P type lines which are defining paths in the GFA graph. These paths are used by some gfa visualisation tools for highlighting the corresponding edges of the graph.

GFA standard: http://gfa-spec.github.io/GFA-spec/GFA1.html
GFA visualisation tool: https://rrwick.github.io/Bandage/

Testing workflow:

```
$ cat tiny_query.fa    
>something|
AGATGTGCTGGAAGAGTACGT
>something2|
TGATGTGCTGAAAGAGTACGA
>first|
TGATGTTTGATGTTTGATGTT

$ ./metagraph build -k 10 -o test_rr/tiny_bld tiny_query.fa

$ ./metagraph assemble test_rr/tiny_bld.dbg -o test_rr/tiny_bld.gfa --unitigs --to-gfa -i tiny_query.fa --compacted 

```
tiny_bld.gfa -> https://ideone.com/SwRPi2

```
$ ./metagraph align -i test_rr/tiny_bld.gfa tiny_query.fa --compacted 
$ ./metagraph align -i test_rr/tiny_bld.dbg tiny_query.fa --gfa-mapping-path test_rr/tiny_bld.gfa 
$ ./metagraph align -i test_rr/tiny_bld.dbg tiny_query.fa --gfa-mapping-path test_rr/tiny_bld.gfa --compacted
```
tiny_bld.gfa -> https://ideone.com/T0DR3M