### PR TITLE
Added DBGWrapper as an abstract parent class for all DeBruijnGraph wrappers

### DIFF
--- a/metagraph/src/cli/load/load_annotated_graph.cpp
+++ b/metagraph/src/cli/load/load_annotated_graph.cpp
@@ -22,6 +22,8 @@ using mtg::common::logger;
 
 std::unique_ptr<AnnotatedDBG> initialize_annotated_dbg(std::shared_ptr<DeBruijnGraph> graph,
                                                        const Config &config) {
+    assert(graph.get() == &graph->get_base_graph());
+
     uint64_t max_index = graph->max_index();
     const auto *dbg_graph = dynamic_cast<const DBGSuccinct*>(graph.get());
 

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -1,14 +1,8 @@
 #include "annotated_dbg.hpp"
 
 #include <array>
-
-#ifdef __AVX2__
-#include <immintrin.h>
-#endif
-
 #include <cstdlib>
 
-#include "graph/representation/canonical_dbg.hpp"
 #include "annotation/representation/row_compressed/annotate_row_compressed.hpp"
 #include "annotation/int_matrix/base/int_matrix.hpp"
 #include "common/utils/simd_utils.hpp"
@@ -694,11 +688,11 @@ void AnnotatedSequenceGraph
 }
 
 bool AnnotatedSequenceGraph::check_compatibility() const {
-    // TODO: add method max_canonical_index() and call it here without casts
-    if (const auto *canonical = dynamic_cast<const CanonicalDBG*>(graph_.get()))
-        return canonical->get_graph().max_index() == annotator_->num_objects();
-
     return graph_->max_index() == annotator_->num_objects();
+}
+
+bool AnnotatedDBG::check_compatibility() const {
+    return dbg_.get_base_graph().max_index() == annotator_->num_objects();
 }
 
 

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -78,6 +78,8 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
 
     const DeBruijnGraph& get_graph() const { return dbg_; }
 
+    bool check_compatibility() const;
+
     // add k-mer counts to the annotation, thread-safe for concurrent calls
     void add_kmer_counts(std::string_view sequence,
                          const std::vector<Label> &labels,

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -215,6 +215,110 @@ class DBGWrapper : public DeBruijnGraph {
     std::shared_ptr<const Graph> graph_;
 };
 
+template <typename Graph = DeBruijnGraph>
+class DBGNodeModifyingWrapper : public DBGWrapper<Graph> {
+  public:
+    typedef typename Graph::node_index node_index;
+    typedef typename Graph::CallPath CallPath;
+    typedef typename Graph::OutgoingEdgeCallback OutgoingEdgeCallback;
+    typedef typename Graph::IncomingEdgeCallback IncomingEdgeCallback;
+
+    template <typename... Args>
+    explicit DBGNodeModifyingWrapper(Args&&... args)
+          : DBGWrapper<Graph>(std::forward<Args>(args)...) {}
+
+    virtual ~DBGNodeModifyingWrapper() {}
+
+    virtual void map_to_nodes(std::string_view sequence,
+                              const std::function<void(node_index)> &callback,
+                              const std::function<bool()> &terminate
+                                  = [](){ return false; }) const override = 0;
+
+    virtual void map_to_nodes_sequentially(std::string_view sequence,
+                                           const std::function<void(node_index)> &callback,
+                                           const std::function<bool()> &terminate
+                                               = [](){ return false; }) const override = 0;
+
+    virtual void
+    adjacent_outgoing_nodes(node_index node,
+                            const std::function<void(node_index)> &callback) const override = 0;
+
+    virtual void
+    adjacent_incoming_nodes(node_index node,
+                            const std::function<void(node_index)> &callback) const override = 0;
+
+    virtual void call_outgoing_kmers(node_index kmer,
+                                     const OutgoingEdgeCallback &callback) const override = 0;
+
+    virtual void call_incoming_kmers(node_index kmer,
+                                     const IncomingEdgeCallback &callback) const override = 0;
+
+    virtual void call_nodes(const std::function<void(node_index)> &callback,
+                            const std::function<bool()> &stop_early
+                                = [](){ return false; }) const override = 0;
+    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override = 0;
+
+    virtual uint64_t num_nodes() const override = 0;
+    virtual uint64_t max_index() const override = 0;
+
+    virtual std::string get_node_sequence(node_index index) const override = 0;
+
+    virtual node_index traverse(node_index node, char next_char) const override = 0;
+    virtual node_index traverse_back(node_index node, char prev_char) const override = 0;
+
+    virtual size_t outdegree(node_index node) const override = 0;
+    virtual size_t indegree(node_index node) const override = 0;
+
+    virtual void traverse(node_index start,
+                          const char *begin,
+                          const char *end,
+                          const std::function<void(node_index)> &callback,
+                          const std::function<bool()> &terminate = [](){ return false; }) const override {
+        DeBruijnGraph::traverse(start, begin, end, callback, terminate);
+    }
+
+    virtual void call_sequences(const CallPath &callback,
+                                size_t num_threads = 1,
+                                bool kmers_in_single_form = false) const override {
+        DeBruijnGraph::call_sequences(callback, num_threads, kmers_in_single_form);
+    }
+
+    virtual void call_unitigs(const CallPath &callback,
+                              size_t num_threads = 1,
+                              size_t min_tip_size = 1,
+                              bool kmers_in_single_form = false) const override {
+        DeBruijnGraph::call_unitigs(callback, num_threads, min_tip_size, kmers_in_single_form);
+    }
+
+    virtual bool has_single_outgoing(node_index node) const override {
+        return DeBruijnGraph::has_single_outgoing(node);
+    }
+
+    virtual bool has_multiple_outgoing(node_index node) const override {
+        return DeBruijnGraph::has_multiple_outgoing(node);
+    }
+
+    virtual bool has_no_incoming(node_index node) const override {
+        return DeBruijnGraph::has_no_incoming(node);
+    }
+
+    virtual bool has_single_incoming(node_index node) const override {
+        return DeBruijnGraph::has_single_incoming(node);
+    }
+
+    virtual node_index kmer_to_node(std::string_view kmer) const override {
+        return DeBruijnGraph::kmer_to_node(kmer);
+    }
+
+    virtual bool find(std::string_view sequence, double discovery_fraction = 1) const override {
+        return DeBruijnGraph::find(sequence, discovery_fraction);
+    }
+
+    virtual void call_source_nodes(const std::function<void(node_index)> &callback) const override {
+        return DeBruijnGraph::call_source_nodes(callback);
+    }
+};
+
 } // namespace graph
 } // namespace mtg
 

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -71,7 +71,7 @@ class IDBGWrapper : public DeBruijnGraph {
 };
 
 /**
- * This wrapper uses the default methods from DeBruijnGraph when available
+ * This wrapper uses the default methods from Graph when available
  */
 template <typename Graph = DeBruijnGraph>
 class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
