### PR TITLE
Taxonomic class debug

### DIFF
--- a/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
@@ -68,6 +68,7 @@ TaxoClassifier::TaxoClassifier(const std::string &filepath) {
 std::string TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                                          const std::string &sequence,
                                          const double &lca_coverage_threshold) {
+    std::cout << "\n\n\n";
     tsl::hopscotch_map<NormalizedTaxId, uint64_t> raw_node_matches;
     uint64_t total_kmers = 0;
 
@@ -78,13 +79,22 @@ std::string TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
             total_kmers++;
         }
     });
+
+    std::cout << "raw_node_matches\n";
+    for (auto &it: raw_node_matches) {
+        std::cout << "fst=" << it.first << " scd=" << it.second << "\n";
+    }
+
     tsl::hopscotch_set<NormalizedTaxId> nodes_already_propagated;
+    tsl::hopscotch_map<NormalizedTaxId, uint64_t> node_scores;
 
     uint64_t desired_number_kmers = total_kmers * lca_coverage_threshold;
     NormalizedTaxId best_lca = root_node;
     uint64_t best_lca_dist_to_root = 1;
+    std::cout << "iterate raw nodes \n";
     for (const auto &node_pair: raw_node_matches) {
         uint64_t start_node = node_pair.first;
+        std::cout << "\tstart_node=" << start_node << "\n";
         if (nodes_already_propagated.count(start_node)) {
             continue;
         }
@@ -103,16 +113,17 @@ std::string TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                 if (raw_node_matches.count(act_node)) {
                     score_from_unprocessed_parents += raw_node_matches[act_node];
                 }
+                std::cout << "\tadd unprocessed parent=" << act_node << "\n";
                 unprocessed_parents.push_back(act_node);
             } else {
                 if (raw_node_matches.count(act_node)) {
                     score_from_processed_parents += raw_node_matches[act_node];
                 }
+                std::cout << "\tadd processed parent=" << act_node << "\n";
                 processed_parents.push_back(act_node);
             }
         }
-
-        tsl::hopscotch_map<NormalizedTaxId, uint64_t> node_scores;
+        std::cout << "\n";
         for (uint64_t i = 0; i < unprocessed_parents.size(); ++i) {
             NormalizedTaxId &act_node = unprocessed_parents[i];
             node_scores[act_node] = score_from_processed_parents +
@@ -126,6 +137,7 @@ std::string TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                 best_lca = act_node;
                 best_lca_dist_to_root = act_dist_to_root;
             }
+            std::cout << "\tnode_scores[" << act_node << "]=" << node_scores[act_node] / (double)total_kmers << " act_dist_to_root=" << act_dist_to_root << "\n";
         }
         for (uint64_t i = 0; i < processed_parents.size(); ++i) {
             NormalizedTaxId &act_node = processed_parents[i];
@@ -137,8 +149,10 @@ std::string TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                 best_lca = act_node;
                 best_lca_dist_to_root = act_dist_to_root;
             }
+            std::cout << "\tnode_scores[" << act_node << "]=" << node_scores[act_node] / (double)total_kmers << " act_dist_to_root=" << act_dist_to_root << "\n";
         }
     }
+    std::cout << "best_lca=" << best_lca << std::endl;
     return node_to_acc_version[best_lca];
 }
 

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
@@ -42,6 +42,7 @@ void TaxoClassifier::import_taxonomy(const std::string &filepath) {
         logger->error("Can't load serialized 'node_parent' from file '{}'.", filepath.c_str());
         std::exit(1);
     }
+    std::cerr << "node_parents.size=" << node_parent.size() << "\n";
     f.close();
     logger->trace("Finished with importing metagraph taxonomic data after '{}' sec", timer.elapsed());
 }
@@ -63,6 +64,7 @@ TaxoClassifier::TaxoClassifier(const std::string &filepath) {
 TaxId TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                                    const std::string &sequence,
                                    const double &lca_coverage_threshold) {
+    std::cout << "\n\n\n";
     tsl::hopscotch_map<TaxId, uint64_t> raw_node_matches;
     uint64_t total_kmers = 0;
 
@@ -74,14 +76,21 @@ TaxId TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
         }
     });
 
