### PR TITLE
optimized parallelization: annotate sequence batches

### DIFF
--- a/metagraph/integration_tests/test_annotate.py
+++ b/metagraph/integration_tests/test_annotate.py
@@ -59,14 +59,12 @@ class TestAnnotate(unittest.TestCase):
 
         for anno_repr in ['row', 'column']:
             # build annotation
-            annotate_command = '{exe} annotate --anno-header -i {graph} \
-                    --anno-type {anno_repr} -o {outfile} {input}'.format(
-                exe=METAGRAPH,
-                graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-                anno_repr=anno_repr,
-                outfile=self.tempdir.name + '/annotation',
-                input=TEST_DATA_DIR + '/transcripts_100.fa'
-            )
+            annotate_command = f'{METAGRAPH} annotate --anno-header -p {NUM_THREADS} \
+                                -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                                --anno-type {anno_repr} \
+                                -o {self.tempdir.name}/annotation \
+                                {TEST_DATA_DIR}/transcripts_100.fa'
+
             res = subprocess.run([annotate_command], shell=True)
             self.assertEqual(res.returncode, 0)
 
@@ -113,14 +111,11 @@ class TestAnnotate(unittest.TestCase):
 
         for anno_repr in ['row', 'column']:
             # build annotation
-            annotate_command = '{exe} annotate --anno-header -i {graph} \
-                    --anno-type {anno_repr} -o {outfile} {input}'.format(
-                exe=METAGRAPH,
-                graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-                anno_repr=anno_repr,
-                outfile=self.tempdir.name + '/annotation',
-                input=TEST_DATA_DIR + '/transcripts_100.fa'
-            )
+            annotate_command = f'{METAGRAPH} annotate --anno-header -p {NUM_THREADS} \
+                                -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                                --anno-type {anno_repr} -o {self.tempdir.name}/annotation \
+                                {TEST_DATA_DIR}/transcripts_100.fa'
+
             res = subprocess.run([annotate_command], shell=True)
             self.assertEqual(res.returncode, 0)
 
@@ -143,14 +138,10 @@ class TestAnnotate(unittest.TestCase):
         Annotate non-canonical graph constructed from non-canonical KMC database
         """
 
-        construct_command = '{exe} build --mask-dummy -p {num_threads} \
-                --graph {repr} -k 11 -o {outfile} {input}'.format(
-            exe=METAGRAPH,
-            num_threads=NUM_THREADS,
-            repr=graph_repr,
-            outfile=self.tempdir.name + '/graph',
-            input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters.kmc_suf'
-        )
+        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+                            --graph {graph_repr} -k 11 \
+                            -o {self.tempdir.name}/graph \
+                            {TEST_DATA_DIR}/transcripts_1000_kmc_counters.kmc_suf'
 
         res = subprocess.run([construct_command], shell=True)
         self.assertEqual(res.returncode, 0)
@@ -168,14 +159,11 @@ class TestAnnotate(unittest.TestCase):
 
         for anno_repr in ['row', 'column']:
             # build annotation
-            annotate_command = '{exe} annotate --anno-label LabelName -i {graph} \
-                    --anno-type {anno_repr} -o {outfile} {input}'.format(
-                exe=METAGRAPH,
-                graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-                anno_repr=anno_repr,
-                outfile=self.tempdir.name + '/annotation',
-                input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters.kmc_suf'
-            )
+            annotate_command = f'{METAGRAPH} annotate --anno-label LabelName -p {NUM_THREADS} \
+                                -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                                --anno-type {anno_repr} -o {self.tempdir.name}/annotation \
+                                {TEST_DATA_DIR}/transcripts_1000_kmc_counters.kmc_suf'
+
             res = subprocess.run([annotate_command], shell=True)
             self.assertEqual(res.returncode, 0)
 
@@ -198,14 +186,10 @@ class TestAnnotate(unittest.TestCase):
         Annotate non-canonical graph constructed from canonical KMC database
         """
 