@@ -85,8 +85,7 @@ class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
     virtual ~DBGNodeModifyingWrapper() {}
 
     /**
-     * These methods should be implemented. The DeBruijnGraph defaults cannot
-     * be used.
+     * These methods should be implemented. The Graph defaults cannot be used.
      */
     virtual void call_nodes(const std::function<void(node_index)> &callback,
                             const std::function<bool()> &stop_early

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -2,7 +2,6 @@
 #define __DBG_WRAPPER__
 
 #include "sequence_graph.hpp"
-#include "common/logger.hpp"
 
 
 namespace mtg {

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -1,0 +1,222 @@
+#ifndef __DBG_WRAPPER__
+#define __DBG_WRAPPER__
+
+#include "sequence_graph.hpp"
+#include "common/logger.hpp"
+
+
+namespace mtg {
+namespace graph {
+
+/**
+ * This abstract class stores a graph internally and transfers all calls to it.
+ * It can be used as a parent to other wrappers which add additional functionality.
+ * All children of this class must implement add_sequence, load, and operator==
+ */
+template <class Graph = DeBruijnGraph>
+class DBGWrapper : public DeBruijnGraph {
+  public:
+    template <class InGraph>
+    explicit DBGWrapper(std::shared_ptr<InGraph> graph)
+          : graph_ptr_(std::dynamic_pointer_cast<Graph>(graph)), graph_(graph_ptr_) {
+        assert(graph_);
+        assert(graph_ptr_);
+    }
+
+    template <class InGraph>
+    explicit DBGWrapper(std::shared_ptr<const InGraph> graph)
+          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) {
+        assert(graph_);
+        assert(!graph_ptr_);
+    }
+
+    // aliasing constructor
+    template <class InGraph>
+    explicit DBGWrapper(const InGraph &graph)
+          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
+        assert(graph_);
+        assert(!graph_ptr_);
+    }
+
+    virtual ~DBGWrapper() {}
+
+    /**
+     * Added methods
+     */
+    virtual const Graph& get_graph() const { return *graph_; }
+    virtual std::shared_ptr<const Graph> get_graph_ptr() const { return graph_; }
+    virtual std::shared_ptr<Graph> get_mutable_graph_ptr() const { return graph_ptr_; }
+
+    /**
+     * Methods from SequenceGraph
+     */
+    virtual void add_sequence(std::string_view sequence,
+                              const std::function<void(node_index)> &on_insertion
+                                  = [](node_index) {}) override = 0;
+
+    // Traverse graph mapping sequence to the graph nodes
+    // and run callback for each node until the termination condition is satisfied
+    virtual void map_to_nodes(std::string_view sequence,
+                              const std::function<void(node_index)> &callback,
+                              const std::function<bool()> &terminate
+                                  = [](){ return false; }) const override {
+        graph_->map_to_nodes(sequence, callback, terminate);
+    }
+
+    // Traverse graph mapping sequence to the graph nodes
+    // and run callback for each node until the termination condition is satisfied.
+    // Guarantees that nodes are called in the same order as the input sequence
+    virtual void map_to_nodes_sequentially(std::string_view sequence,
+                                           const std::function<void(node_index)> &callback,
+                                           const std::function<bool()> &terminate
+                                               = [](){ return false; }) const override {
+        graph_->map_to_nodes_sequentially(sequence, callback, terminate);
+    }
+
+    // Given a node index, call the target nodes of all edges outgoing from it.
+    virtual void
+    adjacent_outgoing_nodes(node_index node,
+                            const std::function<void(node_index)> &callback) const override {
+        graph_->adjacent_outgoing_nodes(node, callback);
+    }
+
+    // Given a node index, call the source nodes of all edges incoming to it.
+    virtual void
+    adjacent_incoming_nodes(node_index node,
+                            const std::function<void(node_index)> &callback) const override {
+        graph_->adjacent_incoming_nodes(node, callback);
+    }
+
+    virtual void call_nodes(const std::function<void(node_index)> &callback,
+                            const std::function<bool()> &stop_early
+                                = [](){ return false; }) const override {
+        graph_->call_nodes(callback, stop_early);
+    }
+
+    virtual uint64_t num_nodes() const override { return graph_->num_nodes(); }
+    virtual uint64_t max_index() const override { return graph_->max_index(); }
+
+    virtual bool load(const std::string &filename) override = 0;
+
+    virtual void serialize(const std::string &filename) const override {
+        graph_->serialize(filename);
+    }
+
+    virtual std::string file_extension() const override { return graph_->file_extension(); }
+
+    // Get string corresponding to |node_index|.
+    // Note: Not efficient if sequences in nodes overlap. Use sparingly.
+    virtual std::string get_node_sequence(node_index index) const override {
+        return graph_->get_node_sequence(index);
+    }
+
+
+    /**
+     * Methods from DeBruijnGraph
+     */
+    virtual size_t get_k() const override { return graph_->get_k(); }
+    virtual Mode get_mode() const override { return graph_->get_mode(); }
+
+    virtual node_index traverse(node_index node, char next_char) const override {
+        return graph_->traverse(node, next_char);
+    }
+
+    virtual node_index traverse_back(node_index node, char prev_char) const override {
+        return graph_->traverse_back(node, prev_char);
+    }
+
+    // Given a starting node and a sequence of edge labels, traverse the graph
+    // forward. The traversal is terminated once terminate() returns true or
+    // when the sequence is exhausted.
+    // In canonical mode, non-canonical k-mers are NOT mapped to canonical ones.
+    virtual void traverse(node_index start,
+                          const char *begin,
+                          const char *end,
+                          const std::function<void(node_index)> &callback,
+                          const std::function<bool()> &terminate = [](){ return false; }) const override {
+        graph_->traverse(start, begin, end, callback, terminate);
+    }
+
+    virtual void call_sequences(const CallPath &callback,
+                                size_t num_threads = 1,
+                                bool kmers_in_single_form = false) const override {
+        graph_->call_sequences(callback, num_threads, kmers_in_single_form);
+    }
+
+    virtual void call_unitigs(const CallPath &callback,
+                              size_t num_threads = 1,
+                              size_t min_tip_size = 1,
+                              bool kmers_in_single_form = false) const override {
+        graph_->call_unitigs(callback, num_threads, min_tip_size, kmers_in_single_form);
+    }
+
+    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override {
+        graph_->call_kmers(callback);
+    }
+
+    virtual size_t outdegree(node_index node) const override {
+        return graph_->outdegree(node);
+    }
+
+    virtual bool has_single_outgoing(node_index node) const override {
+        return graph_->has_single_outgoing(node);
+    }
+
+    virtual bool has_multiple_outgoing(node_index node) const override {
+        return graph_->has_multiple_outgoing(node);
+    }
+
+    virtual size_t indegree(node_index node) const override {
+        return graph_->indegree(node);
+    }
+
+    virtual bool has_no_incoming(node_index node) const override {
+        return graph_->has_no_incoming(node);
+    }
+
+    virtual bool has_single_incoming(node_index node) const override {
+        return graph_->has_single_incoming(node);
+    }
+
+    virtual node_index kmer_to_node(std::string_view kmer) const override {
+        return graph_->kmer_to_node(kmer);
+    }
+
+    virtual void call_outgoing_kmers(node_index kmer,
+                                     const OutgoingEdgeCallback &callback) const override {
+        graph_->call_outgoing_kmers(kmer, callback);
+    }
+
+    virtual void call_incoming_kmers(node_index kmer,
+                                     const IncomingEdgeCallback &callback) const override {
+        graph_->call_incoming_kmers(kmer, callback);
+    }
+
+    // Check whether graph contains fraction of nodes from the sequence
+    virtual bool find(std::string_view sequence, double discovery_fraction = 1) const override {
+        return graph_->find(sequence, discovery_fraction);
+    }
+
+    virtual bool operator==(const DeBruijnGraph &other) const override = 0;
+
+    virtual const std::string& alphabet() const override { return graph_->alphabet(); }
+    virtual void print(std::ostream &out) const override { graph_->print(out); }
+
+    // Call all nodes that have no incoming edges
+    virtual void call_source_nodes(const std::function<void(node_index)> &callback) const override {
+        graph_->call_source_nodes(callback);
+    }
+
+    virtual const DeBruijnGraph& get_base_graph() const override final {
+        return graph_->get_base_graph();
+    }
+
+  protected:
+    std::shared_ptr<Graph> graph_ptr_;
+    std::shared_ptr<const Graph> graph_;
+};
+
+} // namespace graph
+} // namespace mtg
+
+#endif // __DBG_WRAPPER__

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -13,17 +13,17 @@ namespace graph {
  * All children of this class must implement add_sequence, load, and operator==
  */
 template <class Graph = DeBruijnGraph>
-class DBGWrapper : public DeBruijnGraph {
+class IDBGWrapper : public DeBruijnGraph {
   public:
     template <class InGraph>
-    explicit DBGWrapper(std::shared_ptr<InGraph> graph)
+    explicit IDBGWrapper(std::shared_ptr<InGraph> graph)
           : graph_ptr_(std::dynamic_pointer_cast<Graph>(graph)), graph_(graph_ptr_) {
         assert(graph_);
         assert(graph_ptr_);
     }
 
     template <class InGraph>
-    explicit DBGWrapper(std::shared_ptr<const InGraph> graph)
+    explicit IDBGWrapper(std::shared_ptr<const InGraph> graph)
           : graph_(std::dynamic_pointer_cast<const Graph>(graph)) {
         assert(graph_);
         assert(!graph_ptr_);
@@ -31,13 +31,13 @@ class DBGWrapper : public DeBruijnGraph {
 
     // aliasing constructor
     template <class InGraph>
-    explicit DBGWrapper(const InGraph &graph)
+    explicit IDBGWrapper(const InGraph &graph)
           : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
         assert(graph_);
         assert(!graph_ptr_);
     }
 
-    virtual ~DBGWrapper() {}
+    virtual ~IDBGWrapper() {}
 
     /**
      * Added methods
@@ -47,275 +47,200 @@ class DBGWrapper : public DeBruijnGraph {
     virtual std::shared_ptr<Graph> get_mutable_graph_ptr() const { return graph_ptr_; }
 
     /**
-     * Methods from SequenceGraph
+     * Methods shared by all wrappers
      */
-    virtual void add_sequence(std::string_view sequence,
-                              const std::function<void(node_index)> &on_insertion
-                                  = [](node_index) {}) override = 0;
-
-    // Traverse graph mapping sequence to the graph nodes
-    // and run callback for each node until the termination condition is satisfied
-    virtual void map_to_nodes(std::string_view sequence,
-                              const std::function<void(node_index)> &callback,
-                              const std::function<bool()> &terminate
-                                  = [](){ return false; }) const override {
-        graph_->map_to_nodes(sequence, callback, terminate);
+    virtual std::string file_extension() const override final { return graph_->file_extension(); }
+    virtual size_t get_k() const override final { return graph_->get_k(); }
+    virtual const std::string& alphabet() const override final { return graph_->alphabet(); }
+    virtual void print(std::ostream &out) const override { graph_->print(out); }
+    virtual const DeBruijnGraph& get_base_graph() const override final {
+        return graph_->get_base_graph();
     }
-
-    // Traverse graph mapping sequence to the graph nodes
-    // and run callback for each node until the termination condition is satisfied.
-    // Guarantees that nodes are called in the same order as the input sequence
-    virtual void map_to_nodes_sequentially(std::string_view sequence,
-                                           const std::function<void(node_index)> &callback,
-                                           const std::function<bool()> &terminate
-                                               = [](){ return false; }) const override {
-        graph_->map_to_nodes_sequentially(sequence, callback, terminate);
-    }
-
-    // Given a node index, call the target nodes of all edges outgoing from it.
-    virtual void
-    adjacent_outgoing_nodes(node_index node,
-                            const std::function<void(node_index)> &callback) const override {
-        graph_->adjacent_outgoing_nodes(node, callback);
-    }
-
-    // Given a node index, call the source nodes of all edges incoming to it.
-    virtual void
-    adjacent_incoming_nodes(node_index node,
-                            const std::function<void(node_index)> &callback) const override {
-        graph_->adjacent_incoming_nodes(node, callback);
-    }
-
-    virtual void call_nodes(const std::function<void(node_index)> &callback,
-                            const std::function<bool()> &stop_early
-                                = [](){ return false; }) const override {
-        graph_->call_nodes(callback, stop_early);
-    }
-
-    virtual uint64_t num_nodes() const override { return graph_->num_nodes(); }
-    virtual uint64_t max_index() const override { return graph_->max_index(); }
-
-    virtual bool load(const std::string &filename) override = 0;
-
     virtual void serialize(const std::string &filename) const override {
         graph_->serialize(filename);
     }
 
-    virtual std::string file_extension() const override { return graph_->file_extension(); }
-
-    // Get string corresponding to |node_index|.
-    // Note: Not efficient if sequences in nodes overlap. Use sparingly.
-    virtual std::string get_node_sequence(node_index index) const override {
-        return graph_->get_node_sequence(index);
-    }
-
-
     /**
-     * Methods from DeBruijnGraph
+     * Methods to implement
      */
-    virtual size_t get_k() const override { return graph_->get_k(); }
-    virtual Mode get_mode() const override { return graph_->get_mode(); }
-
-    virtual node_index traverse(node_index node, char next_char) const override {
-        return graph_->traverse(node, next_char);
-    }
-
-    virtual node_index traverse_back(node_index node, char prev_char) const override {
-        return graph_->traverse_back(node, prev_char);
-    }
-
-    // Given a starting node and a sequence of edge labels, traverse the graph
-    // forward. The traversal is terminated once terminate() returns true or
-    // when the sequence is exhausted.
-    // In canonical mode, non-canonical k-mers are NOT mapped to canonical ones.
-    virtual void traverse(node_index start,
-                          const char *begin,
-                          const char *end,
-                          const std::function<void(node_index)> &callback,
-                          const std::function<bool()> &terminate = [](){ return false; }) const override {
-        graph_->traverse(start, begin, end, callback, terminate);
-    }
-
-    virtual void call_sequences(const CallPath &callback,
-                                size_t num_threads = 1,
-                                bool kmers_in_single_form = false) const override {
-        graph_->call_sequences(callback, num_threads, kmers_in_single_form);
-    }
-
-    virtual void call_unitigs(const CallPath &callback,
-                              size_t num_threads = 1,
-                              size_t min_tip_size = 1,
-                              bool kmers_in_single_form = false) const override {
-        graph_->call_unitigs(callback, num_threads, min_tip_size, kmers_in_single_form);
-    }
-
-    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override {
-        graph_->call_kmers(callback);
-    }
-
-    virtual size_t outdegree(node_index node) const override {
-        return graph_->outdegree(node);
-    }
-
-    virtual bool has_single_outgoing(node_index node) const override {
-        return graph_->has_single_outgoing(node);
-    }
-
-    virtual bool has_multiple_outgoing(node_index node) const override {
-        return graph_->has_multiple_outgoing(node);
-    }
-
-    virtual size_t indegree(node_index node) const override {
-        return graph_->indegree(node);
-    }
-
-    virtual bool has_no_incoming(node_index node) const override {
-        return graph_->has_no_incoming(node);
-    }
-
-    virtual bool has_single_incoming(node_index node) const override {
-        return graph_->has_single_incoming(node);
-    }
-
-    virtual node_index kmer_to_node(std::string_view kmer) const override {
-        return graph_->kmer_to_node(kmer);
-    }
-
-    virtual void call_outgoing_kmers(node_index kmer,
-                                     const OutgoingEdgeCallback &callback) const override {
-        graph_->call_outgoing_kmers(kmer, callback);
-    }
-
-    virtual void call_incoming_kmers(node_index kmer,
-                                     const IncomingEdgeCallback &callback) const override {
-        graph_->call_incoming_kmers(kmer, callback);
-    }
-
-    // Check whether graph contains fraction of nodes from the sequence
-    virtual bool find(std::string_view sequence, double discovery_fraction = 1) const override {
-        return graph_->find(sequence, discovery_fraction);
-    }
-
     virtual bool operator==(const DeBruijnGraph &other) const override = 0;
-
-    virtual const std::string& alphabet() const override { return graph_->alphabet(); }
-    virtual void print(std::ostream &out) const override { graph_->print(out); }
-
-    // Call all nodes that have no incoming edges
-    virtual void call_source_nodes(const std::function<void(node_index)> &callback) const override {
-        graph_->call_source_nodes(callback);
-    }
-
-    virtual const DeBruijnGraph& get_base_graph() const override final {
-        return graph_->get_base_graph();
-    }
 
   protected:
     std::shared_ptr<Graph> graph_ptr_;
     std::shared_ptr<const Graph> graph_;
 };
 
+/**
+ * This wrapper uses the default methods from DeBruijnGraph when available
+ */
 template <typename Graph = DeBruijnGraph>
-class DBGNodeModifyingWrapper : public DBGWrapper<Graph> {
+class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
   public:
     typedef typename Graph::node_index node_index;
+
+    template <typename... Args>
+    explicit DBGNodeModifyingWrapper(Args&&... args)
+          : IDBGWrapper<Graph>(std::forward<Args>(args)...) {}
+
+    virtual ~DBGNodeModifyingWrapper() {}
+
+    /**
+     * These methods should be implemented. The DeBruijnGraph defaults cannot
+     * be used.
+     */
+    virtual void call_nodes(const std::function<void(node_index)> &callback,
+                            const std::function<bool()> &stop_early
+                                = [](){ return false; }) const override = 0;
+
+    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override = 0;
+
+    virtual uint64_t max_index() const override = 0;
+};
+
+/**
+ * This wrapper uses the methods directly from the underlying graph by default
+ */
+template <class Graph = DeBruijnGraph>
+class DBGWrapper : public IDBGWrapper<Graph> {
+    typedef typename Graph::node_index node_index;
+    typedef typename Graph::Mode Mode;
     typedef typename Graph::CallPath CallPath;
     typedef typename Graph::OutgoingEdgeCallback OutgoingEdgeCallback;
     typedef typename Graph::IncomingEdgeCallback IncomingEdgeCallback;
 
     template <typename... Args>
-    explicit DBGNodeModifyingWrapper(Args&&... args)
-          : DBGWrapper<Graph>(std::forward<Args>(args)...) {}
+    explicit DBGWrapper(Args&&... args) : IDBGWrapper<Graph>(std::forward<Args>(args)...) {}
 
-    virtual ~DBGNodeModifyingWrapper() {}
+    virtual ~DBGWrapper() {}
 
+    /**
+     * Methods from SequenceGraph
+     */
     virtual void map_to_nodes(std::string_view sequence,
                               const std::function<void(node_index)> &callback,
                               const std::function<bool()> &terminate
-                                  = [](){ return false; }) const override = 0;
+                                  = [](){ return false; }) const override {
+        this->graph_->map_to_nodes(sequence, callback, terminate);
+    }
 
     virtual void map_to_nodes_sequentially(std::string_view sequence,
                                            const std::function<void(node_index)> &callback,
                                            const std::function<bool()> &terminate
-                                               = [](){ return false; }) const override = 0;
+                                               = [](){ return false; }) const override {
+        this->graph_->map_to_nodes_sequentially(sequence, callback, terminate);
+    }
 
     virtual void
     adjacent_outgoing_nodes(node_index node,
-                            const std::function<void(node_index)> &callback) const override = 0;
+                            const std::function<void(node_index)> &callback) const override {
+        this->graph_->adjacent_outgoing_nodes(node, callback);
+    }
 
     virtual void
     adjacent_incoming_nodes(node_index node,
-                            const std::function<void(node_index)> &callback) const override = 0;
-
-    virtual void call_outgoing_kmers(node_index kmer,
-                                     const OutgoingEdgeCallback &callback) const override = 0;
-
-    virtual void call_incoming_kmers(node_index kmer,
-                                     const IncomingEdgeCallback &callback) const override = 0;
+                            const std::function<void(node_index)> &callback) const override {
+        this->graph_->adjacent_incoming_nodes(node, callback);
+    }
 
     virtual void call_nodes(const std::function<void(node_index)> &callback,
                             const std::function<bool()> &stop_early
-                                = [](){ return false; }) const override = 0;
-    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override = 0;
+                                = [](){ return false; }) const override {
+        this->graph_->call_nodes(callback, stop_early);
+    }
 
