### PR TITLE
Add `print_signature` support to server `/search` endpoint

### DIFF
--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -38,6 +38,7 @@ class GraphClientJson:
     def search(self, sequence: Union[str, Iterable[str]],
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
+               print_signature: bool = False,
                align: bool = False,
                **align_params) -> Tuple[JsonDict, str]:
         """See parameters for alignment `align_params` in align()"""
@@ -59,7 +60,8 @@ class GraphClientJson:
 
         param_dict = {"count_labels": True,
                       "discovery_fraction": discovery_threshold,
-                      "num_labels": top_labels}
+                      "num_labels": top_labels,
+                      "print_signature": print_signature}
 
         return self._json_seq_query(sequence, param_dict, "search")
 
@@ -139,12 +141,13 @@ class GraphClient:
     def search(self, sequence: Union[str, Iterable[str]],
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
+               print_signature: bool = False,
                align: bool = False,
                **align_params) -> pd.DataFrame:
         """See parameters for alignment `align_params` in align()"""
 
         json_obj = self._json_client.search(sequence, top_labels,
-                                            discovery_threshold,
+                                            discovery_threshold, print_signature,
                                             align, **align_params)
 
         return helpers.df_from_search_result(json_obj)
@@ -182,6 +185,7 @@ class MultiGraphClient:
     def search(self, sequence: Union[str, Iterable[str]],
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
+               print_signature: bool = False,
                align: bool = False,
                **align_params) -> Dict[str, pd.DataFrame]:
         """See parameters for alignment `align_params` in align()"""
@@ -189,7 +193,7 @@ class MultiGraphClient:
         result = {}
         for name, graph_client in self.graphs.items():
             result[name] = graph_client.search(sequence, top_labels,
-                                               discovery_threshold,
+                                               discovery_threshold, print_signature,
                                                align, **align_params)
 
         return result

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -226,6 +226,12 @@ class TestAPIClient(TestAPIBase):
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
 
+    def test_api_simple_query_w_signature_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, print_signature=True)
+        df = ret[self.graph_name]
+
+        self.assertEqual((self.sample_query_expected_rows, 4), df.shape)
+
     def test_api_simple_query_align_df(self):
         ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, align=True, min_exact_match=0.01)
         df = ret[self.graph_name]

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -97,6 +97,10 @@ std::string convert_query_response_to_json(const std::string &ret_str) {
             }
             sampleEntry["kmer_count"] = (int)atoi(entries[1].c_str());
 
+            if (entries.size() > 2) {
+                sampleEntry["signature"] = entries[2];
+            }
+
             res_obj["results"].append(sampleEntry);
         }
 
@@ -154,6 +158,7 @@ std::string process_search_request(const std::string &received_message,
     config.count_labels = true;
     config.num_top_labels = json.get("num_labels", config.num_top_labels).asInt();
     config.fast = json.get("fast", config.fast).asBool();
+    config.print_signature = json.get("print_signature", config.print_signature).asBool();
 
     std::unique_ptr<graph::align::DBGAlignerConfig> aligner_config;
     if (json.get("align", false).asBool()) {


### PR DESCRIPTION
👋  Hi there – very cool project. I'm experimenting with a use case where this is helpful for visually indicating which k-mers match the DBG vs. which are misses – the CLI `--print-signature` option accomplishes this, but there's no way to currently do that with the server.

This small patch adds support for sending a `print_signature: True` argument to the `/search` server endpoint (defaults to `False`), including in the Python client. 