### PR TITLE
dump chunks in parallel

### DIFF
--- a/metagraph/src/common/elias_fano.cpp
+++ b/metagraph/src/common/elias_fano.cpp
@@ -23,14 +23,16 @@ void concat(const std::vector<std::string> &files, const std::string &result) {
         suffixes.push_back(".count");
 
     for (const std::string &suffix : suffixes) {
-        std::string concat_command = "cat ";
-        for (uint32_t i = 1; i < files.size(); ++i) {
-            concat_command += files[i] + suffix + " ";
-        }
-        concat_command += " >> " + files[0] + suffix;
+        if (files.size() > 1) {
+            std::string concat_command = "cat ";
+            for (uint32_t i = 1; i < files.size(); ++i) {
+                concat_command += files[i] + suffix + " ";
+            }
+            concat_command += " >> " + files[0] + suffix;
 
-        if (std::system(concat_command.c_str()))
-            throw std::runtime_error("Error while cat-ing files: " + concat_command);
+            if (std::system(concat_command.c_str()))
+                throw std::runtime_error("Error while cat-ing files: " + concat_command);
+        }
 
         std::filesystem::rename(files[0] + suffix, result + suffix);
         for (const std::string &f : files) {

--- a/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
+++ b/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
@@ -120,13 +120,14 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
     std::vector<std::string> block_names(num_blocks);
     #pragma omp parallel for num_threads(num_blocks) schedule(static, 1)
     for (size_t t = 0; t < num_blocks; ++t) {
-        block_names[t] = file_name + "_" + std::to_string(t);
+        block_names[t] = file_name + "_block_" + std::to_string(t);
         EliasFanoEncoder<T> encoder(data_.size(),
                                     utils::get_first(data_.front()),
                                     utils::get_first(data_.back()),
                                     block_names[t]);
-        size_t block_size = (data_.size() + num_blocks - 1) / num_blocks;
-        for (size_t i = t * block_size; i < std::min(data_.size(), (t + 1) * block_size); ++i) {
+        const size_t block_size = (data_.size() + num_blocks - 1) / num_blocks;
+        const size_t block_end = std::min(data_.size(), (t + 1) * block_size);
+        for (size_t i = t * block_size; i < block_end; ++i) {
             encoder.add(data_[i]);
         }
         uint64_t written = encoder.finish();

--- a/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
+++ b/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
@@ -22,8 +22,9 @@ SortedSetDiskBase<T>::SortedSetDiskBase(size_t num_threads,
       max_disk_space_bytes_(max_disk_space_bytes),
       merge_count_(merge_count),
       chunk_file_prefix_(tmp_dir/"chunk_"),
+      num_blocks_(std::max(num_threads_, (size_t)1)),
       merge_queue_(std::min(reserved_num_elements, QUEUE_EL_COUNT)),
-      async_merge_l1_(merge_count_ == 0 ? 0 : 3, 100) {
+      async_merge_l1_(merge_count_ == 0 ? 0 : num_threads_, 100) {
     if (reserved_num_elements == 0) {
         logger->error("SortedSetDisk buffer cannot have size 0");
         std::exit(EXIT_FAILURE);
@@ -116,13 +117,12 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
 
     std::string file_name = chunk_file_prefix_ + std::to_string(chunk_count_);
 
-    const size_t num_blocks = std::max(num_threads_, (size_t)1);
-    std::vector<std::string> block_names(num_blocks);
-    #pragma omp parallel for num_threads(num_blocks) schedule(static, 1)
-    for (size_t t = 0; t < num_blocks; ++t) {
-        block_names[t] = file_name + "_block_" + std::to_string(t);
-        EliasFanoEncoderBuffered<T> encoder(block_names[t], 1000);
-        const size_t block_size = (data_.size() + num_blocks - 1) / num_blocks;
+    // dump chunk in parallel to num_blocks_ blocks
+    #pragma omp parallel for num_threads(num_blocks_) schedule(static, 1)
+    for (size_t t = 0; t < num_blocks_; ++t) {
+        std::string block_name = file_name + "_block_" + std::to_string(t);
+        EliasFanoEncoderBuffered<T> encoder(block_name, 1000);
+        const size_t block_size = (data_.size() + num_blocks_ - 1) / num_blocks_;
         const size_t block_end = std::min(data_.size(), (t + 1) * block_size);
         for (size_t i = t * block_size; i < block_end; ++i) {
             encoder.add(data_[i]);
@@ -132,7 +132,6 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
         #pragma omp critical
         total_chunk_size_bytes_ += written;
     }
-    concat(block_names, file_name);
 
     chunk_count_++;
 
@@ -156,7 +155,8 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
         l1_chunk_count_ = 0;
     } else if (merge_count_ > 1 && chunk_count_ % merge_count_ == 0) {
         async_merge_l1_.enqueue(merge_l1, chunk_file_prefix_, chunk_count_ - merge_count_,
-                                chunk_count_, &l1_chunk_count_, &total_chunk_size_bytes_);
+                                chunk_count_, &l1_chunk_count_, &total_chunk_size_bytes_,
+                                num_blocks_);
     }
 }
 
@@ -197,19 +197,37 @@ void SortedSetDiskBase<T>::try_reserve(size_t size, size_t min_size) {
 }
 
 template <typename T>
+std::string SortedSetDiskBase<T>::merge_blocks(const std::string &chunk_file_prefix,
+                                               uint32_t chunk,
+                                               size_t num_blocks) {
+    std::string chunk_name = chunk_file_prefix + std::to_string(chunk);
+    if (!std::filesystem::exists(chunk_name + "_block_" + std::to_string(0)))
+        return chunk_name; // already merged
+
+    std::vector<std::string> block_names(num_blocks);
+    for (size_t t = 0; t < num_blocks; ++t) {
+        block_names[t] = chunk_name + "_block_" + std::to_string(t);
+    }
+    concat(block_names, chunk_name);
+    return chunk_name;
+}
+
+template <typename T>
 void SortedSetDiskBase<T>::merge_l1(const std::string &chunk_file_prefix,
                                     uint32_t chunk_begin,
                                     uint32_t chunk_end,
                                     std::atomic<uint32_t> *l1_chunk_count,
-                                    std::atomic<size_t> *total_size) {
+                                    std::atomic<size_t> *total_size,
+                                    size_t blocks_per_chunk) {
     assert(chunk_begin < chunk_end);
     const std::string &merged_l1_file_name
             = merged_l1_name(chunk_file_prefix, chunk_begin / (chunk_end - chunk_begin));
 
     std::vector<std::string> to_merge;
     for (uint32_t i = chunk_begin; i < chunk_end; ++i) {
-        to_merge.push_back(chunk_file_prefix + std::to_string(i));
-        *total_size -= static_cast<int64_t>(std::filesystem::file_size(to_merge.back()));
+        std::string chunk_name = merge_blocks(chunk_file_prefix, i, blocks_per_chunk);
+        to_merge.push_back(chunk_name);
+        *total_size -= static_cast<int64_t>(std::filesystem::file_size(chunk_name));
     }
     logger->trace("Starting merging chunks {}..{} into {}", chunk_begin, chunk_end - 1,
                   merged_l1_file_name);
@@ -252,7 +270,10 @@ std::vector<std::string> SortedSetDiskBase<T>::get_file_names() {
     for (size_t i = 0; i < l1_chunk_count_; ++i) {
         file_names.push_back(merged_l1_name(chunk_file_prefix_, i));
     }
+    #pragma omp parallel for num_threads(num_threads_) schedule(dynamic)
     for (size_t i = merge_count_ * l1_chunk_count_; i < chunk_count_; ++i) {
+        merge_blocks(chunk_file_prefix_, i, num_blocks_);
+        #pragma omp critical
         file_names.push_back(chunk_file_prefix_ + std::to_string(i));
     }
     std::string sorted_file_name = chunk_file_prefix_ + "sorted";

--- a/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
+++ b/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
@@ -1,6 +1,5 @@
 #include "sorted_set_disk_base.hpp"
 
-#include <omp.h>
 #include <sdsl/uint128_t.hpp>
 #include <sdsl/uint256_t.hpp>
 
@@ -117,7 +116,7 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
 
     std::string file_name = chunk_file_prefix_ + std::to_string(chunk_count_);
 
-    // dump chunk in parallel to num_blocks_ blocks
+    // split chunk into |num_blocks_| blocks and dump to disk in parallel
     #pragma omp parallel for num_threads(num_blocks_) schedule(static, 1)
     for (size_t t = 0; t < num_blocks_; ++t) {
         std::string block_name = file_name + "_block_" + std::to_string(t);

--- a/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
+++ b/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
@@ -126,10 +126,7 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
         for (size_t i = t * block_size; i < block_end; ++i) {
             encoder.add(data_[i]);
         }
-        uint64_t written = encoder.finish();
-
-        #pragma omp critical
-        total_chunk_size_bytes_ += written;
+        total_chunk_size_bytes_ += encoder.finish();
     }
 
     chunk_count_++;

--- a/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
+++ b/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
@@ -121,14 +121,15 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
     #pragma omp parallel for num_threads(num_blocks) schedule(static, 1)
     for (size_t t = 0; t < num_blocks; ++t) {
         block_names[t] = file_name + "_block_" + std::to_string(t);
-        EliasFanoEncoder<T> encoder(data_.size(),
-                                    utils::get_first(data_.front()),
-                                    utils::get_first(data_.back()),
-                                    block_names[t]);
         const size_t block_size = (data_.size() + num_blocks - 1) / num_blocks;
-        const size_t block_end = std::min(data_.size(), (t + 1) * block_size);
-        for (size_t i = t * block_size; i < block_end; ++i) {
-            encoder.add(data_[i]);
+        auto *it = data_.data() + t * block_size;
+        auto *end = data_.data() + std::min(data_.size(), (t + 1) * block_size);
+        EliasFanoEncoder<T> encoder(data_.size(),
+                                    utils::get_first(*it),
+                                    utils::get_first(*(end - 1)),
+                                    block_names[t]);
+        for ( ; it != end; ++it) {
+            encoder.add(*it);
         }
         uint64_t written = encoder.finish();
 

--- a/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
+++ b/metagraph/src/common/sorted_sets/sorted_set_disk_base.cpp
@@ -121,15 +121,11 @@ void SortedSetDiskBase<T>::dump_to_file(bool is_done) {
     #pragma omp parallel for num_threads(num_blocks) schedule(static, 1)
     for (size_t t = 0; t < num_blocks; ++t) {
         block_names[t] = file_name + "_block_" + std::to_string(t);
+        EliasFanoEncoderBuffered<T> encoder(block_names[t], 1000);
         const size_t block_size = (data_.size() + num_blocks - 1) / num_blocks;
-        auto *it = data_.data() + t * block_size;
-        auto *end = data_.data() + std::min(data_.size(), (t + 1) * block_size);
-        EliasFanoEncoder<T> encoder(data_.size(),
-                                    utils::get_first(*it),
-                                    utils::get_first(*(end - 1)),
-                                    block_names[t]);
-        for ( ; it != end; ++it) {
-            encoder.add(*it);
+        const size_t block_end = std::min(data_.size(), (t + 1) * block_size);
+        for (size_t i = t * block_size; i < block_end; ++i) {
+            encoder.add(data_[i]);
         }
         uint64_t written = encoder.finish();
 

--- a/metagraph/src/common/sorted_sets/sorted_set_disk_base.hpp
+++ b/metagraph/src/common/sorted_sets/sorted_set_disk_base.hpp
@@ -170,6 +170,8 @@ class SortedSetDiskBase {
 
     std::string chunk_file_prefix_;
 
+    size_t num_blocks_;
+
     /**
      * True if the data merging thread was started, and data started flowing into the #merge_queue_.
      */
@@ -204,7 +206,12 @@ class SortedSetDiskBase {
                          uint32_t chunk_begin,
                          uint32_t chunk_end,
                          std::atomic<uint32_t> *l1_chunk_count,
-                         std::atomic<size_t> *total_size);
+                         std::atomic<size_t> *total_size,
+                         size_t blocks_per_chunk);
+
+    static std::string merge_blocks(const std::string &chunk_file_prefix,
+                                    uint32_t chunk,
+                                    size_t num_blocks);
 
     static void merge_all(const std::string &out_file,
                           const std::vector<std::string> &to_merge);


### PR DESCRIPTION
Fixes the bottleneck in SortedSetDisk (writing of chunks to disk) by splitting them and writing in parallel.

Also fixes the RAM usage by switching from EliasFanoEncoder to EliasFanoEncoderBuffered.

For parallel graph construction with disk swap, the speedup is ~40-50% (for the k-mer collection/counting stage)