### PR TITLE
remove temp directory after it's not needed, before exit()

### DIFF
--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -302,7 +302,6 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
 
     const std::filesystem::path tmp_path = utils::create_temp_dir(
             std::filesystem::path(dest_dir).remove_filename(), "col");
-    logger->trace("Using temporary directory {}", tmp_path);
 
     // stores the row indices that were set because of differences to incoming/outgoing
     // edges, for each of the sources, per chunk. set_rows_fwd is already sorted
@@ -543,8 +542,8 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
 
         logger->trace("Serialized {}", fpath);
     }
-    logger->trace("Removing temp directory: {}", tmp_path);
-    std::filesystem::remove_all(tmp_path);
+
+    utils::remove_temp_dir(tmp_path);
 
     if (!compute_row_reduction)
         return;

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -15,7 +15,7 @@ namespace utils {
 
 std::filesystem::path create_temp_dir(std::filesystem::path path,
                                       const std::string &name = "");
-
+void remove_temp_dir(std::filesystem::path dir_name);
 
 bool check_if_writable(const std::string &filename);
 

--- a/metagraph/src/graph/representation/succinct/boss_chunk.cpp
+++ b/metagraph/src/graph/representation/succinct/boss_chunk.cpp
@@ -138,8 +138,7 @@ BOSS::Chunk::Chunk(uint64_t alph_size, size_t k, bool canonical,
 }
 
 BOSS::Chunk::~Chunk() {
-    std::error_code ec;
-    fs::remove_all(dir_, ec);
+    utils::remove_temp_dir(dir_);
 }
 
 template <typename Array>

--- a/metagraph/src/kmer/kmer_collector.cpp
+++ b/metagraph/src/kmer/kmer_collector.cpp
@@ -164,7 +164,7 @@ template <typename KMER, class KmerExtractor, class Container>
 KmerCollector<KMER, KmerExtractor, Container>
 ::~KmerCollector() {
     if (!tmp_dir_.empty())
-        std::filesystem::remove_all(tmp_dir_);
+        utils::remove_temp_dir(tmp_dir_);
 }
 
 template <typename KMER, class KmerExtractor, class Container>


### PR DESCRIPTION
A small change, makes it remove temp directories right after they are not needed and not wait until the program terminates.
So it doesn't show a long list of `Cleaning up temporary directory ...` in the end.