-    virtual uint64_t num_nodes() const override = 0;
-    virtual uint64_t max_index() const override = 0;
+    virtual uint64_t num_nodes() const override { return this->graph_->num_nodes(); }
+    virtual uint64_t max_index() const override { return this->graph_->max_index(); }
 
-    virtual std::string get_node_sequence(node_index index) const override = 0;
+    virtual void serialize(const std::string &filename) const override {
+        this->graph_->serialize(filename);
+    }
 
-    virtual node_index traverse(node_index node, char next_char) const override = 0;
-    virtual node_index traverse_back(node_index node, char prev_char) const override = 0;
+    virtual std::string get_node_sequence(node_index index) const override {
+        return this->graph_->get_node_sequence(index);
+    }
 
-    virtual size_t outdegree(node_index node) const override = 0;
-    virtual size_t indegree(node_index node) const override = 0;
+    /**
+     * Methods from DeBruijnGraph
+     */
+    virtual Mode get_mode() const override { return this->graph_->get_mode(); }
+
+    virtual node_index traverse(node_index node, char next_char) const override {
+        return this->graph_->traverse(node, next_char);
+    }
+
+    virtual node_index traverse_back(node_index node, char prev_char) const override {
+        return this->graph_->traverse_back(node, prev_char);
+    }
 
     virtual void traverse(node_index start,
                           const char *begin,
                           const char *end,
                           const std::function<void(node_index)> &callback,
                           const std::function<bool()> &terminate = [](){ return false; }) const override {
-        DeBruijnGraph::traverse(start, begin, end, callback, terminate);
+        this->graph_->traverse(start, begin, end, callback, terminate);
     }
 
     virtual void call_sequences(const CallPath &callback,
                                 size_t num_threads = 1,
                                 bool kmers_in_single_form = false) const override {
-        DeBruijnGraph::call_sequences(callback, num_threads, kmers_in_single_form);
+        this->graph_->call_sequences(callback, num_threads, kmers_in_single_form);
     }
 
     virtual void call_unitigs(const CallPath &callback,
                               size_t num_threads = 1,
                               size_t min_tip_size = 1,
                               bool kmers_in_single_form = false) const override {
-        DeBruijnGraph::call_unitigs(callback, num_threads, min_tip_size, kmers_in_single_form);
+        this->graph_->call_unitigs(callback, num_threads, min_tip_size, kmers_in_single_form);
+    }
+
+    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override {
+        this->graph_->call_kmers(callback);
+    }
+
+    virtual size_t outdegree(node_index node) const override {
+        return this->graph_->outdegree(node);
     }
 
     virtual bool has_single_outgoing(node_index node) const override {
-        return DeBruijnGraph::has_single_outgoing(node);
+        return this->graph_->has_single_outgoing(node);
     }
 
     virtual bool has_multiple_outgoing(node_index node) const override {
-        return DeBruijnGraph::has_multiple_outgoing(node);
+        return this->graph_->has_multiple_outgoing(node);
+    }
+
+    virtual size_t indegree(node_index node) const override {
+        return this->graph_->indegree(node);
     }
 
     virtual bool has_no_incoming(node_index node) const override {
-        return DeBruijnGraph::has_no_incoming(node);
+        return this->graph_->has_no_incoming(node);
     }
 
     virtual bool has_single_incoming(node_index node) const override {
-        return DeBruijnGraph::has_single_incoming(node);
+        return this->graph_->has_single_incoming(node);
     }
 
     virtual node_index kmer_to_node(std::string_view kmer) const override {
-        return DeBruijnGraph::kmer_to_node(kmer);
+        return this->graph_->kmer_to_node(kmer);
+    }
+
+    virtual void call_outgoing_kmers(node_index kmer,
+                                     const OutgoingEdgeCallback &callback) const override {
+        this->graph_->call_outgoing_kmers(kmer, callback);
+    }
+
+    virtual void call_incoming_kmers(node_index kmer,
+                                     const IncomingEdgeCallback &callback) const override {
+        this->graph_->call_incoming_kmers(kmer, callback);
     }
 
     virtual bool find(std::string_view sequence, double discovery_fraction = 1) const override {
-        return DeBruijnGraph::find(sequence, discovery_fraction);
+        return this->graph_->find(sequence, discovery_fraction);
     }
 
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const override {
-        return DeBruijnGraph::call_source_nodes(callback);
+        this->graph_->call_source_nodes(callback);
     }
 };
 

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -10,7 +10,7 @@ namespace graph {
 /**
  * This abstract class stores a graph internally and transfers all calls to it.
  * It can be used as a parent to other wrappers which add additional functionality.
- * All children of this class must implement add_sequence, load, and operator==
+ * All children of this class must implement operator==
  */
 template <class Graph = DeBruijnGraph>
 class IDBGWrapper : public DeBruijnGraph {
@@ -22,7 +22,6 @@ class IDBGWrapper : public DeBruijnGraph {
      */
     virtual const Graph& get_graph() const { return *graph_; }
     virtual std::shared_ptr<const Graph> get_graph_ptr() const { return graph_; }
-    virtual std::shared_ptr<Graph> get_mutable_graph_ptr() const { return graph_ptr_; }
 
     /**
      * Methods shared by all wrappers
@@ -34,8 +33,21 @@ class IDBGWrapper : public DeBruijnGraph {
     virtual const DeBruijnGraph& get_base_graph() const override final {
         return graph_->get_base_graph();
     }
-    virtual void serialize(const std::string &filename) const override {
-        graph_->serialize(filename);
+
+    /**
+     * Not implemented
+     */
+    virtual void serialize(const std::string &) const override final {
+        throw std::runtime_error("serialize not implemented on graph wrappers");
+    }
+
+    virtual bool load(const std::string &) override final {
+        throw std::runtime_error("load not implemented on graph wrappers");
+    }
+
+    virtual void add_sequence(std::string_view,
+                              const std::function<void(node_index)> &) override final {
+        throw std::runtime_error("add_sequence not implemented on graph wrappers");
     }
 
     /**
@@ -44,29 +56,27 @@ class IDBGWrapper : public DeBruijnGraph {
     virtual bool operator==(const DeBruijnGraph &other) const override = 0;
 
   protected:
-    std::shared_ptr<Graph> graph_ptr_;
     std::shared_ptr<const Graph> graph_;
 
     template <class InGraph>
-    explicit IDBGWrapper(std::shared_ptr<InGraph> graph)
-          : graph_ptr_(std::dynamic_pointer_cast<Graph>(graph)), graph_(graph_ptr_) {
-        assert(graph_);
-        assert(graph_ptr_);
-    }
+    IDBGWrapper(std::shared_ptr<const InGraph> graph)
+          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) { assert(graph_); }
 
     template <class InGraph>
-    explicit IDBGWrapper(std::shared_ptr<const InGraph> graph)
-          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) {
-        assert(graph_);
-        assert(!graph_ptr_);
-    }
+    IDBGWrapper(std::shared_ptr<InGraph> graph)
+          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) { assert(graph_); }
 
-    // aliasing constructor
+    // aliasing constructors
     template <class InGraph>
     explicit IDBGWrapper(const InGraph &graph)
           : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
         assert(graph_);
-        assert(!graph_ptr_);
+    }
+
+    template <class InGraph>
+    explicit IDBGWrapper(InGraph &graph)
+          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
+        assert(graph_);
     }
 };
 
@@ -81,7 +91,7 @@ class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
     typedef typename Graph::node_index node_index;
 
     template <typename... Args>
-    explicit DBGNodeModifyingWrapper(Args&&... args)
+    DBGNodeModifyingWrapper(Args&&... args)
           : IDBGWrapper<Graph>(std::forward<Args>(args)...) {}
 
     virtual ~DBGNodeModifyingWrapper() {}
@@ -112,7 +122,7 @@ class DBGWrapper : public IDBGWrapper<Graph> {
     typedef typename Graph::IncomingEdgeCallback IncomingEdgeCallback;
 
     template <typename... Args>
-    explicit DBGWrapper(Args&&... args) : IDBGWrapper<Graph>(std::forward<Args>(args)...) {}
+    DBGWrapper(Args&&... args) : IDBGWrapper<Graph>(std::forward<Args>(args)...) {}
 
     virtual ~DBGWrapper() {}
 

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -9,13 +9,35 @@ namespace graph {
 
 /**
  * This abstract class stores a graph internally and transfers all calls to it.
- * It can be used as a parent to other wrappers which add additional functionality.
- * All children of this class must implement operator==
+ * This wrapper uses the default methods from Graph when available. This may be
+ * used when the nodes and edges of the wrapped graph differ from the underlying
+ * graph.
  */
 template <class Graph = DeBruijnGraph>
-class IDBGWrapper : public DeBruijnGraph {
+class DBGWrapper : public DeBruijnGraph {
   public:
-    virtual ~IDBGWrapper() {}
+    template <class InGraph>
+    DBGWrapper(std::shared_ptr<const InGraph> graph)
+          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) { assert(graph_); }
+
+    template <class InGraph>
+    DBGWrapper(std::shared_ptr<InGraph> graph)
+          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) { assert(graph_); }
+
+    // aliasing constructors
+    template <class InGraph>
+    explicit DBGWrapper(const InGraph &graph)
+          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
+        assert(graph_);
+    }
+
+    template <class InGraph>
+    explicit DBGWrapper(InGraph &graph)
+          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
+        assert(graph_);
+    }
+
+    virtual ~DBGWrapper() {}
 
     /**
      * Added methods
@@ -51,54 +73,11 @@ class IDBGWrapper : public DeBruijnGraph {
     }
 
     /**
-     * Methods to implement
+     * The Graph defaults of these are likely to break in a wrapped graph,
+     * so these should be implemented.
      */
     virtual bool operator==(const DeBruijnGraph &other) const override = 0;
 
-  protected:
-    std::shared_ptr<const Graph> graph_;
-
-    template <class InGraph>
-    IDBGWrapper(std::shared_ptr<const InGraph> graph)
-          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) { assert(graph_); }
-
-    template <class InGraph>
-    IDBGWrapper(std::shared_ptr<InGraph> graph)
-          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) { assert(graph_); }
-
-    // aliasing constructors
-    template <class InGraph>
-    explicit IDBGWrapper(const InGraph &graph)
-          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
-        assert(graph_);
-    }
-
-    template <class InGraph>
-    explicit IDBGWrapper(InGraph &graph)
-          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
-        assert(graph_);
-    }
-};
-
-/**
- * This wrapper uses the default methods from Graph when available. This may be
- * used when the nodes and edges of the wrapped graph differ from the underlying
- * graph.
- */
-template <typename Graph = DeBruijnGraph>
-class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
-  public:
-    typedef typename Graph::node_index node_index;
-
-    template <typename... Args>
-    DBGNodeModifyingWrapper(Args&&... args)
-          : IDBGWrapper<Graph>(std::forward<Args>(args)...) {}
-
-    virtual ~DBGNodeModifyingWrapper() {}
-
-    /**
-     * These methods should be implemented. The Graph defaults cannot be used.
-     */
     virtual void call_nodes(const std::function<void(node_index)> &callback,
                             const std::function<bool()> &stop_early
                                 = [](){ return false; }) const override = 0;