-        construct_command = '{exe} build --mask-dummy -p {num_threads} \
-                --graph {repr} -k 11 -o {outfile} {input}'.format(
-            exe=METAGRAPH,
-            num_threads=NUM_THREADS,
-            repr=graph_repr,
-            outfile=self.tempdir.name + '/graph',
-            input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters_both_strands.kmc_suf'
-        )
+        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+                            --graph {graph_repr} -k 11 \
+                            -o {self.tempdir.name}/graph \
+                            {TEST_DATA_DIR}/transcripts_1000_kmc_counters_both_strands.kmc_suf'
 
         res = subprocess.run([construct_command], shell=True)
         self.assertEqual(res.returncode, 0)
@@ -223,14 +207,11 @@ class TestAnnotate(unittest.TestCase):
 
         for anno_repr in ['row', 'column']:
             # build annotation
-            annotate_command = '{exe} annotate --anno-label LabelName -i {graph} \
-                    --anno-type {anno_repr} -o {outfile} {input}'.format(
-                exe=METAGRAPH,
-                graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-                anno_repr=anno_repr,
-                outfile=self.tempdir.name + '/annotation_single',
-                input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters.kmc_suf'
-            )
+            annotate_command = f'{METAGRAPH} annotate --anno-label LabelName -p {NUM_THREADS} \
+                                -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                                --anno-type {anno_repr} -o {self.tempdir.name}/annotation_single \
+                                {TEST_DATA_DIR}/transcripts_1000_kmc_counters.kmc_suf'
+
             res = subprocess.run([annotate_command], shell=True)
             self.assertEqual(res.returncode, 0)
 
@@ -248,14 +229,11 @@ class TestAnnotate(unittest.TestCase):
             self.assertEqual('representation: ' + anno_repr, params_str[3])
 
             # both strands
-            annotate_command = '{exe} annotate --anno-label LabelName -i {graph} \
-                    --anno-type {anno_repr} -o {outfile} {input}'.format(
-                exe=METAGRAPH,
-                graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-                anno_repr=anno_repr,
-                outfile=self.tempdir.name + '/annotation_both',
-                input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters_both_strands.kmc_suf'
-            )
+            annotate_command = f'{METAGRAPH} annotate --anno-label LabelName -p {NUM_THREADS} \
+                                -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                                --anno-type {anno_repr} -o {self.tempdir.name}/annotation_both \
+                                {TEST_DATA_DIR}/transcripts_1000_kmc_counters_both_strands.kmc_suf'
+
             res = subprocess.run([annotate_command], shell=True)
             self.assertEqual(res.returncode, 0)
 