+    std::cout << "raw_node_matches\n";
+    for (auto &it: raw_node_matches) {
+        std::cout << "fst=" << it.first << " scd=" << it.second << "\n";
+    }
+
     tsl::hopscotch_set<TaxId> nodes_already_propagated;
     tsl::hopscotch_map<TaxId, uint64_t> node_scores;
 
     uint64_t desired_number_kmers = total_kmers * lca_coverage_threshold;
     TaxId best_lca = root_node;
     uint64_t best_lca_dist_to_root = 1;
+    std::cout << "iterate raw nodes \n";
     for (const auto &node_pair: raw_node_matches) {
         TaxId start_node = node_pair.first;
+        std::cout << "\tstart_node=" << start_node << "\n";
         if (nodes_already_propagated.count(start_node)) {
             continue;
         }
@@ -100,14 +109,17 @@ TaxId TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                 if (raw_node_matches.count(act_node)) {
                     score_from_unprocessed_parents += raw_node_matches[act_node];
                 }
+                std::cout << "\tadd unprocessed parent=" << act_node << "\n";
                 unprocessed_parents.push_back(act_node);
             } else {
                 if (raw_node_matches.count(act_node)) {
                     score_from_processed_parents += raw_node_matches[act_node];
                 }
+                std::cout << "\tadd processed parent=" << act_node << "\n";
                 processed_parents.push_back(act_node);
             }
         }
+        std::cout << "\n";
         for (uint64_t i = 0; i < unprocessed_parents.size(); ++i) {
             TaxId &act_node = unprocessed_parents[i];
             node_scores[act_node] =
@@ -121,6 +133,7 @@ TaxId TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                 best_lca = act_node;
                 best_lca_dist_to_root = act_dist_to_root;
             }
+            std::cout << "\tnode_scores[" << act_node << "]=" << node_scores[act_node] / (double)total_kmers << " act_dist_to_root=" << act_dist_to_root << "\n";
         }
         for (uint64_t i = 0; i < processed_parents.size(); ++i) {
             TaxId &act_node = processed_parents[i];
@@ -132,8 +145,10 @@ TaxId TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
                 best_lca = act_node;
                 best_lca_dist_to_root = act_dist_to_root;
             }
+            std::cout << "\tnode_scores[" << act_node << "]=" << node_scores[act_node] / (double)total_kmers << " act_dist_to_root=" << act_dist_to_root << "\n";
         }
     }
+    std::cout << "best_lca=" << best_lca << std::endl;
     return best_lca;
 }
 

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
@@ -42,7 +42,10 @@ void TaxoClassifier::import_taxonomy(const std::string &filepath) {
         logger->error("Can't load serialized 'node_to_acc_version' from file '{}'.", filepath.c_str());
         std::exit(1);
     }