@@ -106,155 +85,9 @@ class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
     virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override = 0;
 
     virtual uint64_t max_index() const override = 0;
-};
 
-/**
- * This wrapper uses the methods directly from the underlying graph by default.
- * This may be used when the nodes and edges of the wrapped graph are the
- * same as the underlying graph.
- */
-template <class Graph = DeBruijnGraph>
-class DBGWrapper : public IDBGWrapper<Graph> {
-    typedef typename Graph::node_index node_index;
-    typedef typename Graph::Mode Mode;
-    typedef typename Graph::CallPath CallPath;
-    typedef typename Graph::OutgoingEdgeCallback OutgoingEdgeCallback;
-    typedef typename Graph::IncomingEdgeCallback IncomingEdgeCallback;
-
-    template <typename... Args>
-    DBGWrapper(Args&&... args) : IDBGWrapper<Graph>(std::forward<Args>(args)...) {}
-
-    virtual ~DBGWrapper() {}
-
-    /**
-     * Methods from SequenceGraph
-     */
-    virtual void map_to_nodes(std::string_view sequence,
-                              const std::function<void(node_index)> &callback,
-                              const std::function<bool()> &terminate
-                                  = [](){ return false; }) const override {
-        this->graph_->map_to_nodes(sequence, callback, terminate);
-    }
-
-    virtual void map_to_nodes_sequentially(std::string_view sequence,
-                                           const std::function<void(node_index)> &callback,
-                                           const std::function<bool()> &terminate
-                                               = [](){ return false; }) const override {
-        this->graph_->map_to_nodes_sequentially(sequence, callback, terminate);
-    }
-
-    virtual void
-    adjacent_outgoing_nodes(node_index node,
-                            const std::function<void(node_index)> &callback) const override {
-        this->graph_->adjacent_outgoing_nodes(node, callback);
-    }
-
-    virtual void
-    adjacent_incoming_nodes(node_index node,
-                            const std::function<void(node_index)> &callback) const override {
-        this->graph_->adjacent_incoming_nodes(node, callback);
-    }
-
-    virtual void call_nodes(const std::function<void(node_index)> &callback,
-                            const std::function<bool()> &stop_early
-                                = [](){ return false; }) const override {
-        this->graph_->call_nodes(callback, stop_early);
-    }
-
-    virtual uint64_t num_nodes() const override { return this->graph_->num_nodes(); }
-    virtual uint64_t max_index() const override { return this->graph_->max_index(); }
-
-    virtual void serialize(const std::string &filename) const override {
-        this->graph_->serialize(filename);
-    }
-
-    virtual std::string get_node_sequence(node_index index) const override {
-        return this->graph_->get_node_sequence(index);
-    }
-
-    /**
-     * Methods from DeBruijnGraph
-     */
-    virtual Mode get_mode() const override { return this->graph_->get_mode(); }
-
-    virtual node_index traverse(node_index node, char next_char) const override {
-        return this->graph_->traverse(node, next_char);
-    }
-
-    virtual node_index traverse_back(node_index node, char prev_char) const override {
-        return this->graph_->traverse_back(node, prev_char);
-    }
-
-    virtual void traverse(node_index start,
-                          const char *begin,
-                          const char *end,
-                          const std::function<void(node_index)> &callback,
-                          const std::function<bool()> &terminate = [](){ return false; }) const override {
-        this->graph_->traverse(start, begin, end, callback, terminate);
-    }
-
-    virtual void call_sequences(const CallPath &callback,
-                                size_t num_threads = 1,
-                                bool kmers_in_single_form = false) const override {
-        this->graph_->call_sequences(callback, num_threads, kmers_in_single_form);
-    }
-
-    virtual void call_unitigs(const CallPath &callback,
-                              size_t num_threads = 1,
-                              size_t min_tip_size = 1,
-                              bool kmers_in_single_form = false) const override {
-        this->graph_->call_unitigs(callback, num_threads, min_tip_size, kmers_in_single_form);
-    }
-
-    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override {
-        this->graph_->call_kmers(callback);
-    }
-
-    virtual size_t outdegree(node_index node) const override {
-        return this->graph_->outdegree(node);
-    }
-
-    virtual bool has_single_outgoing(node_index node) const override {
-        return this->graph_->has_single_outgoing(node);
-    }
-
-    virtual bool has_multiple_outgoing(node_index node) const override {
-        return this->graph_->has_multiple_outgoing(node);
-    }
-
-    virtual size_t indegree(node_index node) const override {
-        return this->graph_->indegree(node);
-    }
-
-    virtual bool has_no_incoming(node_index node) const override {
-        return this->graph_->has_no_incoming(node);
-    }
-
-    virtual bool has_single_incoming(node_index node) const override {
-        return this->graph_->has_single_incoming(node);
-    }
-
-    virtual node_index kmer_to_node(std::string_view kmer) const override {
-        return this->graph_->kmer_to_node(kmer);
-    }
-
-    virtual void call_outgoing_kmers(node_index kmer,
-                                     const OutgoingEdgeCallback &callback) const override {
-        this->graph_->call_outgoing_kmers(kmer, callback);
-    }
-
-    virtual void call_incoming_kmers(node_index kmer,
-                                     const IncomingEdgeCallback &callback) const override {
-        this->graph_->call_incoming_kmers(kmer, callback);
-    }
-
-    virtual bool find(std::string_view sequence, double discovery_fraction = 1) const override {
-        return this->graph_->find(sequence, discovery_fraction);
-    }
-
-    virtual void call_source_nodes(const std::function<void(node_index)> &callback) const override {
-        this->graph_->call_source_nodes(callback);
-    }
+  protected:
+    std::shared_ptr<const Graph> graph_;
 };
 
 } // namespace graph

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -15,28 +15,6 @@ namespace graph {
 template <class Graph = DeBruijnGraph>
 class IDBGWrapper : public DeBruijnGraph {
   public:
-    template <class InGraph>
-    explicit IDBGWrapper(std::shared_ptr<InGraph> graph)
-          : graph_ptr_(std::dynamic_pointer_cast<Graph>(graph)), graph_(graph_ptr_) {
-        assert(graph_);
-        assert(graph_ptr_);
-    }
-
-    template <class InGraph>
-    explicit IDBGWrapper(std::shared_ptr<const InGraph> graph)
-          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) {
-        assert(graph_);
-        assert(!graph_ptr_);
-    }
-
-    // aliasing constructor
-    template <class InGraph>
-    explicit IDBGWrapper(const InGraph &graph)
-          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
-        assert(graph_);
-        assert(!graph_ptr_);
-    }
-
     virtual ~IDBGWrapper() {}
 
     /**
@@ -68,6 +46,28 @@ class IDBGWrapper : public DeBruijnGraph {
   protected:
     std::shared_ptr<Graph> graph_ptr_;
     std::shared_ptr<const Graph> graph_;
+
+    template <class InGraph>
+    explicit IDBGWrapper(std::shared_ptr<InGraph> graph)
+          : graph_ptr_(std::dynamic_pointer_cast<Graph>(graph)), graph_(graph_ptr_) {
+        assert(graph_);
+        assert(graph_ptr_);
+    }
+
+    template <class InGraph>
+    explicit IDBGWrapper(std::shared_ptr<const InGraph> graph)
+          : graph_(std::dynamic_pointer_cast<const Graph>(graph)) {
+        assert(graph_);
+        assert(!graph_ptr_);
+    }
+
+    // aliasing constructor
+    template <class InGraph>
+    explicit IDBGWrapper(const InGraph &graph)
+          : graph_(std::shared_ptr<const Graph>{}, dynamic_cast<const Graph*>(&graph)) {
+        assert(graph_);
+        assert(!graph_ptr_);
+    }
 };
 
 /**

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -52,6 +52,7 @@ class DBGWrapper : public DeBruijnGraph {
     virtual size_t get_k() const override final { return graph_->get_k(); }
     virtual const std::string& alphabet() const override final { return graph_->alphabet(); }
     virtual void print(std::ostream &out) const override { graph_->print(out); }
+    virtual Mode get_mode() const override { return graph_->get_mode(); }
     virtual const DeBruijnGraph& get_base_graph() const override final {
         return graph_->get_base_graph();
     }

--- a/metagraph/src/graph/representation/base/dbg_wrapper.hpp
+++ b/metagraph/src/graph/representation/base/dbg_wrapper.hpp
@@ -71,7 +71,9 @@ class IDBGWrapper : public DeBruijnGraph {
 };
 
 /**
- * This wrapper uses the default methods from Graph when available
+ * This wrapper uses the default methods from Graph when available. This may be
+ * used when the nodes and edges of the wrapped graph differ from the underlying
+ * graph.
  */
 template <typename Graph = DeBruijnGraph>
 class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
