### PR TITLE
save disk space in first stage of row-diff transform

### DIFF
--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1142,9 +1142,11 @@ void convert_to_row_diff(const std::vector<std::string> &files,
         size_t mem_bytes_left = mem_bytes;
         std::vector<std::string> file_batch;
         for ( ; i < files.size(); ++i) {
-            // also include two buffers (fwd and back) for each column transformed
+            // also include two buffers (fwd and back) for each column transformed,
+            // or only one buffer if it's the first stage where only the number of
+            // bits per row in row-diff is computed
             uint64_t file_size = std::filesystem::file_size(files[i])
-                                + ROW_DIFF_BUFFER_SIZE * sizeof(uint64_t) * 2;
+                                + ROW_DIFF_BUFFER_SIZE * sizeof(uint64_t) * (optimize ? 2 : 1);
             if (file_size > mem_bytes) {
                 logger->warn(
                         "Not enough memory to process {}, requires {} MB, skipped",

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -378,11 +378,14 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
 
         for (size_t j = 0; j < sources[s].num_labels(); ++j) {
             fs::create_directories(tmp_file(s, j, 0).parent_path());
-            // make sure the first chunk exists even if empty
-            dump_chunk_to_disk({}, s, j, 0);
             uint64_t original_nbits = sources[s].get_matrix().data()[j]->num_set_bits();
             set_rows_bwd[s][j].reserve(std::min(buf_size, original_nbits));
-            set_rows_fwd[s][j].reserve(std::min(buf_size, original_nbits));
+
+            if (!compute_row_reduction) {
+                // make sure the first chunk exists even if empty
+                dump_chunk_to_disk({}, s, j, 0);
+                set_rows_fwd[s][j].reserve(std::min(buf_size, original_nbits));
+            }
         }
     }
 
@@ -422,19 +425,26 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
                     uint64_t succ,
                     const uint64_t *pred_begin, const uint64_t *pred_end) {
 
-                __atomic_add_fetch(&row_nbits_block[chunk_idx], 1, __ATOMIC_RELAXED);
-
                 // add current bit if this node is an anchor
                 // or if the successor has zero bit
                 if (anchor[row_idx] || !source_col[succ]) {
-                    auto &v = set_rows_fwd[source_idx][j];
-                    v.push_back(row_idx);
+                    // no reduction, we must keep the bit
+                    // Push to the buffer only if it's the final stage of the
+                    // row-diff transform, where we construct the full row-diff
+                    // columns.
+                    if (!compute_row_reduction) {
+                        auto &v = set_rows_fwd[source_idx][j];
+                        v.push_back(row_idx);
 
-                    if (v.size() == v.capacity()) {
-                        // dump chunk to disk
-                        dump_chunk_to_disk(v, source_idx, j, 0);
-                        v.resize(0);
+                        if (v.size() == v.capacity()) {
+                            // dump chunk to disk
+                            dump_chunk_to_disk(v, source_idx, j, 0);
+                            v.resize(0);
+                        }
                     }
+                } else if (compute_row_reduction) {
+                    // reduction (no bit in row-diff)
+                    __atomic_add_fetch(&row_nbits_block[chunk_idx], -1, __ATOMIC_RELAXED);
                 }
 
                 // check non-anchor predecessor nodes and add them if they are zero
@@ -475,6 +485,7 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
     for (size_t s = 0; s < sources.size(); ++s) {
         for (size_t j = 0; j < sources[s].num_labels(); ++j) {
             auto &fwd = set_rows_fwd[s][j];
+            assert(fwd.empty() || !compute_row_reduction);
             if (fwd.size())
                 dump_chunk_to_disk(fwd, s, j, 0);
 
@@ -518,7 +529,9 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
         for (size_t j = 0; j < label_encoders[l_idx].size(); ++j) {
             auto call_ones = [&](const std::function<void(uint64_t)> &call) {
                 std::vector<std::string> filenames;
-                for (uint32_t chunk = 0; chunk < num_chunks[l_idx][j]; ++chunk) {
+                // skip chunk with fwd bits which have already been counted if stage 1
+                for (uint32_t chunk = compute_row_reduction ? 1 : 0;
+                                    chunk < num_chunks[l_idx][j]; ++chunk) {
                     filenames.push_back(tmp_file(l_idx, j, chunk));
                 }
 
@@ -582,14 +595,16 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
                 std::make_unique<RowDiff<ColumnMajor>>(nullptr, ColumnMajor(std::move(columns))),
                 std::move(label_encoders[l_idx]));
 
-        auto fpath = dest_dir/fs::path(source_files[l_idx])
-                                .filename()
-                                .replace_extension()
-                                .replace_extension(RowDiffColumnAnnotator::kExtension);
+        if (!compute_row_reduction) {
+            auto fpath = dest_dir/fs::path(source_files[l_idx])
+                                    .filename()
+                                    .replace_extension()
+                                    .replace_extension(RowDiffColumnAnnotator::kExtension);
 
-        row_diff[l_idx]->serialize(fpath);
+            row_diff[l_idx]->serialize(fpath);
 
-        logger->trace("Serialized {}", fpath);
+            logger->trace("Serialized {}", fpath);
+        }
     }
 
     utils::remove_temp_dir(tmp_path);

--- a/metagraph/tests/annotation/test_converters.cpp
+++ b/metagraph/tests/annotation/test_converters.cpp
@@ -249,6 +249,7 @@ TEST(RowDiff, ConvertFromColumnCompressedEmpty) {
     graph->serialize(graph_fname);
 
     convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir);
+    convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir, true);
 
     const std::string dest_fname = dst_dir/(std::string("ACGTCAG") + RowDiffColumnAnnotator::kExtension);
     ASSERT_TRUE(std::filesystem::exists(dest_fname));
@@ -289,6 +290,7 @@ TEST(RowDiff, ConvertFromColumnCompressedSameLabels) {
             source_annot.serialize(annot_fname);
 
             convert_to_row_diff({ annot_fname }, graph_fname, 1e9, max_depth, dst_dir);
+            convert_to_row_diff({ annot_fname }, graph_fname, 1e9, max_depth, dst_dir, true);
 
             ASSERT_TRUE(std::filesystem::exists(dest_fname));
             RowDiffColumnAnnotator annotator;
@@ -296,7 +298,7 @@ TEST(RowDiff, ConvertFromColumnCompressedSameLabels) {
             const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
                     .set_graph(graph.get());
             const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
-                    .load_anchor(graph_fname + binmat::kRowDiffAnchorExt + ".unopt");
+                    .load_anchor(graph_fname + binmat::kRowDiffAnchorExt);
 
             ASSERT_EQ(labels.size(), annotator.num_labels());
             ASSERT_EQ(5u, annotator.num_objects());
@@ -341,6 +343,7 @@ TEST(RowDiff, ConvertFromColumnCompressedSameLabelsMultipleColumns) {
             }
 
             convert_to_row_diff(annot_fnames, graph_fname, 1e9, max_depth, dst_dir);
+            convert_to_row_diff(annot_fnames, graph_fname, 1e9, max_depth, dst_dir, true);
 
             for (uint32_t i = 0; i < labels.size(); ++i) {
                 std::string rd_anno = dst_dir/(labels[i] + RowDiffColumnAnnotator::kExtension);
@@ -350,7 +353,7 @@ TEST(RowDiff, ConvertFromColumnCompressedSameLabelsMultipleColumns) {
                 const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
                         .set_graph(graph.get());
                 const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
-                        .load_anchor(graph_fname + binmat::kRowDiffAnchorExt + ".unopt");
+                        .load_anchor(graph_fname + binmat::kRowDiffAnchorExt);
 
                 ASSERT_EQ(1, annotator.num_labels());
                 ASSERT_EQ(5u, annotator.num_objects());
@@ -400,6 +403,7 @@ void test_row_diff(uint32_t k,
     initial_annotation.serialize(annot_fname);
 
     convert_to_row_diff({ annot_fname }, graph_fname, 1e9, max_depth, dst_dir);
+    convert_to_row_diff({ annot_fname }, graph_fname, 1e9, max_depth, dst_dir, true);
 
     ASSERT_TRUE(std::filesystem::exists(dest_fname));
     RowDiffColumnAnnotator annotator;
@@ -407,7 +411,7 @@ void test_row_diff(uint32_t k,
     const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
             .set_graph(graph.get());
     const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
-            .load_anchor(graph_fname + binmat::kRowDiffAnchorExt + ".unopt");
+            .load_anchor(graph_fname + binmat::kRowDiffAnchorExt);
 
     ASSERT_EQ(all_labels.size(), annotator.num_labels());
     ASSERT_EQ(graph->num_nodes(), annotator.num_objects());
@@ -457,6 +461,7 @@ void test_row_diff_separate_columns(uint32_t k,
     }
 
     convert_to_row_diff(annot_fnames, graph_fname, 1e9, max_depth, dst_dir);
+    convert_to_row_diff(annot_fnames, graph_fname, 1e9, max_depth, dst_dir, true);
 
     for (const auto& [label, indices] : col_annotations) {
         const std::string dest_fname
@@ -467,7 +472,7 @@ void test_row_diff_separate_columns(uint32_t k,
         const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
                 .set_graph(graph.get());
         const_cast<binmat::RowDiff<binmat::ColumnMajor> &>(annotator.get_matrix())
-                .load_anchor(graph_fname + binmat::kRowDiffAnchorExt + ".unopt");
+                .load_anchor(graph_fname + binmat::kRowDiffAnchorExt);
 
         ASSERT_EQ(graph->num_nodes(), annotator.num_objects());
 


### PR DESCRIPTION
Don't dump columns that will anyway be redundant after anchor optimization.

Also other related speed optimizations.