### PR TITLE
Test g++-8.0 in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         # If clang, use the default version. Otherwise the compiler install with apt-get.
         [ "${{ matrix.compiler }}" != "clang" ] && sudo apt-get install ${{ matrix.compiler }}
 
-        sudo apt-get install g++-8=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,20 +41,20 @@ jobs:
     - name: install dependencies
       run: |
         # If clang, use the default version. Otherwise the compiler install with apt-get.
-        [ "${{ matrix.compiler }}" != "clang" ] && sudo apt-get install ${{ matrix.compiler }}
+        if [ "${{ matrix.compiler }}" == "g++-8" ]; then
+            sudo apt-get --allow-downgrades install \
+                g++-8=8-20180414-1ubuntu2 \
+                gcc-8-base=8-20180414-1ubuntu2 \
+                gcc-8=8-20180414-1ubuntu2 \
+                libstdc++-8-dev=8-20180414-1ubuntu2 \
+                cpp-8=8-20180414-1ubuntu2 \
+                libgcc-8-dev=8-20180414-1ubuntu2 \
+                libmpx2=8-20180414-1ubuntu2
+        else if [ "${{ matrix.compiler }}" != "clang" ]; then
+            sudo apt-get install ${{ matrix.compiler }}
+        fi
 
-        sudo apt-get --allow-downgrades install \
-            g++-8=8-20180414-1ubuntu2 \
-            gcc-8-base=8-20180414-1ubuntu2 \
-            gcc-8=8-20180414-1ubuntu2 \
-            libstdc++-8-dev=8-20180414-1ubuntu2 \
-            cpp-8=8-20180414-1ubuntu2 \
-            libgcc-8-dev=8-20180414-1ubuntu2 \
-            libmpx2=8-20180414-1ubuntu2 \
-            libbz2-dev \
-            libhts-dev \
-            libjemalloc-dev \
-            libboost-all-dev
+        sudo apt-get libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         # If clang, use the default version. Otherwise the compiler install with apt-get.
         [ "${{ matrix.compiler }}" != "clang" ] && sudo apt-get install ${{ matrix.compiler }}
 
-        sudo apt-get install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 cpp-8=8-20180414-1ubuntu2 libgcc-8-dev=8-20180414-1ubuntu2 libmpx2=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get --allow-downgrades install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 cpp-8=8-20180414-1ubuntu2 libgcc-8-dev=8-20180414-1ubuntu2 libmpx2=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
         compiler: [g++-8, g++-9, g++-10]
         include:
           - compiler: g++-8
+            version: 8-20180414-1ubuntu2
             cxx: g++-8
             cc: gcc-8
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         # If clang, use the default version. Otherwise the compiler install with apt-get.
         [ "${{ matrix.compiler }}" != "clang" ] && sudo apt-get install ${{ matrix.compiler }}
 
-        sudo apt-get install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 cpp-8=8-20180414-1ubuntu2 libgcc-8-dev=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         # If clang, use the default version. Otherwise the compiler install with apt-get.
         [ "${{ matrix.compiler }}" != "clang" ] && sudo apt-get install ${{ matrix.compiler }}
 
-        sudo apt-get install libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get install g++-8=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
             sudo apt-get install ${{ matrix.compiler }}
         fi
 
-        sudo apt-get libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get install libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         # If clang, use the default version. Otherwise the compiler install with apt-get.
         [ "${{ matrix.compiler }}" != "clang" ] && sudo apt-get install ${{ matrix.compiler }}
 
-        sudo apt-get install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 cpp-8=8-20180414-1ubuntu2 libgcc-8-dev=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 cpp-8=8-20180414-1ubuntu2 libgcc-8-dev=8-20180414-1ubuntu2 libmpx2=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,6 @@ jobs:
         compiler: [g++-8, g++-9, g++-10]
         include:
           - compiler: g++-8
-            version: 8-20180414-1ubuntu2
             cxx: g++-8
             cc: gcc-8
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
     - name: install dependencies
       run: |
         # If clang, use the default version. Otherwise the compiler install with apt-get.
-        if [ "${{ matrix.compiler }}" == "g++-8" ]; then
+        if [[ "${{ matrix.compiler }}" == "g++-8" ]]; then
             sudo apt-get --allow-downgrades install \
                 g++-8=8-20180414-1ubuntu2 \
                 gcc-8-base=8-20180414-1ubuntu2 \
@@ -50,7 +50,7 @@ jobs:
                 cpp-8=8-20180414-1ubuntu2 \
                 libgcc-8-dev=8-20180414-1ubuntu2 \
                 libmpx2=8-20180414-1ubuntu2
-        else if [ "${{ matrix.compiler }}" != "clang" ]; then
+        elif [[ "${{ matrix.compiler }}" != "clang" ]]; then
             sudo apt-get install ${{ matrix.compiler }}
         fi
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,18 @@ jobs:
         # If clang, use the default version. Otherwise the compiler install with apt-get.
         [ "${{ matrix.compiler }}" != "clang" ] && sudo apt-get install ${{ matrix.compiler }}
 
-        sudo apt-get --allow-downgrades install g++-8=8-20180414-1ubuntu2 gcc-8-base=8-20180414-1ubuntu2 gcc-8=8-20180414-1ubuntu2 libstdc++-8-dev=8-20180414-1ubuntu2 cpp-8=8-20180414-1ubuntu2 libgcc-8-dev=8-20180414-1ubuntu2 libmpx2=8-20180414-1ubuntu2 libbz2-dev libhts-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get --allow-downgrades install \
+            g++-8=8-20180414-1ubuntu2 \
+            gcc-8-base=8-20180414-1ubuntu2 \
+            gcc-8=8-20180414-1ubuntu2 \
+            libstdc++-8-dev=8-20180414-1ubuntu2 \
+            cpp-8=8-20180414-1ubuntu2 \
+            libgcc-8-dev=8-20180414-1ubuntu2 \
+            libmpx2=8-20180414-1ubuntu2 \
+            libbz2-dev \
+            libhts-dev \
+            libjemalloc-dev \
+            libboost-all-dev
 
     - name: install dependencies for integration tests
       run: |

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 ### Prerequisites
 - cmake 3.10 or higher
-- GNU GCC with C++17 (gcc-8.4.0 or higher), LLVM Clang (clang-7 or higher), or AppleClang (clang-1100.0.33.8 or higher)
+- GNU GCC with C++17 (gcc-8.0.1 or higher), LLVM Clang (clang-7 or higher), or AppleClang (clang-1100.0.33.8 or higher)
 - bzip2
 - HTSlib
 


### PR DESCRIPTION
This downgrades the version of gcc-8 in the CI to 8.0.1 to better check compatibility with older gcc versions.