@@ -97,7 +99,9 @@ class DBGNodeModifyingWrapper : public IDBGWrapper<Graph> {
 };
 
 /**
- * This wrapper uses the methods directly from the underlying graph by default
+ * This wrapper uses the methods directly from the underlying graph by default.
+ * This may be used when the nodes and edges of the wrapped graph are the
+ * same as the underlying graph.
  */
 template <class Graph = DeBruijnGraph>
 class DBGWrapper : public IDBGWrapper<Graph> {

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -227,6 +227,8 @@ class DeBruijnGraph : public SequenceGraph {
 
     // Call all nodes that have no incoming edges
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const;
+
+    virtual const DeBruijnGraph& get_base_graph() const { return *this; }
 };
 
 

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -10,70 +10,63 @@ namespace graph {
 
 using mtg::common::logger;
 
+template <typename Graph>
+CanonicalDBG::CanonicalDBG(Graph&& graph, size_t cache_size)
+      : DBGWrapper(std::forward<Graph>(graph)), cache_size_(cache_size),
+        child_node_cache_(cache_size_), parent_node_cache_(cache_size_),
+        is_palindrome_cache_(cache_size_) {
+    static_assert(!std::is_same_v<Graph, std::shared_ptr<CanonicalDBG>>);
+    static_assert(!std::is_same_v<Graph, std::shared_ptr<const CanonicalDBG>>);
+    flush();
+}
 
-CanonicalDBG::CanonicalDBG(std::shared_ptr<const DeBruijnGraph> graph, size_t cache_size)
-      : const_graph_ptr_(graph),
-        offset_(graph_.max_index()),
-        k_odd_(graph_.get_k() % 2),
-        has_sentinel_(false),
-        alphabet_encoder_({ graph_.alphabet().size() }),
-        cache_size_(cache_size),
-        child_node_cache_(cache_size_),
-        parent_node_cache_(cache_size_),
-        is_palindrome_cache_(k_odd_ ? 0 : cache_size_) {
-    if (graph->get_mode() != DeBruijnGraph::PRIMARY) {
+template CanonicalDBG::CanonicalDBG(std::shared_ptr<DeBruijnGraph>&&, size_t);
+template CanonicalDBG::CanonicalDBG(std::shared_ptr<const DeBruijnGraph>&&, size_t);
+template CanonicalDBG::CanonicalDBG(std::shared_ptr<DeBruijnGraph>&, size_t);
+template CanonicalDBG::CanonicalDBG(std::shared_ptr<const DeBruijnGraph>&, size_t);
+template CanonicalDBG::CanonicalDBG(std::shared_ptr<DBGSuccinct>&, size_t);
+
+void CanonicalDBG::add_sequence(std::string_view sequence,
+                               const std::function<void(node_index)> &on_insertion) {
+    if (!graph_ptr_)
+        throw std::runtime_error("load only supported for non-const graphs");
+
+    graph_ptr_->add_sequence(sequence, on_insertion);
+    flush();
+}
+
+bool CanonicalDBG::load(const std::string &filename) {
+    if (!graph_ptr_)
+        throw std::runtime_error("load only supported for non-const graphs");
+
+    if (!graph_ptr_->load(filename))
+        return false;
+
+    flush();
+    return true;
+}
+
+void CanonicalDBG::flush() {
+    if (graph_->get_mode() != DeBruijnGraph::PRIMARY) {
         logger->error("Only primary graphs can be wrapped in CanonicalDBG");
         exit(1);
     }
 
-    for (size_t i = 0; i < graph_.alphabet().size(); ++i) {
-        alphabet_encoder_[graph_.alphabet()[i]] = i;
-        if (graph_.alphabet()[i] == boss::BOSS::kSentinel)
-            has_sentinel_ = true;
-    }
-}
-
-CanonicalDBG::CanonicalDBG(const CanonicalDBG &canonical)
-      : const_graph_ptr_(canonical.const_graph_ptr_),
-        offset_(canonical.offset_),
-        k_odd_(canonical.k_odd_),
-        has_sentinel_(canonical.has_sentinel_),
-        alphabet_encoder_(canonical.alphabet_encoder_),
-        cache_size_(canonical.cache_size_),
-        child_node_cache_(cache_size_),
-        parent_node_cache_(cache_size_),
-        is_palindrome_cache_(k_odd_ ? 0 : cache_size_) {}
-
-CanonicalDBG::CanonicalDBG(std::shared_ptr<DeBruijnGraph> graph, size_t cache_size)
-      : CanonicalDBG(std::dynamic_pointer_cast<const DeBruijnGraph>(graph), cache_size) {
-    graph_ptr_ = graph;
-}
-
-CanonicalDBG::CanonicalDBG(const DeBruijnGraph &graph, size_t cache_size)
-      : CanonicalDBG(std::shared_ptr<const DeBruijnGraph>(&graph, [](const auto*) {}),
-                     cache_size) {}
-
-CanonicalDBG::CanonicalDBG(DeBruijnGraph &graph, size_t cache_size)
-      : CanonicalDBG(std::shared_ptr<DeBruijnGraph>(&graph, [](const auto*) {}),
-                     cache_size) {}
-
-uint64_t CanonicalDBG::num_nodes() const {
-    logger->trace("Number of nodes may be overestimated if k is even or reverse complements are present in the graph");
-    return graph_.num_nodes() * 2;
-}
-
-void CanonicalDBG
-::add_sequence(std::string_view sequence,
-               const std::function<void(node_index)> &on_insertion) {
-    assert(graph_ptr_ && "add_sequence only supported for non-const graphs.");
-
-    graph_ptr_->add_sequence(sequence, on_insertion);
-    offset_ = graph_.max_index();
     child_node_cache_.Clear();
     parent_node_cache_.Clear();
     is_palindrome_cache_.Clear();
-}
 
+    offset_ = graph_->max_index();
+    k_odd_ = (graph_->get_k() % 2);
+    has_sentinel_ = false;
+    alphabet_encoder_.fill(graph_->alphabet().size());
+
+    for (size_t i = 0; i < graph_->alphabet().size(); ++i) {
+        alphabet_encoder_[graph_->alphabet()[i]] = i;
+        if (graph_->alphabet()[i] == boss::BOSS::kSentinel)
+            has_sentinel_ = true;
+    }
+}
 
 void CanonicalDBG
 ::map_to_nodes_sequentially(std::string_view sequence,
@@ -87,7 +80,7 @@ void CanonicalDBG
 
     // map until the first mismatch
     bool stop = false;
-    graph_.map_to_nodes_sequentially(sequence,
+    graph_->map_to_nodes_sequentially(sequence,
         [&](node_index node) {
             if (node) {
                 path.push_back(node);
@@ -114,10 +107,10 @@ void CanonicalDBG
     std::string rev_seq(sequence);
     ::reverse_complement(rev_seq.begin(), rev_seq.end());
     // map the reverse-complement
-    std::vector<node_index> rev_path = map_sequence_to_nodes(graph_, rev_seq);
+    std::vector<node_index> rev_path = map_sequence_to_nodes(*graph_, rev_seq);
 
     // map the forward
-    const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(&graph_);
+    const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(graph_.get());
     if (dbg_succ && get_k() % 2) {
         // if it's a boss table with odd k (without palindromic k-mers),
         // we can skip k-mers that have been found in the rev-compl sequence
@@ -148,7 +141,7 @@ void CanonicalDBG
         assert(it == rev_path.rend());
 
     } else {
-        path = map_sequence_to_nodes(graph_, sequence);
+        path = map_sequence_to_nodes(*graph_, sequence);
     }
 
     assert(path.size() == rev_path.size());
@@ -189,7 +182,7 @@ void CanonicalDBG::append_next_rc_nodes(node_index node,
      *         TGGCTT      AAGCCA
      */
 
-    const auto &alphabet = graph_.alphabet();
+    const auto &alphabet = graph_->alphabet();
 
     //        rshift    rc
     // ATGGCT -> TGGCT* -> *AGCCA
@@ -199,7 +192,7 @@ void CanonicalDBG::append_next_rc_nodes(node_index node,
 
     // for each n, check for nAGCCA. If found, define and store the index for
     // TGGCTrc(n) as index(nAGCCA) + offset_
-    if (const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(&graph_)) {
+    if (const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(graph_.get())) {
         const auto &boss = dbg_succ->get_boss();
         dbg_succ->call_nodes_with_suffix_matching_longest_prefix(
             std::string_view(&rev_seq[1], get_k() - 1),
@@ -219,9 +212,9 @@ void CanonicalDBG::append_next_rc_nodes(node_index node,
                 if (k_odd_) {
                     logger->error(
                         "Primary graph contains both forward and reverse complement: {} {} -> {} {}\t{} {}",
-                        node, graph_.get_node_sequence(node),
-                        children[c], graph_.get_node_sequence(children[c]),
-                        next, graph_.get_node_sequence(next));
+                        node, graph_->get_node_sequence(node),
+                        children[c], graph_->get_node_sequence(children[c]),
+                        next, graph_->get_node_sequence(next));
                     exit(1);
                 }
 
@@ -236,7 +229,7 @@ void CanonicalDBG::append_next_rc_nodes(node_index node,
             // For non-DBGSuccinct graphs, this should be fast enough.
             if (alphabet[c] != boss::BOSS::kSentinel && children[c] == npos) {
                 rev_seq[0] = complement(alphabet[c]);
-                node_index next = graph_.kmer_to_node(rev_seq);
+                node_index next = graph_->kmer_to_node(rev_seq);
                 if (next != npos)
                     children[c] = next + offset_;
             }
@@ -257,7 +250,7 @@ void CanonicalDBG
         return;
     }
 
-    const auto &alphabet = graph_.alphabet();
+    const auto &alphabet = graph_->alphabet();
 
     if (auto fetch = child_node_cache_.TryGet(node)) {
         for (size_t c = 0; c < alphabet.size(); ++c) {
@@ -269,7 +262,7 @@ void CanonicalDBG
         std::vector<node_index> children(alphabet.size(), npos);
         size_t max_num_edges_left = children.size() - has_sentinel_;
 
-        graph_.call_outgoing_kmers(node, [&](node_index next, char c) {
+        graph_->call_outgoing_kmers(node, [&](node_index next, char c) {
             if (c != boss::BOSS::kSentinel) {
                 children[alphabet_encoder_[c]] = next;
                 --max_num_edges_left;
@@ -301,7 +294,7 @@ void CanonicalDBG::append_prev_rc_nodes(node_index node,
      *  AAGCCA                    TGGCTT
      */
 
-    const auto &alphabet = graph_.alphabet();
+    const auto &alphabet = graph_->alphabet();
 
     //        lshift    rc
     // AGCCAT -> *AGCCA -> TGGCT*
@@ -311,7 +304,7 @@ void CanonicalDBG::append_prev_rc_nodes(node_index node,
 
     // for each n, check for TGGCTn. If found, define and store the index for
     // rc(n)AGCCA as index(TGGCTn) + offset_
-    if (const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(&graph_)) {
+    if (const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(graph_.get())) {
         // Find the BOSS node TGGCT and iterate through all of its outdoing edges.
         // Then, convert the edge indices to get the DBGSuccinct node indices
         const auto &boss = dbg_succ->get_boss();
@@ -338,9 +331,9 @@ void CanonicalDBG::append_prev_rc_nodes(node_index node,
                     if (k_odd_) {
                         logger->error(
                             "Primary graph contains both forward and reverse complement: {} {} -> {} {}\t{} {}",
-                            node, graph_.get_node_sequence(node),
-                            parents[c], graph_.get_node_sequence(parents[c]),
-                            prev, graph_.get_node_sequence(prev)
+                            node, graph_->get_node_sequence(node),
+                            parents[c], graph_->get_node_sequence(parents[c]),
+                            prev, graph_->get_node_sequence(prev)
                         );
                         exit(1);
                     }
@@ -356,7 +349,7 @@ void CanonicalDBG::append_prev_rc_nodes(node_index node,
             // For non-DBGSuccinct graphs, this should be fast enough.
             if (alphabet[c] != boss::BOSS::kSentinel && parents[c] == npos) {
                 rev_seq.back() = complement(alphabet[c]);
-                node_index prev = graph_.kmer_to_node(rev_seq);
+                node_index prev = graph_->kmer_to_node(rev_seq);
                 if (prev != npos)
                     parents[c] = prev + offset_;
             }
@@ -377,7 +370,7 @@ void CanonicalDBG
         return;
     }
 
-    const auto &alphabet = graph_.alphabet();
+    const auto &alphabet = graph_->alphabet();
 
     if (auto fetch = parent_node_cache_.TryGet(node)) {
         for (size_t c = 0; c < alphabet.size(); ++c) {
@@ -389,7 +382,7 @@ void CanonicalDBG
         std::vector<node_index> parents(alphabet.size(), npos);
         size_t max_num_edges_left = parents.size() - has_sentinel_;
 
-        graph_.call_incoming_kmers(node, [&](node_index prev, char c) {
+        graph_->call_incoming_kmers(node, [&](node_index prev, char c) {
             if (c != boss::BOSS::kSentinel) {
                 parents[alphabet_encoder_[c]] = prev;
                 --max_num_edges_left;
@@ -441,7 +434,7 @@ void CanonicalDBG::call_sequences(const CallPath &callback,
                                   size_t num_threads,
                                   bool kmers_in_single_form) const {
     if (kmers_in_single_form) {
-        graph_.call_sequences(callback, num_threads, false);
+        graph_->call_sequences(callback, num_threads, false);
     } else {
         // TODO: port over implementation from DBGSuccinct to DeBruijnGraph
         DeBruijnGraph::call_sequences(callback, num_threads, false);
@@ -459,7 +452,7 @@ void CanonicalDBG::call_unitigs(const CallPath &callback,
 std::string CanonicalDBG::get_node_sequence(node_index index) const {
     assert(index <= offset_ * 2);
     node_index node = get_base_node(index);
-    std::string seq = graph_.get_node_sequence(node);
+    std::string seq = graph_->get_node_sequence(node);
 
     if (node != index)
         ::reverse_complement(seq.begin(), seq.end());
@@ -473,13 +466,13 @@ DeBruijnGraph::node_index CanonicalDBG::traverse(node_index node, char next_char
         node = traverse_back(node - offset_, complement(next_char));
         return node != npos ? reverse_complement(node) : npos;
     } else {
-        node_index next = graph_.traverse(node, next_char);
+        node_index next = graph_->traverse(node, next_char);
         if (next != npos)
             return next;
 
         std::string rev_seq = get_node_sequence(node).substr(1) + next_char;
         ::reverse_complement(rev_seq.begin(), rev_seq.end());
-        next = graph_.kmer_to_node(rev_seq);
+        next = graph_->kmer_to_node(rev_seq);
         return next != npos ? reverse_complement(next) : next;
     }
 }
@@ -491,21 +484,21 @@ DeBruijnGraph::node_index CanonicalDBG::traverse_back(node_index node,
         node = traverse(node - offset_, complement(prev_char));
         return node != npos ? reverse_complement(node) : npos;
     } else {
-        node_index prev = graph_.traverse_back(node, prev_char);
+        node_index prev = graph_->traverse_back(node, prev_char);
         if (prev != npos)
             return prev;
 
         std::string rev_seq = std::string(1, prev_char)
             + get_node_sequence(node).substr(0, get_k() - 1);
         ::reverse_complement(rev_seq.begin(), rev_seq.end());
-        prev = graph_.kmer_to_node(rev_seq);
+        prev = graph_->kmer_to_node(rev_seq);
         return prev != npos ? reverse_complement(prev) : prev;
     }
 }
 
 void CanonicalDBG::call_nodes(const std::function<void(node_index)> &callback,
                               const std::function<bool()> &stop_early) const {
-    graph_.call_nodes([&](node_index i) {
+    graph_->call_nodes([&](node_index i) {
                           callback(i);
                           if (!stop_early()) {
                               node_index j = reverse_complement(i);
@@ -546,12 +539,12 @@ DeBruijnGraph::node_index CanonicalDBG::reverse_complement(node_index node) cons
         return *fetch ? node : node + offset_;
 
     } else {
-        std::string seq = graph_.get_node_sequence(node);
+        std::string seq = graph_->get_node_sequence(node);
         std::string rev_seq = seq;
         ::reverse_complement(rev_seq.begin(), rev_seq.end());
         bool palindrome = (rev_seq == seq);
 
-        assert(palindrome || graph_.kmer_to_node(rev_seq) == npos);
+        assert(palindrome || graph_->kmer_to_node(rev_seq) == npos);
 
         is_palindrome_cache_.Put(node, palindrome);
         return palindrome ? node : node + offset_;

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -12,7 +12,7 @@ using mtg::common::logger;
 
 template <typename Graph>
 CanonicalDBG::CanonicalDBG(Graph&& graph, size_t cache_size)
-      : DBGNodeModifyingWrapper<DeBruijnGraph>(std::forward<Graph>(graph)),
+      : DBGWrapper<DeBruijnGraph>(std::forward<Graph>(graph)),
         cache_size_(cache_size), child_node_cache_(cache_size_),
         parent_node_cache_(cache_size_), is_palindrome_cache_(cache_size_) {
     static_assert(!std::is_same_v<Graph, std::shared_ptr<CanonicalDBG>>);

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -26,26 +26,6 @@ template CanonicalDBG::CanonicalDBG(std::shared_ptr<DeBruijnGraph>&, size_t);
 template CanonicalDBG::CanonicalDBG(std::shared_ptr<const DeBruijnGraph>&, size_t);
 template CanonicalDBG::CanonicalDBG(std::shared_ptr<DBGSuccinct>&, size_t);
 
-void CanonicalDBG::add_sequence(std::string_view sequence,
-                               const std::function<void(node_index)> &on_insertion) {
-    if (!graph_ptr_)
-        throw std::runtime_error("load only supported for non-const graphs");
-
-    graph_ptr_->add_sequence(sequence, on_insertion);
-    flush();
-}
-
-bool CanonicalDBG::load(const std::string &filename) {
-    if (!graph_ptr_)
-        throw std::runtime_error("load only supported for non-const graphs");
-
-    if (!graph_ptr_->load(filename))
-        return false;
-
-    flush();
-    return true;
-}
-
 void CanonicalDBG::flush() {
     if (graph_->get_mode() != DeBruijnGraph::PRIMARY) {
         logger->error("Only primary graphs can be wrapped in CanonicalDBG");

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -7,8 +7,7 @@
 #include <cache.hpp>
 #include <lru_cache_policy.hpp>
 
-#include "graph/representation/base/sequence_graph.hpp"
-
+#include "graph/representation/base/dbg_wrapper.hpp"
 
 namespace mtg {
 namespace graph {
@@ -17,40 +16,18 @@ namespace graph {
  * CanonicalDBG is a wrapper which acts like a canonical-mode DeBruijnGraph, but
  * uses a non-canonical DeBruijnGraph as the underlying storage.
  */
-class CanonicalDBG : public DeBruijnGraph {
+class CanonicalDBG : public DBGWrapper<DeBruijnGraph> {
   public:
-    /**
-     * Constructs a CanonicalDBG
-     * @param graph a graph
-     * @param cache_size the number of graph traversal call results to be cached
-     */
-    CanonicalDBG(const DeBruijnGraph &graph, size_t cache_size = 100'000);
+    template <typename Graph>
+    explicit CanonicalDBG(Graph&& graph, size_t cache_size = 100'000);
 
-    /**
-     * Constructs a CanonicalDBG
-     * @param graph a graph
-     * @param cache_size the number of graph traversal call results to be cached
-     */
-    CanonicalDBG(DeBruijnGraph &graph, size_t cache_size = 100'000);
+    CanonicalDBG(const CanonicalDBG &canonical)
+          : CanonicalDBG(canonical.graph_ptr_ ? canonical.graph_ptr_ : canonical.graph_,
+                         canonical.cache_size_) {}
 
-    /**
-     * Constructs a CanonicalDBG
-     * @param graph a pointer to the graph
-     * @param cache_size the number of graph traversal call results to be cached
-     */
-    CanonicalDBG(std::shared_ptr<const DeBruijnGraph> graph, size_t cache_size = 100'000);
-    /**
-     * Constructs a CanonicalDBG
-     * @param graph a pointer to the graph
-     * @param cache_size the number of graph traversal call results to be cached
-     */
-    CanonicalDBG(std::shared_ptr<DeBruijnGraph> graph, size_t cache_size = 100'000);
-
-    /**
-     * Copy constructor for CanonicalDBG. This creates a new wrapper with empty caches.
-     * @param canonical the graph to copy
-     */
-    CanonicalDBG(const CanonicalDBG &canonical);
+    CanonicalDBG(CanonicalDBG &canonical)
+          : CanonicalDBG(canonical.graph_ptr_ ? canonical.graph_ptr_ : canonical.graph_,
+                         canonical.cache_size_) {}
 
     // caches cannot be resized or moved, so disable these constructors
     CanonicalDBG& operator=(const CanonicalDBG &canonical) = delete;
@@ -59,86 +36,72 @@ class CanonicalDBG : public DeBruijnGraph {
 
     virtual ~CanonicalDBG() {}
 
-    virtual void add_sequence(std::string_view sequence,
-                              const std::function<void(node_index)> &on_insertion = [](node_index) {}) override;
-
     // Traverse graph mapping sequence to the graph nodes
     // and run callback for each node until the termination condition is satisfied
     virtual void map_to_nodes(std::string_view sequence,
                               const std::function<void(node_index)> &callback,
-                              const std::function<bool()> &terminate = [](){ return false; }) const override;
+                              const std::function<bool()> &terminate = [](){ return false; }) const override final;
 
     // Traverse graph mapping sequence to the graph nodes
     // and run callback for each node until the termination condition is satisfied.
     // Guarantees that nodes are called in the same order as the input sequence
     virtual void map_to_nodes_sequentially(std::string_view sequence,
                                            const std::function<void(node_index)> &callback,
-                                           const std::function<bool()> &terminate = [](){ return false; }) const override;
+                                           const std::function<bool()> &terminate = [](){ return false; }) const override final;
 
     // Given a node index, call the target nodes of all edges outgoing from it.
     virtual void adjacent_outgoing_nodes(node_index node,
-                                         const std::function<void(node_index)> &callback) const override;
+                                         const std::function<void(node_index)> &callback) const override final;
 
     virtual void call_outgoing_kmers(node_index kmer,
-                                     const OutgoingEdgeCallback &callback) const override;
+                                     const OutgoingEdgeCallback &callback) const override final;
 
     virtual void call_incoming_kmers(node_index kmer,
-                                     const IncomingEdgeCallback &callback) const override;
+                                     const IncomingEdgeCallback &callback) const override final;
 
     // Given a node index, call the source nodes of all edges incoming to it.
     virtual void adjacent_incoming_nodes(node_index node,
-                                         const std::function<void(node_index)> &callback) const override;
+                                         const std::function<void(node_index)> &callback) const override final;
 
     virtual void call_sequences(const CallPath &callback,
                                 size_t num_threads = 1,
-                                bool kmers_in_single_form = false) const override;
+                                bool kmers_in_single_form = false) const override final;
 
     virtual void call_unitigs(const CallPath &callback,
                               size_t num_threads = 1,
                               size_t min_tip_size = 1,
-                              bool kmers_in_single_form = false) const override;
+                              bool kmers_in_single_form = false) const override final;
 
-    virtual uint64_t num_nodes() const override;
-    virtual uint64_t max_index() const override { return graph_.max_index() * 2; }
-
-    virtual bool load(const std::string &) override {
-        throw std::runtime_error("Not implemented");
-    }
-
-    virtual void serialize(const std::string &) const override {
-        throw std::runtime_error("Not implemented");
-    }
-
-    virtual std::string file_extension() const override { return graph_.file_extension(); }
-
-    virtual const std::string& alphabet() const override { return graph_.alphabet(); }
+    virtual uint64_t num_nodes() const override final { return graph_->num_nodes() * 2; }
+    virtual uint64_t max_index() const override final { return graph_->max_index() * 2; }
 
     // Get string corresponding to |node_index|.
     // Note: Not efficient if sequences in nodes overlap. Use sparingly.
-    virtual std::string get_node_sequence(node_index index) const override;
-
-    virtual size_t get_k() const override { return graph_.get_k(); }
+    virtual std::string get_node_sequence(node_index index) const override final;
 
     virtual Mode get_mode() const override { return CANONICAL; }
 
     // Traverse the outgoing edge
-    virtual node_index traverse(node_index node, char next_char) const override;
+    virtual node_index traverse(node_index node, char next_char) const override final;
     // Traverse the incoming edge
-    virtual node_index traverse_back(node_index node, char prev_char) const override;
+    virtual node_index traverse_back(node_index node, char prev_char) const override final;
 
-    virtual size_t outdegree(node_index) const override;
-    virtual size_t indegree(node_index) const override;
+    virtual size_t outdegree(node_index) const override final;
+    virtual size_t indegree(node_index) const override final;
 
     virtual void call_nodes(const std::function<void(node_index)> &callback,
-                            const std::function<bool()> &stop_early = [](){ return false; }) const override;
+                            const std::function<bool()> &stop_early = [](){ return false; }) const override final;
 
-    virtual const DeBruijnGraph& get_graph() const { return graph_; }
+    virtual void add_sequence(std::string_view sequence,
+                              const std::function<void(node_index)> &on_insertion
+                                  = [](node_index) {}) override;
+    virtual bool load(const std::string &filename) override;
 
-    virtual bool operator==(const CanonicalDBG &other) const {
-        return graph_ == other.graph_;
+    bool operator==(const CanonicalDBG &other) const {
+        return *graph_ == *other.graph_;
     }
 
-    virtual bool operator==(const DeBruijnGraph &other) const override;
+    virtual bool operator==(const DeBruijnGraph &other) const override final;
 
     void reverse_complement(std::string &seq, std::vector<node_index> &path) const;
 
@@ -151,16 +114,6 @@ class CanonicalDBG : public DeBruijnGraph {
     node_index reverse_complement(node_index node) const;
 
   private:
-    std::shared_ptr<const DeBruijnGraph> const_graph_ptr_;
-    const DeBruijnGraph &graph_ = *const_graph_ptr_;
-    size_t offset_;
-    bool k_odd_;
-    bool has_sentinel_;
-
-    std::shared_ptr<DeBruijnGraph> graph_ptr_;
-
-    std::array<size_t, 256> alphabet_encoder_;
-
     size_t cache_size_;
 
     // cache the results of call_outgoing_kmers
@@ -174,6 +127,15 @@ class CanonicalDBG : public DeBruijnGraph {
     // cache whether a given node is a palindrome (it's equal to its reverse complement)
     mutable caches::fixed_sized_cache<node_index, bool,
                                       caches::LRUCachePolicy<node_index>> is_palindrome_cache_;
+
+    size_t offset_;
+    bool k_odd_;
+    bool has_sentinel_;
+
+    std::array<size_t, 256> alphabet_encoder_;
+
+    // reset all caches
+    void flush();
 
     // find all parent nodes of node in the CanonicalDBG which are represented
     // in the reverse complement orientation in the underlying primary graph

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -16,7 +16,7 @@ namespace graph {
  * CanonicalDBG is a wrapper which acts like a canonical-mode DeBruijnGraph, but
  * uses a non-canonical DeBruijnGraph as the underlying storage.
  */
-class CanonicalDBG : public DBGNodeModifyingWrapper<DeBruijnGraph> {
+class CanonicalDBG : public DBGWrapper<DeBruijnGraph> {
   public:
     template <typename Graph>
     explicit CanonicalDBG(Graph&& graph, size_t cache_size = 100'000);

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -96,8 +96,8 @@ class CanonicalDBG : public DBGNodeModifyingWrapper<DeBruijnGraph> {
 
     virtual void add_sequence(std::string_view sequence,
                               const std::function<void(node_index)> &on_insertion
-                                  = [](node_index) {}) override;
-    virtual bool load(const std::string &filename) override;
+                                  = [](node_index) {}) override final;
+    virtual bool load(const std::string &filename) override final;
 
     bool operator==(const CanonicalDBG &other) const {
         return *graph_ == *other.graph_;

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -23,12 +23,10 @@ class CanonicalDBG : public DBGNodeModifyingWrapper<DeBruijnGraph> {
 
     // copy constructors
     CanonicalDBG(const CanonicalDBG &canonical)
-          : CanonicalDBG(canonical.graph_ptr_ ? canonical.graph_ptr_ : canonical.graph_,
-                         canonical.cache_size_) {}
+          : CanonicalDBG(canonical.graph_, canonical.cache_size_) {}
 
     CanonicalDBG(CanonicalDBG &canonical)
-          : CanonicalDBG(canonical.graph_ptr_ ? canonical.graph_ptr_ : canonical.graph_,
-                         canonical.cache_size_) {}
+          : CanonicalDBG(canonical.graph_, canonical.cache_size_) {}
 
     // caches cannot be resized or moved, so disable these constructors
     CanonicalDBG& operator=(const CanonicalDBG &canonical) = delete;
@@ -108,10 +106,6 @@ class CanonicalDBG : public DBGNodeModifyingWrapper<DeBruijnGraph> {
     virtual void call_nodes(const std::function<void(node_index)> &callback,
                             const std::function<bool()> &stop_early = [](){ return false; }) const override final;
 
-    virtual void add_sequence(std::string_view sequence,
-                              const std::function<void(node_index)> &on_insertion
-                                  = [](node_index) {}) override final;
-    virtual bool load(const std::string &filename) override final;
     virtual bool operator==(const DeBruijnGraph &other) const override final;
 
   private:

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -16,7 +16,7 @@ namespace graph {
  * CanonicalDBG is a wrapper which acts like a canonical-mode DeBruijnGraph, but
  * uses a non-canonical DeBruijnGraph as the underlying storage.
  */
-class CanonicalDBG : public DBGWrapper<DeBruijnGraph> {
+class CanonicalDBG : public DBGNodeModifyingWrapper<DeBruijnGraph> {
   public:
     template <typename Graph>
     explicit CanonicalDBG(Graph&& graph, size_t cache_size = 100'000);
@@ -88,6 +88,8 @@ class CanonicalDBG : public DBGWrapper<DeBruijnGraph> {
 
     virtual size_t outdegree(node_index) const override final;
     virtual size_t indegree(node_index) const override final;
+
+    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override;
 
     virtual void call_nodes(const std::function<void(node_index)> &callback,
                             const std::function<bool()> &stop_early = [](){ return false; }) const override final;

--- a/metagraph/src/graph/representation/masked_graph.cpp
+++ b/metagraph/src/graph/representation/masked_graph.cpp
@@ -182,6 +182,27 @@ void MaskedDeBruijnGraph
     }
 }
 
+void MaskedDeBruijnGraph
+::call_kmers(const std::function<void(node_index, const std::string&)> &callback) const {
+    assert(max_index() + 1 == kmers_in_graph_->size());
+
+    if (only_valid_nodes_in_mask_) {
+        // iterate only through the nodes marked in the mask
+        kmers_in_graph_->call_ones([&](node_index index) {
+            if (index) {
+                assert(in_subgraph(index));
+                callback(index, get_node_sequence(index));
+            }
+        });
+    } else {
+        // call all nodes in the base graph and check the mask
+        graph_->call_kmers([&](node_index index, const std::string &seq) {
+            if (in_subgraph(index))
+                callback(index, seq);
+        });
+    }
+}
+
 // Traverse graph mapping sequence to the graph nodes
 // and run callback for each node until the termination condition is satisfied
 void MaskedDeBruijnGraph::map_to_nodes(std::string_view sequence,

--- a/metagraph/src/graph/representation/masked_graph.cpp
+++ b/metagraph/src/graph/representation/masked_graph.cpp
@@ -191,6 +191,7 @@ void MaskedDeBruijnGraph
         kmers_in_graph_->call_ones([&](node_index index) {
             if (index) {
                 assert(in_subgraph(index));
+                // TODO: make this more efficient
                 callback(index, get_node_sequence(index));
             }
         });

--- a/metagraph/src/graph/representation/masked_graph.hpp
+++ b/metagraph/src/graph/representation/masked_graph.hpp
@@ -85,19 +85,6 @@ class MaskedDeBruijnGraph : public DBGNodeModifyingWrapper<DeBruijnGraph> {
     virtual uint64_t num_nodes() const override { return kmers_in_graph_->num_set_bits(); }
     virtual uint64_t max_index() const override { return graph_->max_index(); }
 
-    virtual void add_sequence(std::string_view,
-                              const std::function<void(node_index)> &) override {
-        throw std::runtime_error("Not implemented");
-    }
-
-    virtual bool load(const std::string &) override {
-        throw std::runtime_error("Not implemented");
-    }
-
-    virtual void serialize(const std::string &) const override {
-        throw std::runtime_error("Not implemented");
-    }
-
     // Get string corresponding to |node_index|.
     // Note: Not efficient if sequences in nodes overlap. Use sparingly.
     virtual std::string get_node_sequence(node_index index) const override;

--- a/metagraph/src/graph/representation/masked_graph.hpp
+++ b/metagraph/src/graph/representation/masked_graph.hpp
@@ -11,14 +11,14 @@
 namespace mtg {
 namespace graph {
 
-class MaskedDeBruijnGraph : public DBGNodeModifyingWrapper<DeBruijnGraph> {
+class MaskedDeBruijnGraph : public DBGWrapper<DeBruijnGraph> {
   public:
     template <class Graph>
     MaskedDeBruijnGraph(Graph&& graph,
                         std::unique_ptr<bitmap>&& kmers_in_graph,
                         bool only_valid_nodes_in_mask = false,
                         Mode mode = BASIC)
-          : DBGNodeModifyingWrapper<DeBruijnGraph>(std::forward<Graph>(graph)),
+          : DBGWrapper<DeBruijnGraph>(std::forward<Graph>(graph)),
             kmers_in_graph_(std::move(kmers_in_graph)),
             only_valid_nodes_in_mask_(only_valid_nodes_in_mask),
             mode_(mode) {

--- a/metagraph/src/graph/representation/masked_graph.hpp
+++ b/metagraph/src/graph/representation/masked_graph.hpp
@@ -5,33 +5,46 @@
 #include <vector>
 
 #include "common/vectors/bitmap.hpp"
-#include "graph/representation/base/sequence_graph.hpp"
+#include "graph/representation/base/dbg_wrapper.hpp"
 
 
 namespace mtg {
 namespace graph {
 
-class MaskedDeBruijnGraph : public DeBruijnGraph {
+class MaskedDeBruijnGraph : public DBGWrapper<DeBruijnGraph> {
   public:
-    MaskedDeBruijnGraph(std::shared_ptr<const DeBruijnGraph> graph,
+    template <class Graph>
+    MaskedDeBruijnGraph(Graph&& graph,
                         std::unique_ptr<bitmap>&& kmers_in_graph,
                         bool only_valid_nodes_in_mask = false,
-                        Mode mode = BASIC);
+                        Mode mode = BASIC)
+          : DBGWrapper(std::forward<Graph>(graph)),
+            kmers_in_graph_(std::move(kmers_in_graph)),
+            only_valid_nodes_in_mask_(only_valid_nodes_in_mask),
+            mode_(mode) {
+        assert(kmers_in_graph_.get());
+        assert(kmers_in_graph_->size() == graph_->max_index() + 1);
 
-    MaskedDeBruijnGraph(std::shared_ptr<const DeBruijnGraph> graph,
+        if (graph_->get_mode() == PRIMARY && mode_ != PRIMARY) {
+            throw std::runtime_error("Any subgraph of a primary graph is primary, thus"
+                                     " the mode of the subgraph must be set to PRIMARY");
+        }
+
+        if (graph_->get_mode() != CANONICAL && mode_ == CANONICAL)
+            throw std::runtime_error("Canonical subgraph requires canonical base graph");
+    }
+
+    template <class Graph>
+    MaskedDeBruijnGraph(Graph&& graph,
                         std::function<bool(node_index)>&& callback,
                         bool only_valid_nodes_in_mask = false,
-                        Mode mode = BASIC);
-
-    MaskedDeBruijnGraph(MaskedDeBruijnGraph&&) = default;
-    MaskedDeBruijnGraph& operator=(MaskedDeBruijnGraph&&) = default;
+                        Mode mode = BASIC)
+          : MaskedDeBruijnGraph(std::forward<Graph>(graph),
+                                std::make_unique<bitmap_lazy>(
+                                    std::move(callback), graph->max_index() + 1),
+                                only_valid_nodes_in_mask, mode) {}
 
     virtual ~MaskedDeBruijnGraph() {}
-
-    virtual void add_sequence(std::string_view,
-                              const std::function<void(node_index)> &) override {
-        throw std::runtime_error("Not implemented");
-    }
 
     // Traverse graph mapping sequence to the graph nodes
     // and run callback for each node until the termination condition is satisfied
@@ -70,7 +83,11 @@ class MaskedDeBruijnGraph : public DeBruijnGraph {
                               bool kmers_in_single_form = false) const override;
 
     virtual uint64_t num_nodes() const override { return kmers_in_graph_->num_set_bits(); }
-    virtual uint64_t max_index() const override { return graph_->max_index(); }
+
+    virtual void add_sequence(std::string_view,
+                              const std::function<void(node_index)> &) override {
+        throw std::runtime_error("Not implemented");
+    }
 
     virtual bool load(const std::string &) override {
         throw std::runtime_error("Not implemented");
@@ -80,15 +97,9 @@ class MaskedDeBruijnGraph : public DeBruijnGraph {
         throw std::runtime_error("Not implemented");
     }
 
-    virtual std::string file_extension() const override { return graph_->file_extension(); }
-
-    virtual const std::string& alphabet() const override { return graph_->alphabet(); }
-
     // Get string corresponding to |node_index|.
     // Note: Not efficient if sequences in nodes overlap. Use sparingly.
     virtual std::string get_node_sequence(node_index index) const override;
-
-    virtual size_t get_k() const override { return graph_->get_k(); }
 
     virtual Mode get_mode() const override { return mode_; }
 
@@ -103,11 +114,8 @@ class MaskedDeBruijnGraph : public DeBruijnGraph {
     virtual void call_nodes(const std::function<void(node_index)> &callback,
                             const std::function<bool()> &stop_early = [](){ return false; }) const override;
 
-    virtual const DeBruijnGraph& get_graph() const { return *graph_; }
-    std::shared_ptr<const DeBruijnGraph> get_graph_ptr() const { return graph_; }
-
     virtual inline bool in_subgraph(node_index node) const {
-        assert(node > 0 && node <= graph_->max_index());
+        assert(node > 0 && node <= max_index());
         assert(kmers_in_graph_.get());
 
         return (*kmers_in_graph_)[node];
@@ -121,7 +129,6 @@ class MaskedDeBruijnGraph : public DeBruijnGraph {
     virtual const bitmap& get_mask() const { return *kmers_in_graph_; }
 
   private:
-    std::shared_ptr<const DeBruijnGraph> graph_;
     std::unique_ptr<bitmap> kmers_in_graph_;
     bool only_valid_nodes_in_mask_;
     Mode mode_;

--- a/metagraph/src/graph/representation/masked_graph.hpp
+++ b/metagraph/src/graph/representation/masked_graph.hpp
@@ -129,7 +129,6 @@ class MaskedDeBruijnGraph : public DBGNodeModifyingWrapper<DeBruijnGraph> {
 
     virtual const bitmap& get_mask() const { return *kmers_in_graph_; }
 
-    // TODO: make this more efficient
     virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override;
 
     virtual node_index kmer_to_node(std::string_view kmer) const override {

--- a/metagraph/src/graph/representation/masked_graph.hpp
+++ b/metagraph/src/graph/representation/masked_graph.hpp
@@ -11,14 +11,14 @@
 namespace mtg {
 namespace graph {
 
-class MaskedDeBruijnGraph : public DBGWrapper<DeBruijnGraph> {
+class MaskedDeBruijnGraph : public DBGNodeModifyingWrapper<DeBruijnGraph> {
   public:
     template <class Graph>
     MaskedDeBruijnGraph(Graph&& graph,
                         std::unique_ptr<bitmap>&& kmers_in_graph,
                         bool only_valid_nodes_in_mask = false,
                         Mode mode = BASIC)
-          : DBGWrapper(std::forward<Graph>(graph)),
+          : DBGNodeModifyingWrapper<DeBruijnGraph>(std::forward<Graph>(graph)),
             kmers_in_graph_(std::move(kmers_in_graph)),
             only_valid_nodes_in_mask_(only_valid_nodes_in_mask),
             mode_(mode) {
@@ -83,6 +83,7 @@ class MaskedDeBruijnGraph : public DBGWrapper<DeBruijnGraph> {
                               bool kmers_in_single_form = false) const override;
 
     virtual uint64_t num_nodes() const override { return kmers_in_graph_->num_set_bits(); }
+    virtual uint64_t max_index() const override { return graph_->max_index(); }
 
     virtual void add_sequence(std::string_view,
                               const std::function<void(node_index)> &) override {
@@ -127,6 +128,21 @@ class MaskedDeBruijnGraph : public DBGWrapper<DeBruijnGraph> {
     virtual void set_mask(bitmap *mask) { kmers_in_graph_.reset(mask); }
 
     virtual const bitmap& get_mask() const { return *kmers_in_graph_; }
+
+    // TODO: make this more efficient
+    virtual void call_kmers(const std::function<void(node_index, const std::string&)> &callback) const override;
+
+    virtual node_index kmer_to_node(std::string_view kmer) const override {
+        node_index node = graph_->kmer_to_node(kmer);
+        return (*kmers_in_graph_)[node] ? node : npos;
+    }
+
+    virtual void call_source_nodes(const std::function<void(node_index)> &callback) const override {
+        graph_->call_source_nodes([&](node_index node) {
+            if ((*kmers_in_graph_)[node])
+                callback(node);
+        });
+    }
 
   private:
     std::unique_ptr<bitmap> kmers_in_graph_;

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -151,21 +151,21 @@ build_graph<DBGSuccinct>(uint64_t k,
     return graph;
 }
 
+DBGSuccinct& get_dbg_succ(DeBruijnGraph &graph) {
+    return const_cast<DBGSuccinct&>(dynamic_cast<const DBGSuccinct&>(graph.get_base_graph()));
+}
+
+BOSS& get_boss(DeBruijnGraph &graph) {
+    return const_cast<BOSS&>(dynamic_cast<const DBGSuccinct&>(graph.get_base_graph()).get_boss());
+}
+
 template <>
 std::shared_ptr<DeBruijnGraph>
 build_graph<DBGSuccinctIndexed<1>>(uint64_t k,
                                    std::vector<std::string> sequences,
                                    DeBruijnGraph::Mode mode) {
     auto graph = build_graph<DBGSuccinct>(k, sequences, mode);
-    BOSS *boss;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        DeBruijnGraph &mutable_graph = const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        );
-        boss = &dynamic_cast<DBGSuccinct&>(mutable_graph).get_boss();
-    } else {
-        boss = &dynamic_cast<DBGSuccinct&>(*graph).get_boss();
-    }
+    BOSS *boss = &get_boss(*graph);
     boss->index_suffix_ranges(1);
 
     return graph;
@@ -177,15 +177,7 @@ build_graph<DBGSuccinctIndexed<2>>(uint64_t k,
                                    std::vector<std::string> sequences,
                                    DeBruijnGraph::Mode mode) {
     auto graph = build_graph<DBGSuccinct>(k, sequences, mode);
-    BOSS *boss;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        DeBruijnGraph &mutable_graph = const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        );
-        boss = &dynamic_cast<DBGSuccinct&>(mutable_graph).get_boss();
-    } else {
-        boss = &dynamic_cast<DBGSuccinct&>(*graph).get_boss();
-    }
+    BOSS *boss = &get_boss(*graph);
     boss->index_suffix_ranges(std::min(k - 1, (uint64_t)2));
 
     return graph;
@@ -197,15 +189,7 @@ build_graph<DBGSuccinctIndexed<10>>(uint64_t k,
                                     std::vector<std::string> sequences,
                                     DeBruijnGraph::Mode mode) {
     auto graph = build_graph<DBGSuccinct>(k, sequences, mode);
-    BOSS *boss;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        DeBruijnGraph &mutable_graph = const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        );
-        boss = &dynamic_cast<DBGSuccinct&>(mutable_graph).get_boss();
-    } else {
-        boss = &dynamic_cast<DBGSuccinct&>(*graph).get_boss();
-    }
+    BOSS *boss = &get_boss(*graph);
     boss->index_suffix_ranges(std::min(k - 1, (uint64_t)10));
 
     return graph;
@@ -217,14 +201,7 @@ build_graph<DBGSuccinctBloomFPR<1, 1>>(uint64_t k,
                                        std::vector<std::string> sequences,
                                        DeBruijnGraph::Mode mode) {
     auto graph = build_graph<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter_from_fpr(1.0);
 
     return graph;
@@ -236,14 +213,7 @@ build_graph<DBGSuccinctBloomFPR<1, 10>>(uint64_t k,
                                         std::vector<std::string> sequences,
                                         DeBruijnGraph::Mode mode) {
     auto graph = build_graph<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter_from_fpr(1.0 / 10);
 
     return graph;
@@ -255,14 +225,7 @@ build_graph<DBGSuccinctBloom<4, 1>>(uint64_t k,
                                     std::vector<std::string> sequences,
                                     DeBruijnGraph::Mode mode) {
     auto graph = build_graph<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter(4.0, 1);
 
     return graph;
@@ -274,14 +237,7 @@ build_graph<DBGSuccinctBloom<4, 50>>(uint64_t k,
                                      std::vector<std::string> sequences,
                                      DeBruijnGraph::Mode mode) {
     auto graph = build_graph<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter(4.0, 50);
 
     return graph;
@@ -355,15 +311,7 @@ build_graph_batch<DBGSuccinctIndexed<1>>(uint64_t k,
                                          std::vector<std::string> sequences,
                                          DeBruijnGraph::Mode mode) {
     auto graph = build_graph_batch<DBGSuccinct>(k, sequences, mode);
-    BOSS *boss;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        DeBruijnGraph &mutable_graph = const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        );
-        boss = &dynamic_cast<DBGSuccinct&>(mutable_graph).get_boss();
-    } else {
-        boss = &dynamic_cast<DBGSuccinct&>(*graph).get_boss();
-    }
+    BOSS *boss = &get_boss(*graph);
     boss->index_suffix_ranges(1);
 
     return graph;
@@ -375,15 +323,7 @@ build_graph_batch<DBGSuccinctIndexed<2>>(uint64_t k,
                                          std::vector<std::string> sequences,
                                          DeBruijnGraph::Mode mode) {
     auto graph = build_graph_batch<DBGSuccinct>(k, sequences, mode);
-    BOSS *boss;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        DeBruijnGraph &mutable_graph = const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        );
-        boss = &dynamic_cast<DBGSuccinct&>(mutable_graph).get_boss();
-    } else {
-        boss = &dynamic_cast<DBGSuccinct&>(*graph).get_boss();
-    }
+    BOSS *boss = &get_boss(*graph);
     boss->index_suffix_ranges(std::min(k - 1, (uint64_t)2));
 
     return graph;
@@ -395,15 +335,7 @@ build_graph_batch<DBGSuccinctIndexed<10>>(uint64_t k,
                                           std::vector<std::string> sequences,
                                           DeBruijnGraph::Mode mode) {
     auto graph = build_graph_batch<DBGSuccinct>(k, sequences, mode);
-    BOSS *boss;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        DeBruijnGraph &mutable_graph = const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        );
-        boss = &dynamic_cast<DBGSuccinct&>(mutable_graph).get_boss();
-    } else {
-        boss = &dynamic_cast<DBGSuccinct&>(*graph).get_boss();
-    }
+    BOSS *boss = &get_boss(*graph);
     boss->index_suffix_ranges(std::min(k - 1, (uint64_t)10));
 
     return graph;
@@ -415,14 +347,7 @@ build_graph_batch<DBGSuccinctBloomFPR<1, 1>>(uint64_t k,
                                              std::vector<std::string> sequences,
                                              DeBruijnGraph::Mode mode) {
     auto graph = build_graph_batch<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter_from_fpr(1.0);
 
     return graph;
@@ -434,14 +359,7 @@ build_graph_batch<DBGSuccinctBloomFPR<1, 10>>(uint64_t k,
                                               std::vector<std::string> sequences,
                                               DeBruijnGraph::Mode mode) {
     auto graph = build_graph_batch<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter_from_fpr(1.0 / 10);
 
     return graph;
@@ -453,14 +371,7 @@ build_graph_batch<DBGSuccinctBloom<4, 1>>(uint64_t k,
                                           std::vector<std::string> sequences,
                                           DeBruijnGraph::Mode mode) {
     auto graph = build_graph_batch<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter(4.0, 1);
 
     return graph;
@@ -472,14 +383,7 @@ build_graph_batch<DBGSuccinctBloom<4, 50>>(uint64_t k,
                                            std::vector<std::string> sequences,
                                            DeBruijnGraph::Mode mode) {
     auto graph = build_graph_batch<DBGSuccinct>(k, sequences, mode);
-    DBGSuccinct *dbg_succ;
-    if (mode == DeBruijnGraph::PRIMARY) {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(const_cast<DeBruijnGraph&>(
-            std::dynamic_pointer_cast<CanonicalDBG>(graph)->get_graph()
-        ));
-    } else {
-        dbg_succ = &dynamic_cast<DBGSuccinct&>(*graph);
-    }
+    DBGSuccinct *dbg_succ = &get_dbg_succ(*graph);
     dbg_succ->initialize_bloom_filter(4.0, 50);
 
     return graph;

--- a/metagraph/tests/graph/test_aligner.cpp
+++ b/metagraph/tests/graph/test_aligner.cpp
@@ -1378,12 +1378,9 @@ TEST(DBGAlignerTest, align_suffix_seed_snp_canonical) {
         auto dbg_succ = std::make_shared<DBGSuccinct>(k, mode);
         dbg_succ->add_sequence(reference_rc);
 
-        std::shared_ptr<DeBruijnGraph> graph;
-        if (mode == DeBruijnGraph::PRIMARY) {
-            graph = std::make_shared<CanonicalDBG>(*dbg_succ);
-        } else {
-            graph = dbg_succ;
-        }
+        std::shared_ptr<DeBruijnGraph> graph = dbg_succ;
+        if (mode == DeBruijnGraph::PRIMARY)
+            graph = std::make_shared<CanonicalDBG>(graph);
 
         DBGAlignerConfig config(DBGAlignerConfig::dna_scoring_matrix(2, -1, -2));
         config.max_num_seeds_per_locus = std::numeric_limits<size_t>::max();
@@ -1573,7 +1570,7 @@ TEST(DBGAlignerTest, align_suffix_seed_no_full_seeds) {
 
     auto dbg_succ = std::make_shared<DBGSuccinct>(k, DeBruijnGraph::PRIMARY);
     dbg_succ->add_sequence(reference);
-    auto graph = std::make_shared<CanonicalDBG>(*dbg_succ);
+    auto graph = std::make_shared<CanonicalDBG>(dbg_succ);
 
     DBGAlignerConfig config(DBGAlignerConfig::dna_scoring_matrix(2, -1, -2));
     config.max_num_seeds_per_locus = std::numeric_limits<size_t>::max();


### PR DESCRIPTION
This was grabbed from #333. It adds the `DBGWrapper` abstract parent class and `SequenceGraph::get_base_graph` (for easy type checking)