### PR TITLE
Immediately serialize node weights when building graph

### DIFF
--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -102,6 +102,7 @@ add_compile_options(
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(
     -Wno-exit-time-destructors
+    -Wno-deprecated-declarations
   )
 
   if (NOT CMAKE_CXX_COMPILER_ID MATCHES "AppleClang")

--- a/metagraph/src/cli/build.cpp
+++ b/metagraph/src/cli/build.cpp
@@ -157,11 +157,12 @@ int build_graph(Config *config) {
         assert(graph_data.size());
 
         if (config->count_kmers) {
-            sdsl::int_vector<> kmer_counts;
+            sdsl::int_vector_buffer<> kmer_counts;
             graph_data.initialize_boss(boss_graph.get(), &kmer_counts);
             graph.reset(new DBGSuccinct(boss_graph.release(), config->graph_mode));
-            graph->add_extension(std::make_shared<NodeWeights>(std::move(kmer_counts)));
-            assert(graph->get_extension<NodeWeights>()->is_compatible(*graph));
+            NodeWeights::serialize(std::move(kmer_counts),
+                    utils::remove_suffix(config->outfbase, DBGSuccinct::kExtension)
+                                                            + DBGSuccinct::kExtension);
         } else {
             graph_data.initialize_boss(boss_graph.get());
             graph.reset(new DBGSuccinct(boss_graph.release(), config->graph_mode));

--- a/metagraph/src/graph/graph_extensions/node_weights.cpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.cpp
@@ -62,7 +62,7 @@ void NodeWeights::serialize(const std::string &filename_base) const {
     weights_.serialize(outstream);
 }
 
-    // serialize weights from buffer without loading all in RAM
+// serialize weights from buffer without loading all in RAM
 void NodeWeights::serialize(sdsl::int_vector_buffer<>&& weights,
                             const std::string &filename_base) {
     const auto fname

--- a/metagraph/src/graph/graph_extensions/node_weights.cpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.cpp
@@ -68,7 +68,7 @@ void NodeWeights::serialize(sdsl::int_vector_buffer<>&& weights,
         = utils::remove_suffix(filename_base, kWeightsExtension)
                                         + kWeightsExtension;
     const std::string old_fname = weights.filename();
-    weights.close(false);
+    weights.close(false); // close without removing the file
     fs::rename(old_fname, fname);
 }
 

--- a/metagraph/src/graph/graph_extensions/node_weights.cpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.cpp
@@ -62,7 +62,6 @@ void NodeWeights::serialize(const std::string &filename_base) const {
     weights_.serialize(outstream);
 }
 
-// serialize weights from buffer without loading all in RAM
 void NodeWeights::serialize(sdsl::int_vector_buffer<>&& weights,
                             const std::string &filename_base) {
     const auto fname

--- a/metagraph/src/graph/graph_extensions/node_weights.hpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.hpp
@@ -37,7 +37,7 @@ class NodeWeights : public SequenceGraph::GraphExtension {
 
     bool load(const std::string &filename_base);
     void serialize(const std::string &filename_base) const;
-    // serialize weights from buffer without loading all in RAM
+    // serialize weights from buffer |weights| without loading all in RAM
     static void serialize(sdsl::int_vector_buffer<>&& weights,
                           const std::string &filename_base);
 

--- a/metagraph/src/graph/graph_extensions/node_weights.hpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.hpp
@@ -5,6 +5,7 @@
 #include <memory>
 
 #include <sdsl/int_vector.hpp>
+#include <sdsl/int_vector_buffer.hpp>
 
 #include "graph/representation/base/sequence_graph.hpp"
 #include "common/vectors/bitmap.hpp"
@@ -36,6 +37,9 @@ class NodeWeights : public SequenceGraph::GraphExtension {
 
     bool load(const std::string &filename_base);
     void serialize(const std::string &filename_base) const;
+    // serialize weights from buffer without loading all in RAM
+    static void serialize(sdsl::int_vector_buffer<>&& weights,
+                          const std::string &filename_base);
 
     bool is_compatible(const SequenceGraph &graph, bool verbose = true) const;
 

--- a/metagraph/src/graph/representation/succinct/boss_chunk.cpp
+++ b/metagraph/src/graph/representation/succinct/boss_chunk.cpp
@@ -269,7 +269,7 @@ void BOSS::Chunk::extend(Chunk &other) {
     assert(!weights_.size() || weights_.size() == W_.size());
 }
 
-void BOSS::Chunk::initialize_boss(BOSS *graph, sdsl::int_vector<> *weights) {
+void BOSS::Chunk::initialize_boss(BOSS *graph, sdsl::int_vector_buffer<> *weights) {
     assert(last_.size() == W_.size());
     assert(!weights_.size() || weights_.size() == W_.size());
 
@@ -278,16 +278,15 @@ void BOSS::Chunk::initialize_boss(BOSS *graph, sdsl::int_vector<> *weights) {
     assert(graph->is_valid());
 
     if (weights) {
-        weights_.flush();
-        std::ifstream in(weights_.filename(), std::ios::binary);
-        weights->load(in);
+        *weights = sdsl::int_vector_buffer<>();
+        weights->swap(weights_);
     }
 }
 
 BOSS*
 BOSS::Chunk::build_boss_from_chunks(const std::vector<std::string> &chunk_filenames,
                                     bool verbose,
-                                    sdsl::int_vector<> *weights,
+                                    sdsl::int_vector_buffer<> *weights,
                                     const std::string &swap_dir) {
     assert(chunk_filenames.size());
 

--- a/metagraph/src/graph/representation/succinct/boss_chunk.hpp
+++ b/metagraph/src/graph/representation/succinct/boss_chunk.hpp
@@ -76,7 +76,7 @@ class BOSS::Chunk {
     bool load(const std::string &filename_base);
     void serialize(const std::string &filename_base);
 
-    void initialize_boss(BOSS *graph, sdsl::int_vector<> *weights = nullptr);
+    void initialize_boss(BOSS *graph, sdsl::int_vector_buffer<> *weights = nullptr);
 
     /**
      * Merge BOSS chunks loaded from the files passed in #chunk_filenames and construct
@@ -85,7 +85,7 @@ class BOSS::Chunk {
     static BOSS*
     build_boss_from_chunks(const std::vector<std::string> &chunk_filenames,
                            bool verbose = false,
-                           sdsl::int_vector<> *weights = nullptr,
+                           sdsl::int_vector_buffer<> *weights = nullptr,
                            const std::string &swap_dir = "");
 
     static constexpr auto kFileExtension = ".dbg.chunk";

--- a/metagraph/src/graph/representation/succinct/boss_construct.hpp
+++ b/metagraph/src/graph/representation/succinct/boss_construct.hpp
@@ -34,7 +34,7 @@ class BOSSConstructor : public IGraphConstructor<BOSS> {
         chunk.initialize_boss(graph);
     }
 
-    void build_graph(BOSS *graph, sdsl::int_vector<> *weights) {
+    void build_graph(BOSS *graph, sdsl::int_vector_buffer<> *weights) {
         auto chunk = constructor_->build_chunk();
         // initialize graph from the chunk built
         chunk.initialize_boss(graph, weights);
@@ -44,7 +44,7 @@ class BOSSConstructor : public IGraphConstructor<BOSS> {
 
     static BOSS* build_graph_from_chunks(const std::vector<std::string> &chunk_filenames,
                                          bool verbose = false,
-                                         sdsl::int_vector<> *weights = nullptr) {
+                                         sdsl::int_vector_buffer<> *weights = nullptr) {
         return BOSS::Chunk::build_boss_from_chunks(chunk_filenames, verbose, weights);
     }
 

--- a/metagraph/tests/graph/succinct/test_boss_construct.cpp
+++ b/metagraph/tests/graph/succinct/test_boss_construct.cpp
@@ -158,7 +158,7 @@ TEST(WeightedBOSSConstruct, ConstructionDummyKmersZeroWeight) {
             constructor.add_sequences(std::vector<std::string>(input_data));
 
             BOSS constructed;
-            sdsl::int_vector<> weights;
+            sdsl::int_vector_buffer<> weights;
             constructor.build_graph(&constructed, &weights);
 
             ASSERT_EQ(constructed.num_edges() + 1, weights.size());
@@ -199,7 +199,7 @@ TEST(WeightedBOSSConstruct, ConstructionDummyKmersZeroWeightChunks) {
 
             BOSS::Chunk chunk = constructor->build_chunk();
 
-            sdsl::int_vector<> weights;
+            sdsl::int_vector_buffer<> weights;
             chunk.initialize_boss(&constructed, &weights);
 
             ASSERT_EQ(constructed.num_edges() + 1, weights.size());


### PR DESCRIPTION
Reduce RAM usage by not loading the node weights in RAM