-    node_parent = load_number_vector_raw<NormalizedTaxId>(f);
+    if (!load_number_vector(f, &node_parent)) {
+        logger->error("Can't load serialized 'node_parent' from file '{}'.", filepath.c_str());
+        std::exit(1);
+    }
 
     f.close();
     logger->trace("Finished with importing metagraph taxonomic data after '{}' sec", timer.elapsed());

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.cpp
@@ -1,0 +1,143 @@
+#include "taxo_classifier.hpp"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cmath>
+#include <tsl/hopscotch_map.h>
+#include <tsl/hopscotch_set.h>
+
+#include "graph/representation/succinct/dbg_succinct.hpp"
+#include "graph/representation/canonical_dbg.hpp"
+#include "common/serialization.hpp"
+#include "common/unix_tools.hpp"
+
+#include "common/logger.hpp"
+
+
+namespace mtg {
+namespace annot {
+
+using mtg::common::logger;
+
+typedef TaxoClassifier::NormalizedTaxId NormalizedTaxId;
+
+void TaxoClassifier::import_taxonomy(const std::string &filepath) {
+    Timer timer;
+    logger->trace("Importing metagraph taxonomic data..");
+
+    std::ifstream f(filepath.c_str(), std::ios::in | std::ios::binary);
+    if (!f.is_open()) {
+        logger->error("Can't open taxonomic file '{}'.", filepath.c_str());
+        std::exit(1);
+    }
+
+    if (!load_number_number_map(f, &taxonomic_map)) {
+        logger->error("Can't load serialized 'taxonomic_map' from file '{}'.", filepath.c_str());
+        std::exit(1);
+    }
+
+    if (!load_string_vector(f, &node_to_acc_version)) {
+        logger->error("Can't load serialized 'node_to_acc_version' from file '{}'.", filepath.c_str());
+        std::exit(1);
+    }
+    node_parent = load_number_vector_raw<NormalizedTaxId>(f);
+
+    f.close();
+    logger->trace("Finished with importing metagraph taxonomic data after '{}' sec", timer.elapsed());
+}
+
+TaxoClassifier::TaxoClassifier(const std::string &filepath) {
+    Timer timer;
+    logger->trace("Constructing Classifier object..");
+    import_taxonomy(filepath);
+
+    for (uint64_t i = 0; i < node_parent.size(); ++i) {
+        if (i == node_parent[i]) {
+            root_node = i;
+            break;
+        }
+    }
+    logger->trace("Finished the Taxonomic Classifier's constructor in '{}' sec", timer.elapsed());
+}
+
+std::string TaxoClassifier::assign_class(const mtg::graph::DeBruijnGraph &graph,
+                                         const std::string &sequence,
+                                         const double &lca_coverage_threshold) {
+    tsl::hopscotch_map<NormalizedTaxId, uint64_t> raw_node_matches;
+    uint64_t total_kmers = 0;
+
+    graph.map_to_nodes(sequence, [&](const auto &i) {
+        if (i > 0) {
+            // We need this i-1, because of the way how annotation cmd is implemented.
+            raw_node_matches[taxonomic_map[i - 1]]++;
+            total_kmers++;
+        }
+    });
+    tsl::hopscotch_set<NormalizedTaxId> nodes_already_propagated;
+
+    uint64_t desired_number_kmers = total_kmers * lca_coverage_threshold;
+    NormalizedTaxId best_lca = root_node;
+    uint64_t best_lca_dist_to_root = 1;
+    for (const auto &node_pair: raw_node_matches) {
+        uint64_t start_node = node_pair.first;
+        if (nodes_already_propagated.count(start_node)) {
+            continue;
+        }
+        uint64_t score_from_processed_parents = 0;
+        uint64_t score_from_unprocessed_parents = raw_node_matches[start_node];
+
+        std::vector<NormalizedTaxId> processed_parents;
+        std::vector<NormalizedTaxId> unprocessed_parents;
+
+        NormalizedTaxId act_node = start_node;
+        unprocessed_parents.push_back(act_node);
+
+        while (act_node != root_node) {
+            act_node = node_parent[act_node];
+            if (!nodes_already_propagated.count(act_node)) {
+                if (raw_node_matches.count(act_node)) {
+                    score_from_unprocessed_parents += raw_node_matches[act_node];
+                }
+                unprocessed_parents.push_back(act_node);
+            } else {
+                if (raw_node_matches.count(act_node)) {
+                    score_from_processed_parents += raw_node_matches[act_node];
+                }
+                processed_parents.push_back(act_node);
+            }
+        }
+
+        tsl::hopscotch_map<NormalizedTaxId, uint64_t> node_scores;
+        for (uint64_t i = 0; i < unprocessed_parents.size(); ++i) {
+            NormalizedTaxId &act_node = unprocessed_parents[i];
+            node_scores[act_node] = score_from_processed_parents +
+                                      score_from_unprocessed_parents;
+            nodes_already_propagated.insert(act_node);
+
+            uint64_t act_dist_to_root =
+                    processed_parents.size() + unprocessed_parents.size() - i;
+            if (node_scores[act_node] >= desired_number_kmers &&
+                act_dist_to_root > best_lca_dist_to_root) {
+                best_lca = act_node;
+                best_lca_dist_to_root = act_dist_to_root;
+            }
+        }
+        for (uint64_t i = 0; i < processed_parents.size(); ++i) {
+            NormalizedTaxId &act_node = processed_parents[i];
+            node_scores[act_node] += score_from_unprocessed_parents;
+
+            uint64_t act_dist_to_root = processed_parents.size() - i;
+            if (node_scores[act_node] >= desired_number_kmers &&
+                act_dist_to_root > best_lca_dist_to_root) {
+                best_lca = act_node;
+                best_lca_dist_to_root = act_dist_to_root;
+            }
+        }
+    }
+    return node_to_acc_version[best_lca];
+}
+
+}
+}

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
@@ -48,7 +48,7 @@ class TaxoClassifier {
 
   public:
     /**
-     * TaxoClassifier a TaxoClassifier
+     * Construct a TaxoClassifier
      *
      * @param [input] filepath path to file exported by TaxonomyDB.
      */
@@ -59,7 +59,7 @@ class TaxoClassifier {
      * Consider matches[node] = number of kmers in 'sequence' for which taxonomic_map points to 'node'.
      *          weight[node] = matches[node] / #(kmers in sequence). (Values in [0, 1])
      *          score[node] = sum(weight[node*]) where node* is in node's subtree or on root->node path. (Values in [0, 1])
-     * The assigned LCA accession version is the farthest node to the root with score[node] >= lca_coverage_threshold.
+     * The assigned LCA accession version is the farthest node to the root with score[node] >= lca_coverage_threshold (unique).
       */
     std::string assign_class(const mtg::graph::DeBruijnGraph &graph,
                              const std::string &sequence,

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
@@ -36,7 +36,7 @@ class TaxoClassifier {
     tsl::hopscotch_map<KmerId, TaxId> taxonomic_map;
 
     /**
-     * Import 'this->taxonomic_map', 'this->node_to_acc_version' and the taxonomic tree (as parent list)
+     * Import 'this->taxonomic_map' and the taxonomic tree (as parent list)
      * from the given filepath (created by TaxonomyDB in annotation cli).
      */
     void import_taxonomy(const std::string &filepath);
@@ -45,15 +45,15 @@ class TaxoClassifier {
     /**
      * Construct a TaxoClassifier
      *
-     * @param [input] filepath path to file exported by TaxonomyDB.
+     * @param [input] filepath to the file exported by TaxonomyDB.
      */
     TaxoClassifier(const std::string &filepath);
 
     /**
      * Assign a LCA taxid to a given sequence.
-     * Consider matches[node] = number of kmers in 'sequence' for which taxonomic_map points to 'node'.
+     * Consider matches[node] = number of kmers in 'sequence' for which the taxonomic_map points to 'node'.
      *          weight[node] = matches[node] / #(kmers in sequence). (Values in [0, 1])
-     *          score[node] = sum(weight[node*]) where node* is in node's subtree or on root->node path. (Values in [0, 1])
+     *          score[node] = sum(weight[node*]) where node* is iterating over node's subtree + node's ancestors (Values in [0, 1])
      * The assigned taxid is the farthest node to the root with score[node] >= lca_coverage_threshold (unique).
       */
     TaxId assign_class(const mtg::graph::DeBruijnGraph &graph,

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
@@ -1,0 +1,70 @@
+#ifndef __TAXONOMIC_CLASSIFIER_HPP__
+#define __TAXONOMIC_CLASSIFIER_HPP__
+
+#include "annotation/representation/base/annotation.hpp"
+#include "cli/load/load_annotated_graph.hpp"
+#include "graph/representation/succinct/dbg_succinct.hpp"
+
+
+namespace mtg {
+namespace annot {
+
+
+/**
+ * TaxoClassifier imports the data from TaxonomicDB and does the taxonomic
+ * classification for a given sequence.
+ */
+class TaxoClassifier {
+  public:
+    typedef std::uint64_t NormalizedTaxId;
+    typedef annot::MultiLabelEncoded<std::string> Annotator;
+    using KmerId = Annotator::Index;
+    using DeBruijnGraph = mtg::graph::DeBruijnGraph;
+
+  private:
+    NormalizedTaxId root_node;
+
+    /**
+     * node_parent[node] returns the taxid of the corresponding parent.
+    */
+    std::vector<NormalizedTaxId> node_parent;
+
+    /**
+     * node_to_acc_version maps normalized taxid to accession version.
+     */
+    std::vector<std::string> node_to_acc_version;
+
+    /**
+     * taxonomic_map returns the taxid LCA for a given kmer.
+     */
+    tsl::hopscotch_map<KmerId, NormalizedTaxId> taxonomic_map;
+
+    /**
+     * Import 'this->taxonomic_map', 'this->node_to_acc_version' and the taxonomic tree (as parent list)
+     * from the given filepath (created by TaxonomyDB in annotation cli).
+     */
+    void import_taxonomy(const std::string &filepath);
+
+  public:
+    /**
+     * TaxoClassifier a TaxoClassifier
+     *
+     * @param [input] filepath path to file exported by TaxonomyDB.
+     */
+    TaxoClassifier(const std::string &filepath);
+
+    /**
+     * Assign a LCA accession version to a given sequence.
+     * Consider matches[node] = number of kmers in 'sequence' for which taxonomic_map points to 'node'.
+     *          weight[node] = matches[node] / #(kmers in sequence). (Values in [0, 1])
+     *          score[node] = sum(weight[node*]) where node* is in node's subtree or on root->node path. (Values in [0, 1])
+     * The assigned LCA accession version is the farthest node to the root with score[node] >= lca_coverage_threshold.
+      */
+    std::string assign_class(const mtg::graph::DeBruijnGraph &graph,
+                             const std::string &sequence,
+                             const double &lca_coverage_threshold);
+};
+
+}
+}
+#endif // __TAXONOMIC_CLASSIFIER_HPP__

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
@@ -9,7 +9,7 @@
 namespace mtg {
 namespace annot {
 
-
+const double DEFAULT_LCA_COVERAGE_THRESHOLD = 0.66;
 /**
  * TaxoClassifier imports the data from TaxonomicDB and does the taxonomic
  * classification for a given sequence.
@@ -20,6 +20,7 @@ class TaxoClassifier {
     typedef annot::MultiLabelEncoded<std::string> Annotator;
     using KmerId = Annotator::Index;
     using DeBruijnGraph = mtg::graph::DeBruijnGraph;
+
 
   private:
     NormalizedTaxId root_node;
@@ -62,7 +63,7 @@ class TaxoClassifier {
       */
     std::string assign_class(const mtg::graph::DeBruijnGraph &graph,
                              const std::string &sequence,
-                             const double &lca_coverage_threshold);
+                             const double &lca_coverage_threshold = DEFAULT_LCA_COVERAGE_THRESHOLD);
 };
 
 }

--- a/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
+++ b/metagraph/src/annotation/taxonomy/taxo_classifier.hpp
@@ -16,29 +16,24 @@ const double DEFAULT_LCA_COVERAGE_THRESHOLD = 0.66;
  */
 class TaxoClassifier {
   public:
-    typedef std::uint64_t NormalizedTaxId;
+    typedef std::uint64_t TaxId;
     typedef annot::MultiLabelEncoded<std::string> Annotator;
     using KmerId = Annotator::Index;
     using DeBruijnGraph = mtg::graph::DeBruijnGraph;
 
 
   private:
-    NormalizedTaxId root_node;
+    TaxId root_node;
 
     /**
-     * node_parent[node] returns the taxid of the corresponding parent.
+     * node_parent[node] returns the taxid of node's parent.
     */
-    std::vector<NormalizedTaxId> node_parent;
-
-    /**
-     * node_to_acc_version maps normalized taxid to accession version.
-     */
-    std::vector<std::string> node_to_acc_version;
+    tsl::hopscotch_map<TaxId, TaxId> node_parent;
 
     /**
      * taxonomic_map returns the taxid LCA for a given kmer.
      */
-    tsl::hopscotch_map<KmerId, NormalizedTaxId> taxonomic_map;
+    tsl::hopscotch_map<KmerId, TaxId> taxonomic_map;
 
     /**
      * Import 'this->taxonomic_map', 'this->node_to_acc_version' and the taxonomic tree (as parent list)
@@ -55,15 +50,15 @@ class TaxoClassifier {
     TaxoClassifier(const std::string &filepath);
 
     /**
-     * Assign a LCA accession version to a given sequence.
+     * Assign a LCA taxid to a given sequence.
      * Consider matches[node] = number of kmers in 'sequence' for which taxonomic_map points to 'node'.
      *          weight[node] = matches[node] / #(kmers in sequence). (Values in [0, 1])
      *          score[node] = sum(weight[node*]) where node* is in node's subtree or on root->node path. (Values in [0, 1])
-     * The assigned LCA accession version is the farthest node to the root with score[node] >= lca_coverage_threshold (unique).
+     * The assigned taxid is the farthest node to the root with score[node] >= lca_coverage_threshold (unique).
       */
-    std::string assign_class(const mtg::graph::DeBruijnGraph &graph,
-                             const std::string &sequence,
-                             const double &lca_coverage_threshold = DEFAULT_LCA_COVERAGE_THRESHOLD);
+    TaxId assign_class(const mtg::graph::DeBruijnGraph &graph,
+                       const std::string &sequence,
+                       const double &lca_coverage_threshold = DEFAULT_LCA_COVERAGE_THRESHOLD);
 };
 
 }

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -1104,6 +1104,8 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "\t   --fast \t\tquery in batches [off]\n");
             fprintf(stderr, "\t   --batch-size \tquery batch size (number of base pairs) [100000000]\n");
             fprintf(stderr, "\n");
+            fprintf(stderr, "Available options for taxonomic classification:\n");
+            fprintf(stderr, "\t   --taxonomic-tree [STR] \tpath to the taxonomicDB created by annotation cmd []\n");
             fprintf(stderr, "Available options for --align:\n");
             fprintf(stderr, "\t   --align-both-strands \t\t\treturn best alignments for either input sequence or its reverse complement [off]\n");
             // fprintf(stderr, "\t   --align-alternative-alignments \tthe number of alternative paths to report per seed [1]\n");

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -861,7 +861,9 @@ std::string query_sequence(size_t id, std::string name, std::string seq,
                            const align::DBGAlignerConfig *aligner_config,
                            std::shared_ptr<annot::TaxoClassifier> taxo_classifier) {
     if (taxo_classifier != nullptr) {
-        return taxo_classifier->assign_class(anno_graph.get_graph(), seq) + "\n";
+        return fmt::format("Sequence '{}' was classified with Tax ID '{}'\n",
+                           name,
+                           taxo_classifier->assign_class(anno_graph.get_graph(), seq));
     }
 
     if (aligner_config) {

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -793,7 +793,7 @@ int query_graph(Config *config) {
     assert(config);
 
     const auto &files = config->fnames;
-    assert(config->infbase_annotators.size() == 1 || config->taxonomic_tree.size());
+    assert(config->infbase_annotators.size() == 1);
     std::shared_ptr<DeBruijnGraph> graph = load_critical_dbg(config->infbase);
 
     std::unique_ptr<AnnotatedDBG> anno_graph = initialize_annotated_dbg(graph, *config);

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -21,6 +21,10 @@ namespace graph {
     }
 }
 
+namespace annot {
+    class TaxoClassifier;
+}
+
 
 namespace cli {
 
@@ -70,6 +74,7 @@ class QueryExecutor {
     const graph::AnnotatedDBG &anno_graph_;
     std::unique_ptr<graph::align::DBGAlignerConfig> aligner_config_;
     ThreadPool &thread_pool_;
+    std::shared_ptr<annot::TaxoClassifier> taxo_classifier_ = nullptr;
 
     void batched_query_fasta(mtg::seq_io::FastaParser &fasta_parser,
                              const std::function<void(const std::string &)> &callback);


### PR DESCRIPTION
TaxoClassifier  does the taxonomic classification for a given sequence. It must receive as input (flag --taxonomic-tree) the taxonomic DB created by annotating metagraph subcmd (https://github.com/ratschlab/metagraph/pull/283)

run cmd:
```
> ./metagraph query -i taxo/virus_database_graph/virus_database.dbg taxo/viral_query.fasta --taxonomic-tree taxo/anno_new.taxo -a taxo/anno.column.annodbg
```

viral_query.fasta -> https://ideone.com/1mopXb
Output -> https://ideone.com/Rj6ZIz
Output (+debugging) -> https://ideone.com/hr2gmA (for reproducing, git branch https://github.com/ratschlab/metagraph/tree/taxonomic_class_debug)
