### PR TITLE
don't write row reduction vectors in anchor optimization stage

### DIFF
--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1180,7 +1180,7 @@ void convert_to_row_diff(const std::vector<std::string> &files,
 
         convert_batch_to_row_diff(
                 graph_fname, graph_fname + kRowDiffAnchorExt + (optimize ? "" : ".unopt"),
-                file_batch, dest_dir, row_reduction_fname, ROW_DIFF_BUFFER_SIZE);
+                file_batch, dest_dir, row_reduction_fname, ROW_DIFF_BUFFER_SIZE, !optimize);
 
         logger->trace("Batch transformed in {} sec", timer.elapsed());
     }

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -342,22 +342,24 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
     }
 
     ThreadPool async_writer(1, 1);
-
+    sdsl::int_vector_buffer row_reduction;
     const bool new_reduction_vector = !std::filesystem::exists(row_reduction_fname);
-    if (new_reduction_vector) {
-        // create an empty vector
-        sdsl::int_vector_buffer(row_reduction_fname,
-                                std::ios::out, 1024 * 1024, ROW_REDUCTION_WIDTH);
-    }
+    if (compute_row_reduction) {
+        if (new_reduction_vector) {
+            // create an empty vector
+            sdsl::int_vector_buffer(row_reduction_fname,
+                                    std::ios::out, 1024 * 1024, ROW_REDUCTION_WIDTH);
+        }
 
-    sdsl::int_vector_buffer row_reduction(row_reduction_fname,
-                                          std::ios::in | std::ios::out, 1024 * 1024);
+        row_reduction = sdsl::int_vector_buffer(row_reduction_fname,
+                                                std::ios::in | std::ios::out, 1024 * 1024);
 
-    if (!new_reduction_vector && row_reduction.size() != anchor.size()) {
-        logger->error("Incompatible sizes of '{}': {} and '{}': {}",
-                      row_reduction_fname, row_reduction.size(),
-                      anchors_fname, anchor.size());
-        exit(1);
+        if (!new_reduction_vector && row_reduction.size() != anchor.size()) {
+            logger->error("Incompatible sizes of '{}': {} and '{}': {}",
+                          row_reduction_fname, row_reduction.size(),
+                          anchors_fname, anchor.size());
+            exit(1);
+        }
     }
 
     // total number of set bits in the original rows

--- a/metagraph/src/annotation/row_diff_builder.hpp
+++ b/metagraph/src/annotation/row_diff_builder.hpp
@@ -22,7 +22,8 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
                                const std::vector<std::string> &source_files,
                                const std::filesystem::path &dest_dir,
                                const std::string &row_reduction_fname,
-                               uint64_t buf_size);
+                               uint64_t buf_size,
+                               bool compute_row_reduction = true);
 
 void optimize_anchors_in_row_diff(const std::string &graph_fname,
                                   const std::filesystem::path &dest_dir,


### PR DESCRIPTION
saves disk space and time by not computing and not writing row reduction vectors, which are not needed anyway if the first stage was fully finished