### PR TITLE
improvements in RowSparse representations

### DIFF
--- a/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.cpp
@@ -19,19 +19,18 @@ RowSparse::RowSparse(const std::function<void(const RowCallback &)> &call_rows,
     sdsl::int_vector_buffer<> set_bits(tmp_dir/"vector", std::ios::out,
                                        1024 * 1024, col_index_width);
     sdsl::bit_vector boundary(num_relations + num_rows, 0);
-    uint64_t idx = 0;
     uint64_t b_idx = 0;
     call_rows([&](const auto &column_indices) {
         assert(std::is_sorted(column_indices.begin(), column_indices.end()));
         uint64_t last = 0;
         for (uint64_t col : column_indices) {
-            set_bits[idx++] = col - last;
+            set_bits.push_back(col - last);
             last = col;
             b_idx++;
         }
         boundary[b_idx++] = 1;
     });
-    assert(idx == num_relations);
+    assert(set_bits.size() == num_relations);
 
     boundary_ = bit_vector_small(boundary);
     set_bits_ = sdsl::vlc_vector<>(set_bits);

--- a/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.cpp
@@ -15,7 +15,7 @@ RowSparse::RowSparse(const std::function<void(const RowCallback &)> &call_rows,
       : num_columns_(num_columns),
         num_rows_(num_columns > 0 ? num_rows : 0) {
     const auto tmp_dir = utils::create_temp_dir(utils::get_swap_path(), "set_bits");
-    sdsl::int_vector_buffer<> set_bits(tmp_dir/"vector", std::ios::in | std::ios::out);
+    sdsl::int_vector_buffer<> set_bits(tmp_dir/"vector", std::ios::out);
     sdsl::bit_vector boundary(num_relations + num_rows, 0);
     uint64_t offset = 0;
     uint64_t idx = 0;

--- a/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.hpp
@@ -4,7 +4,7 @@
 #include <string>
 #include <vector>
 
-#include <sdsl/enc_vector.hpp>
+#include <sdsl/vlc_vector.hpp>
 
 #include "annotation/binary_matrix/base/binary_matrix.hpp"
 #include "common/vectors/bit_vector_adaptive.hpp"
@@ -35,10 +35,7 @@ class RowSparse : public BinaryMatrix {
     uint64_t num_relations() const override { return set_bits_.size(); }
 
   private:
-    // sdsl::enc_vector compresses deltas v[i]-v[i-1] with
-    // elias-type of coding, hence, it makes an assumption
-    // that the vector is sorted (or almost sorted).
-    sdsl::enc_vector<> set_bits_;
+    sdsl::vlc_vector<> set_bits_;
     bit_vector_small boundary_;
     uint64_t num_columns_ = 0;
     uint64_t num_rows_ = 0;

--- a/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_sparse/row_sparse.hpp
@@ -17,10 +17,9 @@ class RowSparse : public BinaryMatrix {
   public:
     RowSparse() {}
     RowSparse(const std::function<void(const RowCallback&)> &call_rows,
-                    uint64_t num_columns,
-                    uint64_t num_rows,
-                    uint64_t num_relations);
-    RowSparse(RowSparse &&) = default;
+              uint64_t num_columns,
+              uint64_t num_rows,
+              uint64_t num_relations);
 
     uint64_t num_columns() const override { return num_columns_; }
     uint64_t num_rows() const override { return num_rows_; }
@@ -33,15 +32,13 @@ class RowSparse : public BinaryMatrix {
     void serialize(std::ostream &out) const override;
 
     // number of ones in the matrix
-    uint64_t num_relations() const override { return elements_.size(); }
+    uint64_t num_relations() const override { return set_bits_.size(); }
 
   private:
     // sdsl::enc_vector compresses deltas v[i]-v[i-1] with
     // elias-type of coding, hence, it makes an assumption
     // that the vector is sorted (or almost sorted).
-    // Thus, this matrix representation compresses best dense
-    // matrices with many set bits per row.
-    sdsl::enc_vector<> elements_;
+    sdsl::enc_vector<> set_bits_;
     bit_vector_small boundary_;
     uint64_t num_columns_ = 0;
     uint64_t num_rows_ = 0;

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -363,6 +363,7 @@ Config::Config(int argc, char *argv[]) {
             filter_by_kmer = true;
         } else if (!strcmp(argv[i], "--disk-swap")) {
             tmp_dir = get_value(i++);
+            utils::set_swap_path(tmp_dir);
         } else if (!strcmp(argv[i], "--disk-cap-gb")) {
             disk_cap_bytes = atoi(get_value(i++)) * 1e9;
         } else if (argv[i][0] == '-') {

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -363,7 +363,6 @@ Config::Config(int argc, char *argv[]) {
             filter_by_kmer = true;
         } else if (!strcmp(argv[i], "--disk-swap")) {
             tmp_dir = get_value(i++);
-            utils::set_swap_path(tmp_dir);
         } else if (!strcmp(argv[i], "--disk-cap-gb")) {
             disk_cap_bytes = atoi(get_value(i++)) * 1e9;
         } else if (argv[i][0] == '-') {
@@ -453,8 +452,10 @@ Config::Config(int argc, char *argv[]) {
     }
 #endif
 
-    if (tmp_dir == "OUTFBASE_TEMP_DIR")
+    if (tmp_dir == "OUTFBASE_TEMP_DIR") {
         tmp_dir = std::filesystem::path(outfbase).remove_filename();
+    }
+    utils::set_swap_path(tmp_dir);
 
     if (identity != CONCATENATE
             && identity != STATS

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -18,8 +18,17 @@ namespace utils {
 
 using mtg::common::logger;
 
+std::filesystem::path SWAP_PATH;
 std::vector<std::string> TMP_DIRS;
 std::mutex TMP_DIRS_MUTEX;
+
+void set_swap_path(std::filesystem::path dir_path) {
+    SWAP_PATH = dir_path;
+}
+
+std::filesystem::path get_swap_path() {
+    return SWAP_PATH;
+}
 
 void cleanup_tmp_dir_on_signal(int sig) {
     logger->trace("Got signal {}. Exiting...", sig);

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -13,6 +13,9 @@
 
 namespace utils {
 
+void set_swap_path(std::filesystem::path dir_path);
+std::filesystem::path get_swap_path();
+
 std::filesystem::path create_temp_dir(std::filesystem::path path,
                                       const std::string &name = "");
 void remove_temp_dir(std::filesystem::path dir_name);


### PR DESCRIPTION
* Changed row_sparse format -> 20-50% smaller, same query time.

* Use int_vector_buffer for more memory efficient construction