@@ -280,14 +258,10 @@ class TestAnnotate(unittest.TestCase):
         Annotate canonical graph with k-mers from KMC
         """
 
-        construct_command = '{exe} build --mask-dummy -p {num_threads} \
-                --graph {repr} --mode canonical -k 11 -o {outfile} {input}'.format(
-            exe=METAGRAPH,
-            num_threads=NUM_THREADS,
-            repr=graph_repr,
-            outfile=self.tempdir.name + '/graph',
-            input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters.kmc_suf'
-        )
+        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+                            --graph {graph_repr} --mode canonical -k 11 \
+                            -o {self.tempdir.name}/graph \
+                            {TEST_DATA_DIR}/transcripts_1000_kmc_counters.kmc_suf'
 
         res = subprocess.run([construct_command], shell=True)
         self.assertEqual(res.returncode, 0)
@@ -305,14 +279,11 @@ class TestAnnotate(unittest.TestCase):
 
         for anno_repr in ['row', 'column']:
             # build annotation
-            annotate_command = '{exe} annotate --anno-label LabelName -i {graph} \
-                    --anno-type {anno_repr} -o {outfile} {input}'.format(
-                exe=METAGRAPH,
-                graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-                anno_repr=anno_repr,
-                outfile=self.tempdir.name + '/annotation_single',
-                input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters.kmc_suf'
-            )
+            annotate_command = f'{METAGRAPH} annotate --anno-label LabelName -p {NUM_THREADS} \
+                                -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                                --anno-type {anno_repr} -o {self.tempdir.name}/annotation_single \
+                                {TEST_DATA_DIR}/transcripts_1000_kmc_counters.kmc_suf'
+
             res = subprocess.run([annotate_command], shell=True)
             self.assertEqual(res.returncode, 0)
 
@@ -330,14 +301,11 @@ class TestAnnotate(unittest.TestCase):
             self.assertEqual('representation: ' + anno_repr, params_str[3])
 
             # both strands
-            annotate_command = '{exe} annotate --anno-label LabelName -i {graph} \
-                    --anno-type {anno_repr} -o {outfile} {input}'.format(
-                exe=METAGRAPH,
-                graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-                anno_repr=anno_repr,
-                outfile=self.tempdir.name + '/annotation_both',
-                input=TEST_DATA_DIR + '/transcripts_1000_kmc_counters_both_strands.kmc_suf'
-            )
+            annotate_command = f'{METAGRAPH} annotate --anno-label LabelName -p {NUM_THREADS} \
+                                -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                                --anno-type {anno_repr} -o {self.tempdir.name}/annotation_both \
+                                {TEST_DATA_DIR}/transcripts_1000_kmc_counters_both_strands.kmc_suf'
+
             res = subprocess.run([annotate_command], shell=True)
             self.assertEqual(res.returncode, 0)
 
@@ -382,16 +350,12 @@ class TestAnnotate(unittest.TestCase):
         self.assertEqual('mode: basic', params_str[2])
 
         # build annotation
-        annotate_command = '{exe} annotate --anno-header -i {graph} \
-                --disk-swap {tmp_dir} --mem-cap-gb 1e-6 \
-                --anno-type {anno_repr} -o {outfile} {input}'.format(
-            exe=METAGRAPH,
-            graph=self.tempdir.name + '/graph' + graph_file_extension[graph_repr],
-            anno_repr=anno_repr,
-            tmp_dir=self.tempdir.name,
-            outfile=self.tempdir.name + '/annotation',
-            input=TEST_DATA_DIR + '/transcripts_100.fa'
-        )
+        annotate_command = f'{METAGRAPH} annotate --anno-header \
+                            --disk-swap {self.tempdir.name} --mem-cap-gb 1e-6 \
+                            -i {self.tempdir.name}/graph{graph_file_extension[graph_repr]} \
+                            --anno-type {anno_repr} -o {self.tempdir.name}/annotation \
+                            {TEST_DATA_DIR}/transcripts_100.fa'
+
         res = subprocess.run([annotate_command], shell=True)
         self.assertEqual(res.returncode, 0)
 

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -289,14 +289,10 @@ convert_row_diff_to_BRWT(RowDiffColumnAnnotator &&annotator,
                          BRWTBottomUpBuilder::Partitioner partitioning,
                          size_t num_parallel_nodes,
                          size_t num_threads) {
-    // we are going to take the columns from the annotator and thus
-    // have to replace them with empty columns to keep the structure valid
     const graph::DBGSuccinct* graph = annotator.get_matrix().graph();
-    std::vector<std::unique_ptr<bit_vector>> columns
-            = annotator.release_matrix()->diffs().release_columns();
 
     auto matrix = std::make_unique<BRWT>(
-            BRWTBottomUpBuilder::build(std::move(columns),
+            BRWTBottomUpBuilder::build(std::move(annotator.release_matrix()->diffs().data()),
                                        partitioning,
                                        num_parallel_nodes,
                                        num_threads)

--- a/metagraph/src/annotation/binary_matrix/column_sparse/column_major.hpp
+++ b/metagraph/src/annotation/binary_matrix/column_sparse/column_major.hpp
@@ -15,6 +15,8 @@ class ColumnMajor : public BinaryMatrix {
   public:
     ColumnMajor() {}
     ColumnMajor(std::vector<std::unique_ptr<bit_vector>>&& columns);
+    ColumnMajor(const std::vector<std::unique_ptr<bit_vector>> &columns)
+        : columns_(&columns) {}
     ColumnMajor(ColumnMajor&& other);
 
     uint64_t num_columns() const override { return columns_->size(); }
@@ -39,10 +41,6 @@ class ColumnMajor : public BinaryMatrix {
     sum_rows(const std::vector<std::pair<Row, size_t>> &index_counts,
              size_t min_count = 1,
              size_t count_cap = std::numeric_limits<size_t>::max()) const override;
-
-    void update_pointer(const std::vector<std::unique_ptr<bit_vector>> &columns) {
-        columns_ = &columns;
-    }
 
     const auto& data() const { return *columns_; }
 

--- a/metagraph/src/annotation/binary_matrix/column_sparse/column_major.hpp
+++ b/metagraph/src/annotation/binary_matrix/column_sparse/column_major.hpp
@@ -14,12 +14,10 @@ namespace binmat {
 class ColumnMajor : public BinaryMatrix {
   public:
     ColumnMajor() {}
-    ColumnMajor(std::vector<std::unique_ptr<bit_vector>>&& columns);
-    ColumnMajor(const std::vector<std::unique_ptr<bit_vector>> &columns)
-        : columns_(&columns) {}
-    ColumnMajor(ColumnMajor&& other);
+    ColumnMajor(std::vector<std::unique_ptr<bit_vector>>&& columns)
+        : columns_(std::move(columns)) {}
 
-    uint64_t num_columns() const override { return columns_->size(); }
+    uint64_t num_columns() const override { return columns_.size(); }
     uint64_t num_rows() const override;
 
     bool get(Row row, Column column) const override;
@@ -42,18 +40,11 @@ class ColumnMajor : public BinaryMatrix {
              size_t min_count = 1,
              size_t count_cap = std::numeric_limits<size_t>::max()) const override;
 
-    const auto& data() const { return *columns_; }
-
-    /**
-     * Returns the columns vector and pilfers the existing columns.
-     */
-    std::vector<std::unique_ptr<bit_vector>> release_columns() {
-        return std::move(data_);
-    }
+    auto& data() { return columns_; }
+    const auto& data() const { return columns_; }
 
   private:
-    std::vector<std::unique_ptr<bit_vector>> data_;
-    const std::vector<std::unique_ptr<bit_vector>> *columns_ = &data_;
+    std::vector<std::unique_ptr<bit_vector>> columns_;
 };
 
 } // namespace binmat

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -187,7 +187,7 @@ bool merge_load_row_diff(const std::vector<std::string> &filenames,
             if (!label_encoder.size())
                 common::logger->warn("No labels in {}", filenames[i]);
 
-            std::vector<std::unique_ptr<bit_vector>> cols = matrix.diffs().release_columns();
+            std::vector<std::unique_ptr<bit_vector>> &cols = matrix.diffs().data();
 
             for (uint32_t j = 0; j < cols.size(); ++j) {
                 callback(offsets[i] + j, label_encoder.decode(j), std::move(cols[j]));

--- a/metagraph/src/annotation/representation/base/annotation.hpp
+++ b/metagraph/src/annotation/representation/base/annotation.hpp
@@ -49,7 +49,8 @@ class MultiLabelAnnotation
 
     virtual void add_labels(const std::vector<Index> &indices,
                             const VLabels &labels) = 0;
-    // for each label and index 'indices[i]' add count 'counts[i]'
+    // For each label and index 'indices[i]' add count 'counts[i]'
+    // Note: must be thread-safe
     virtual void add_label_counts(const std::vector<Index> &indices,
                                   const VLabels &labels,
                                   const std::vector<uint64_t> &counts);

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -106,6 +106,7 @@ void ColumnCompressed<Label>::add_labels(const std::vector<Index> &indices,
 }
 
 // for each label and index 'indices[i]' add count 'counts[i]'
+// thread-safe
 template <typename Label>
 void ColumnCompressed<Label>::add_label_counts(const std::vector<Index> &indices,
                                                const VLabels &labels,
@@ -114,11 +115,20 @@ void ColumnCompressed<Label>::add_label_counts(const std::vector<Index> &indices
 
     const auto &columns = get_matrix().data();
 
-    if (relation_counts_.size() != columns.size())
-        relation_counts_.resize(columns.size());
-
     for (const auto &label : labels) {
         const auto j = label_encoder_.encode(label);
+
+        std::vector<uint64_t> ranks(indices.size());
+        for (size_t i = 0; i < indices.size(); ++i) {
+            if (!(ranks[i] = columns[j]->conditional_rank1(indices[i])))
+                logger->warn("Trying to add count {} for non-annotated object {}."
+                             " The count will be ignored.", counts[i], indices[i]);
+        }
+
+        std::unique_lock<std::mutex> lock(counts_mu_);
+
+        if (relation_counts_.size() != columns.size())
+            relation_counts_.resize(columns.size());
 
         if (!relation_counts_[j].size()) {
             relation_counts_[j] = sdsl::int_vector<>(columns[j]->num_set_bits(), 0, count_width_);
@@ -129,14 +139,10 @@ void ColumnCompressed<Label>::add_label_counts(const std::vector<Index> &indices
         }
 
         for (size_t i = 0; i < indices.size(); ++i) {
-            if (uint64_t rank = columns[j]->conditional_rank1(indices[i])) {
+            if (ranks[i]) {
                 uint64_t count = std::min(counts[i], max_count_);
-                sdsl::int_vector_reference<sdsl::int_vector<>> ref = relation_counts_[j][rank - 1];
+                auto ref = relation_counts_[j][ranks[i] - 1];
                 ref = std::min((uint64_t)ref, max_count_ - count) + count;
-
-            } else {
-                logger->warn("Trying to add count {} for non-annotated object {}."
-                             " The count was ignored.", counts[i], indices[i]);
             }
         }
     }
@@ -748,7 +754,6 @@ const bitmap& ColumnCompressed<Label>::get_column(const Label &label) const {
 template <typename Label>
 const binmat::ColumnMajor& ColumnCompressed<Label>::get_matrix() const {
     flush();
-    annotation_matrix_view_.update_pointer(bitmatrix_);
     return annotation_matrix_view_;
 }
 

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -754,14 +754,14 @@ const bitmap& ColumnCompressed<Label>::get_column(const Label &label) const {
 template <typename Label>
 const binmat::ColumnMajor& ColumnCompressed<Label>::get_matrix() const {
     flush();
-    return annotation_matrix_view_;
+    return matrix_;
 }
 
 template <typename Label>
 binmat::ColumnMajor ColumnCompressed<Label>::release_matrix() {
     flush();
     label_encoder_.clear();
-    return binmat::ColumnMajor(std::move(bitmatrix_));
+    return std::move(matrix_);
 }
 
 template <typename Label>

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -118,7 +118,7 @@ void ColumnCompressed<Label>::add_label_counts(const std::vector<Index> &indices
         relation_counts_.resize(columns.size());
 
     for (const auto &label : labels) {
-        const auto j = label_encoder_.insert_and_encode(label);
+        const auto j = label_encoder_.encode(label);
 
         if (!relation_counts_[j].size()) {
             relation_counts_[j] = sdsl::int_vector<>(columns[j]->num_set_bits(), 0, count_width_);

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
@@ -17,7 +17,7 @@ namespace annot {
 
 /**
  * Multithreading:
- *  The non-const methods must be called sequentially.
+ *  The non-const methods must be called sequentially (except add_label_counts).
  *  Then, any subset of the public const methods can be called concurrently.
  */
 template <typename Label = std::string>
@@ -59,6 +59,7 @@ class ColumnCompressed : public MultiLabelEncoded<Label> {
     void add_labels(const std::vector<Index> &indices,
                     const VLabels &labels) override;
     // for each label and index 'indices[i]' add count 'counts[i]'
+    // thread-safe
     void add_label_counts(const std::vector<Index> &indices,
                           const VLabels &labels,
                           const std::vector<uint64_t> &counts) override;
@@ -133,7 +134,7 @@ class ColumnCompressed : public MultiLabelEncoded<Label> {
     const uint64_t buffer_size_bytes_;
 
     std::vector<std::unique_ptr<bit_vector>> bitmatrix_;
-    mutable binmat::ColumnMajor annotation_matrix_view_;
+    binmat::ColumnMajor annotation_matrix_view_ { bitmatrix_ };
 
     mutable std::mutex bitmap_conversion_mu_;
     mutable bool flushed_ = true;
@@ -142,6 +143,7 @@ class ColumnCompressed : public MultiLabelEncoded<Label> {
                               bitmap_builder*,
                               caches::LRUCachePolicy<size_t>> cached_columns_;
 
+    mutable std::mutex counts_mu_;
     uint8_t count_width_;
     uint64_t max_count_;
     std::vector<sdsl::int_vector<>> relation_counts_;

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
@@ -133,8 +133,8 @@ class ColumnCompressed : public MultiLabelEncoded<Label> {
     const std::string swap_dir_;
     const uint64_t buffer_size_bytes_;
 
-    std::vector<std::unique_ptr<bit_vector>> bitmatrix_;
-    binmat::ColumnMajor annotation_matrix_view_ { bitmatrix_ };
+    binmat::ColumnMajor matrix_;
+    std::vector<std::unique_ptr<bit_vector>> &bitmatrix_ { matrix_.data() };
 
     mutable std::mutex bitmap_conversion_mu_;
     mutable bool flushed_ = true;

--- a/metagraph/src/cli/annotate.cpp
+++ b/metagraph/src/cli/annotate.cpp
@@ -218,6 +218,7 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
 
     ThreadPool thread_pool(get_num_threads() > 1 ? get_num_threads() : 0);
 
+    // not too small, not too large
     const size_t batch_size = 1'000;
     const size_t batch_length = 100'000;
 
@@ -264,7 +265,9 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
                                                      std::vector<std::string>,
                                                      std::vector<uint64_t>>>;
                 thread_pool.enqueue([&](Batch &data) {
-                    anno_graph->add_kmer_counts(std::move(data));
+                    for (auto &[seq, labels, kmer_counts] : data) {
+                        anno_graph->add_kmer_counts(seq, labels, std::move(kmer_counts));
+                    }
                 }, std::move(data));
             },
             batch_size, batch_length, batch_size

--- a/metagraph/src/cli/annotate.cpp
+++ b/metagraph/src/cli/annotate.cpp
@@ -218,6 +218,9 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
 
     ThreadPool thread_pool(get_num_threads() > 1 ? get_num_threads() : 0);
 
+    const size_t batch_size = 1'000;
+    const size_t batch_length = 100'000;
+
     // iterate over input files
     for (const auto &file : files) {
         BatchAccumulator<std::pair<std::string, std::vector<std::string>>> batcher(
@@ -226,7 +229,7 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
                     anno_graph->annotate_sequences(std::move(data));
                 }, std::move(data));
             },
-            1'000, 100'000
+            batch_size, batch_length, batch_size
         );
         call_annotations(
             file,
@@ -264,7 +267,7 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
                     anno_graph->add_kmer_counts(std::move(data));
                 }, std::move(data));
             },
-            1'000, 100'000
+            batch_size, batch_length, batch_size
         );
 
         for (const auto &file : files) {

--- a/metagraph/src/cli/annotate.cpp
+++ b/metagraph/src/cli/annotate.cpp
@@ -4,6 +4,7 @@
 
 #include "common/logger.hpp"
 #include "common/unix_tools.hpp"
+#include "common/batch_accumulator.hpp"
 #include "common/threads/threading.hpp"
 #include "annotation/representation/row_compressed/annotate_row_compressed.hpp"
 #include "seq_io/formats.hpp"
@@ -205,6 +206,7 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
                    const std::vector<std::string> &files,
                    const std::string &annotator_filename) {
     auto anno_graph = initialize_annotated_dbg(graph, config);
+    const size_t k = anno_graph->get_graph().get_k();
 
     bool forward_and_reverse = config.forward_and_reverse;
     if (anno_graph->get_graph().get_mode() == graph::DeBruijnGraph::CANONICAL) {
@@ -218,6 +220,14 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
 
     // iterate over input files
     for (const auto &file : files) {
+        BatchAccumulator<std::pair<std::string, std::vector<std::string>>> batcher(
+            [&](auto&& data) {
+                thread_pool.enqueue([&](auto &data) {
+                    anno_graph->annotate_sequences(std::move(data));
+                }, std::move(data));
+            },
+            1'000, 100'000
+        );
         call_annotations(
             file,
             config.refpath,
@@ -231,12 +241,10 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
             config.fasta_header_delimiter,
             config.anno_labels,
             [&](std::string sequence, auto labels) {
-                thread_pool.enqueue(
-                    [&anno_graph](const std::string &sequence, const auto &labels) {
-                        anno_graph->annotate_sequence(sequence, labels);
-                    },
-                    std::move(sequence), std::move(labels)
-                );
+                if (sequence.size() >= k) {
+                    batcher.push_and_pay(sequence.size(),
+                                         std::move(sequence), std::move(labels));
+                }
             }
         );
     }
@@ -245,7 +253,23 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
 
     if (config.count_kmers) {
         // add k-mer counts
+        BatchAccumulator<std::tuple<std::string,
+                                    std::vector<std::string>,
+                                    std::vector<uint64_t>>> batcher(
+            [&](auto&& data) {
+                using Batch = std::vector<std::tuple<std::string,
+                                                     std::vector<std::string>,
+                                                     std::vector<uint64_t>>>;
+                thread_pool.enqueue([&](Batch &data) {
+                    anno_graph->add_kmer_counts(std::move(data));
+                }, std::move(data));
+            },
+            1'000, 100'000
+        );
+
         for (const auto &file : files) {
+            logger->trace("Annotating k-mer counts for file {}", file);
+
             const std::string &counts_fname
                     = utils::remove_suffix(file, ".gz", ".fasta") + ".kmer_counts.gz";
 
@@ -262,14 +286,11 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
                     [&](std::string sequence,
                                 std::vector<std::string> labels,
                                 std::vector<uint64_t> kmer_counts) {
-                        thread_pool.enqueue(
-                            [&](std::string &sequence,
-                                    std::vector<std::string> &labels,
-                                    std::vector<uint64_t> &kmer_counts) {
-                                anno_graph->add_kmer_counts(sequence, labels, std::move(kmer_counts));
-                            },
-                            std::move(sequence), std::move(labels), std::move(kmer_counts)
-                        );
+                        if (sequence.size() >= k) {
+                            batcher.push_and_pay(sequence.size(),
+                                                 std::move(sequence), std::move(labels),
+                                                 std::move(kmer_counts));
+                        }
                     }
                 );
             } else {
@@ -288,16 +309,11 @@ void annotate_data(std::shared_ptr<graph::DeBruijnGraph> graph,
                     config.fasta_header_delimiter,
                     config.anno_labels,
                     [&](std::string sequence, auto labels) {
-                        thread_pool.enqueue(
-                            [&anno_graph](const std::string &sequence, const auto &labels) {
-                                const size_t k = anno_graph->get_graph().get_k();
-                                if (sequence.size() >= k) {
-                                    anno_graph->add_kmer_counts(sequence, labels,
-                                        std::vector<uint64_t>(sequence.size() - k + 1, 1));
-                                }
-                            },
-                            std::move(sequence), std::move(labels)
-                        );
+                        if (sequence.size() >= k) {
+                            batcher.push_and_pay(sequence.size(),
+                                                 std::move(sequence), std::move(labels),
+                                                 std::vector<uint64_t>(sequence.size() - k + 1, 1));
+                        }
                     }
                 );
             }

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -74,34 +74,34 @@ void AnnotatedSequenceGraph
 ::annotate_sequences(const std::vector<std::pair<std::string, std::vector<Label>>> &data) {
     assert(check_compatibility());
 
-    std::vector<std::vector<row_index>> indices(data.size());
+    std::vector<std::vector<row_index>> ids(data.size());
     size_t last = 0;
     for (size_t t = 0; t < data.size(); ++t) {
         // if the labels are the same, write indexes to the same array
-        auto &ids = data[t].second == data[last].second ? indices[last] : indices[t];
-        ids.reserve(data[t].first.size());
+        auto &indices = data[t].second == data[last].second ? ids[last] : ids[t];
+        indices.reserve(data[t].first.size());
 
         graph_->map_to_nodes(data[t].first, [&](node_index i) {
             if (i > 0)
-                ids.push_back(graph_to_anno_index(i));
+                indices.push_back(graph_to_anno_index(i));
         });
     }
 
     std::lock_guard<std::mutex> lock(mutex_);
 
     for (size_t t = 0; t < data.size(); ++t) {
-        if (!indices[t].size())
+        if (!ids[t].size())
             continue;
 
         if (force_fast_) {
             auto row_major = dynamic_cast<annot::RowCompressed<Label>*>(annotator_.get());
             if (row_major) {
-                row_major->add_labels_fast(indices[t], data[t].second);
+                row_major->add_labels_fast(ids[t], data[t].second);
                 continue;
             }
         }
 
-        annotator_->add_labels(indices[t], data[t].second);
+        annotator_->add_labels(ids[t], data[t].second);
     }
 }
 

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -128,12 +128,8 @@ void AnnotatedDBG::add_kmer_counts(std::string_view sequence,
 
     kmer_counts.resize(end);
 
-    if (!indices.size())
-        return;
-
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    annotator_->add_label_counts(indices, labels, kmer_counts);
+    if (indices.size())
+        annotator_->add_label_counts(indices, labels, kmer_counts);
 }
 
 void AnnotatedDBG::add_kmer_counts(std::vector<std::tuple<std::string,
@@ -164,8 +160,6 @@ void AnnotatedDBG::add_kmer_counts(std::vector<std::tuple<std::string,
 
         kmer_counts.resize(end);
     }
-
-    std::lock_guard<std::mutex> lock(mutex_);
 
     for (size_t t = 0; t < data.size(); ++t) {
         const auto &[_, labels, kmer_counts] = data[t];

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -77,7 +77,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
 
     const DeBruijnGraph& get_graph() const { return dbg_; }
 
-    // add k-mer counts to the annotation
+    // add k-mer counts to the annotation, thread-safe for concurrent calls
     void add_kmer_counts(std::string_view sequence,
                          const std::vector<Label> &labels,
                          std::vector<uint64_t>&& kmer_counts);

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -82,7 +82,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                          const std::vector<Label> &labels,
                          std::vector<uint64_t>&& kmer_counts);
 
-    // annotate k-mer counts from batch, thread-safe for concurrent calls
+    // add k-mer counts from batch, thread-safe for concurrent calls
     void add_kmer_counts(std::vector<std::tuple<std::string,
                                                 std::vector<Label>,
                                                 std::vector<uint64_t>>>&& data);

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -82,6 +82,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                          const std::vector<Label> &labels,
                          std::vector<uint64_t>&& kmer_counts);
 
+    // annotate k-mer counts from batch, thread-safe for concurrent calls
     void add_kmer_counts(std::vector<std::tuple<std::string,
                                                 std::vector<Label>,
                                                 std::vector<uint64_t>>>&& data);

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -82,11 +82,6 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                          const std::vector<Label> &labels,
                          std::vector<uint64_t>&& kmer_counts);
 
-    // add k-mer counts from batch, thread-safe for concurrent calls
-    void add_kmer_counts(std::vector<std::tuple<std::string,
-                                                std::vector<Label>,
-                                                std::vector<uint64_t>>>&& data);
-
     /*********************** Special queries **********************/
 
     // return labels that occur at least in |presence_ratio| k-mers

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -34,6 +34,9 @@ class AnnotatedSequenceGraph {
     // thread-safe, can be called from multiple threads concurrently
     virtual void annotate_sequence(std::string_view sequence,
                                    const std::vector<Label> &labels);
+    // thread-safe, can be called from multiple threads concurrently
+    virtual void annotate_sequences(
+        const std::vector<std::pair<std::string, std::vector<Label>>> &data);
 
     virtual void call_annotated_nodes(const Label &label,
                                       std::function<void(node_index)> callback) const;
@@ -78,6 +81,10 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
     void add_kmer_counts(std::string_view sequence,
                          const std::vector<Label> &labels,
                          std::vector<uint64_t>&& kmer_counts);
+
+    void add_kmer_counts(std::vector<std::tuple<std::string,
+                                                std::vector<Label>,
+                                                std::vector<uint64_t>>>&& data);
 
     /*********************** Special queries **********************/
 


### PR DESCRIPTION
* accumulate batches before annotating to reduce the overhead in the thread pool
* `add_label_counts` is now thread-safe
* added `annotate_sequences` for efficiently annotating batches in parallel
* streamlined ColumnMajor