### PR TITLE
Added SequenceGraph::get_base_node to allow for easier graph wrapper handling

### DIFF
--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
@@ -149,7 +149,7 @@ BinaryMatrix::SetBitPositions RowDiff<BaseMatrix>::get_row(Row row) const {
 
         // fwd always selects the last outgoing edge for a given node
         boss_edge = boss.fwd(boss_edge, w % boss.alph_size);
-        row = graph::AnnotatedSequenceGraph::graph_to_anno_index(
+        row = graph::AnnotatedSequenceGraph::graph_to_anno_transform(
                 graph_->boss_to_kmer_index(boss_edge));
 
         auto diff_row = get_diff(row);
@@ -185,7 +185,7 @@ RowDiff<BaseMatrix>::get_rows(const std::vector<Row> &row_ids) const {
                 graph::AnnotatedSequenceGraph::anno_to_graph_index(row));
 
         while (true) {
-            row = graph::AnnotatedSequenceGraph::graph_to_anno_index(
+            row = graph::AnnotatedSequenceGraph::graph_to_anno_transform(
                     graph_->boss_to_kmer_index(boss_edge));
 
             auto [it, is_new] = node_to_rd.try_emplace(row, rd_ids.size());

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -59,7 +59,7 @@ void build_successor(const std::string &graph_fname,
         if (terminal[i]) {
             uint64_t graph_idx = graph.boss_to_kmer_index(i);
             uint64_t anno_index
-                = graph::AnnotatedSequenceGraph::graph_to_anno_index(graph_idx);
+                = graph::AnnotatedSequenceGraph::graph_to_anno_transform(graph_idx);
             assert(anno_index < num_rows);
             term[anno_index] = 1;
         }
@@ -101,7 +101,7 @@ void build_successor(const std::string &graph_fname,
                 uint64_t next = graph.boss_to_kmer_index(boss.fwd(boss_idx, d));
                 assert(next);
                 succ_buf[r].push_back(
-                    graph::AnnotatedSequenceGraph::graph_to_anno_index(next)
+                    graph::AnnotatedSequenceGraph::graph_to_anno_transform(next)
                 );
             }
             // ignore predecessors if boss_idx is not the last outgoing
@@ -115,7 +115,7 @@ void build_successor(const std::string &graph_fname,
                         if (!terminal[pred] && !dummy[pred]) {
                             uint64_t node_index = graph.boss_to_kmer_index(pred);
                             pred_buf[r].push_back(
-                                graph::AnnotatedSequenceGraph::graph_to_anno_index(node_index)
+                                graph::AnnotatedSequenceGraph::graph_to_anno_transform(node_index)
                             );
                             pred_boundary_buf[r].push_back(0);
                         }

--- a/metagraph/src/cli/augment.cpp
+++ b/metagraph/src/cli/augment.cpp
@@ -166,7 +166,7 @@ int augment_graph(Config *config) {
     // transform indexes of the inserved k-mers to the annotation format
     std::vector<uint64_t> inserted_rows;
     inserted_nodes->call_ones([&](auto i) {
-        inserted_rows.push_back(graph::AnnotatedDBG::graph_to_anno_index(i));
+        inserted_rows.push_back(graph::AnnotatedDBG::graph_to_anno_transform(i));
     });
     annotation->insert_rows(inserted_rows);
 

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -761,8 +761,8 @@ construct_query_graph(const AnnotatedDBG &anno_graph,
 
     for (auto &[first, second] : from_full_to_small) {
         assert(first && second);
-        first = AnnotatedDBG::graph_to_anno_index(first);
-        second = AnnotatedDBG::graph_to_anno_index(second);
+        first = AnnotatedDBG::graph_to_anno_transform(first);
+        second = AnnotatedDBG::graph_to_anno_transform(second);
     }
 
     logger->trace("[Query graph construction] Slicing {} rows out of full annotation...",

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -48,7 +48,7 @@ void AnnotatedSequenceGraph
 
     graph_->map_to_nodes(sequence, [&](node_index i) {
         if (i > 0)
-            indices.push_back(graph_to_anno_index(i));
+            indices.push_back(graph_to_anno_transform(i));
     });
 
     if (!indices.size())
@@ -80,7 +80,7 @@ void AnnotatedDBG::add_kmer_counts(std::string_view sequence,
     graph_->map_to_nodes(sequence, [&](node_index i) {
         // only insert indexes for matched k-mers and shift counts accordingly
         if (i > 0) {
-            indices.push_back(graph_to_anno_index(i));
+            indices.push_back(graph_to_anno_transform(i));
             kmer_counts[indices.size() - 1] = kmer_counts[end++];
         }
     });
@@ -112,7 +112,7 @@ std::vector<Label> AnnotatedDBG::get_labels(std::string_view sequence,
 
     graph_->map_to_nodes(sequence, [&](node_index i) {
         if (i > 0) {
-            index_counts[graph_to_anno_index(i)]++;
+            index_counts[graph_to_anno_transform(i)]++;
             num_present_kmers++;
         } else {
             num_missing_kmers++;
@@ -180,7 +180,7 @@ AnnotatedDBG::get_top_labels(std::string_view sequence,
 
     graph_->map_to_nodes(sequence, [&](node_index i) {
         if (i > 0) {
-            index_counts[graph_to_anno_index(i)]++;
+            index_counts[graph_to_anno_transform(i)]++;
             num_present_kmers++;
         }
     });
@@ -236,7 +236,7 @@ AnnotatedDBG::get_top_label_signatures(std::string_view sequence,
     graph_->map_to_nodes(sequence, [&](node_index i) {
         if (i > 0) {
             kmer_positions.push_back(j);
-            row_indices.push_back(graph_to_anno_index(i));
+            row_indices.push_back(graph_to_anno_transform(i));
         }
         j++;
     });

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -47,12 +47,17 @@ class AnnotatedSequenceGraph {
 
     virtual const Annotator& get_annotation() const { return *annotator_; }
 
-    static row_index graph_to_anno_index(node_index kmer_index) {
+    static row_index graph_to_anno_transform(node_index kmer_index) {
         assert(kmer_index);
         return kmer_index - 1;
     }
+
     static node_index anno_to_graph_index(row_index anno_index) {
         return anno_index + 1;
+    }
+
+    row_index graph_to_anno_index(node_index kmer_index) const {
+        return graph_to_anno_transform(graph_->get_base_node(kmer_index));
     }
 
   protected:

--- a/metagraph/src/graph/representation/base/sequence_graph.cpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.cpp
@@ -105,6 +105,14 @@ void DeBruijnGraph::traverse(node_index start,
     }
 }
 
+DeBruijnGraph::node_index DeBruijnGraph::get_base_node(node_index node) const {
+    if (!is_canonical_mode())
+        return node;
+
+    map_to_nodes(get_node_sequence(node), [&](node_index base) { node = base; });
+    return node;
+}
+
 void call_sequences_from(const DeBruijnGraph &graph,
                          node_index start,
                          const DeBruijnGraph::CallPath &callback,

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -232,7 +232,7 @@ class DeBruijnGraph : public SequenceGraph {
     // Call all nodes that have no incoming edges
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const;
 
-    virtual node_index get_base_node(node_index node) const { return node; }
+    virtual node_index get_base_node(node_index node) const override;
 };
 
 

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -67,6 +67,10 @@ class SequenceGraph {
     // Note: Not efficient if sequences in nodes overlap. Use sparingly.
     virtual std::string get_node_sequence(node_index node) const = 0;
 
+    // If the given node is an implicit node created by a given implementation,
+    // get the index of its underlying node in the graph data.
+    virtual node_index get_base_node(node_index node) const = 0;
+
     /********************************************************/
     /******************* graph extensions *******************/
     /********************************************************/
@@ -227,6 +231,8 @@ class DeBruijnGraph : public SequenceGraph {
 
     // Call all nodes that have no incoming edges
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const;
+
+    virtual node_index get_base_node(node_index node) const { return node; }
 };
 
 

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -232,7 +232,7 @@ class DeBruijnGraph : public SequenceGraph {
     // Call all nodes that have no incoming edges
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const;
 
-    virtual node_index get_base_node(node_index node) const override;
+    virtual node_index get_base_node(node_index node) const;
 };
 
 

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -145,12 +145,20 @@ class CanonicalDBG : public DeBruijnGraph {
 
     void reverse_complement(std::string &seq, std::vector<node_index> &path) const;
 
-    inline node_index get_base_node(node_index node) const {
+    virtual node_index get_base_node(node_index node) const override {
         assert(node);
         assert(node <= offset_ * 2);
-        return !graph_.is_canonical_mode()
-            ? (node > offset_ ? node - offset_ : node)
-            : std::min(node, reverse_complement(node));
+        if (node > offset_)
+            node -= offset_;
+
+        if (!graph_.is_canonical_mode())
+            return node;
+
+        graph_.map_to_nodes(graph_.get_node_sequence(node), [&](auto base_node) {
+            node = base_node;
+        });
+
+        return node;
     }
 
   private:

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -151,14 +151,7 @@ class CanonicalDBG : public DeBruijnGraph {
         if (node > offset_)
             node -= offset_;
 
-        if (!graph_.is_canonical_mode())
-            return node;
-
-        graph_.map_to_nodes(graph_.get_node_sequence(node), [&](auto base_node) {
-            node = base_node;
-        });
-
-        return node;
+        return graph_.get_base_node(node);
     }
 
   private:

--- a/metagraph/tests/annotation/test_annotated_dbg.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg.cpp
@@ -62,11 +62,12 @@ void check_labels(const AnnotatedDBG &anno_graph,
     }
 }
 
-std::vector<uint64_t> edge_to_row_idx(const bitmap &edge_mask) {
+std::vector<uint64_t> edge_to_row_idx(const AnnotatedDBG &anno_graph,
+                                      const bitmap &edge_mask) {
     // transform indexes of k-mers to the annotation format
     std::vector<uint64_t> rows;
     edge_mask.call_ones([&](auto i) {
-        rows.push_back(AnnotatedDBG::graph_to_anno_index(i));
+        rows.push_back(anno_graph.graph_to_anno_index(i));
     });
     return rows;
 }
@@ -89,7 +90,7 @@ TEST(AnnotatedDBG, ExtendGraphWithSimplePath) {
         ASSERT_EQ(k + 2, anno_graph.get_graph().num_nodes());
         EXPECT_EQ(1u, anno_graph.get_annotation().num_objects());
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         EXPECT_FALSE(anno_graph.label_exists("Label"));
@@ -147,7 +148,7 @@ TEST(AnnotatedDBG, ExtendGraphAddPath) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },
@@ -216,7 +217,7 @@ TEST(AnnotatedDBG, Transform) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph->annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph->annotator_->insert_rows(edge_to_row_idx(*anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph->get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },
@@ -303,7 +304,7 @@ TEST(AnnotatedDBG, ExtendGraphAddTwoPaths) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },
@@ -420,7 +421,7 @@ TEST(AnnotatedDBG, ExtendGraphAddTwoPathsParallel) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },
@@ -540,7 +541,7 @@ TEST(AnnotatedDBG, ExtendGraphAddTwoPathsWithoutDummy) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },
@@ -664,7 +665,7 @@ TEST(AnnotatedDBG, ExtendGraphAddTwoPathsWithoutDummyParallel) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },
@@ -786,7 +787,7 @@ TEST(AnnotatedDBG, ExtendGraphAddTwoPathsPruneDummy) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },
@@ -909,7 +910,7 @@ TEST(AnnotatedDBG, ExtendGraphAddTwoPathsPruneDummyParallel) {
             [&](auto new_node) { inserted_nodes.insert_bit(new_node, true); }
         );
 
-        anno_graph.annotator_->insert_rows(edge_to_row_idx(inserted_nodes));
+        anno_graph.annotator_->insert_rows(edge_to_row_idx(anno_graph, inserted_nodes));
         EXPECT_EQ(anno_graph.get_graph().num_nodes() + 1, inserted_nodes.size());
 
         ASSERT_EQ(std::vector<std::string> { "First" },


### PR DESCRIPTION
This adds `SequenceGraph::get_base_node`. For a baseline graph implementation, it maps a node to itself. For graph wrappers (like CanonicalDBG), it maps an implicit node (such as a reverse complement) back to the corresponding node in the underlying graph.

In addition, `AnnotatedDBG::graph_to_anno_index` has been modified to call this method so that no matter what type of graph is used, it returns the expected value. The old functionality (simply shifting indices) is now handled by `AnnotatedDBG::graph_to_anno_transform`.

This allows for alignment tasks (involving graph traversal) to work seamlessly with `AnnotatedDBG` without having to explicitly do complex index transformation to determine node labels (e.g., see #262 )