### PR TITLE
support row-diff transform in memory without disk swap

### DIFF
--- a/metagraph/integration_tests/base.py
+++ b/metagraph/integration_tests/base.py
@@ -106,6 +106,11 @@ class TestingBase(unittest.TestCase):
     def _annotate_graph(input, graph_path, output, anno_repr,
                         separate=False, no_fork_opt=False, no_anchor_opt=False):
         target_anno = anno_repr
+
+        noswap = anno_repr.endswith('_noswap')
+        if noswap:
+            anno_repr = anno_repr[:-len('_noswap')]
+
         if (anno_repr in {'row_sparse', 'column_coord'} or
                 anno_repr.endswith('brwt') or
                 anno_repr.startswith('row_diff')):
@@ -142,6 +147,7 @@ class TestingBase(unittest.TestCase):
 
         other_args = ' --count-kmers' if with_counts else ''
         other_args += ' --coordinates' if final_anno.endswith('_coord') else ''
+        other_args += ' --disk-swap \"\"' if noswap else ''
 
         if target_anno == 'row_diff':
             command += ' -i ' + graph_path

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -24,6 +24,7 @@ anno_file_extension = {'column': '.column.annodbg',
                        'row_sparse': '.row_sparse.annodbg',
                        'row_diff_brwt': '.row_diff_brwt.annodbg',
                        'row_diff_sparse': '.row_diff_sparse.annodbg',
+                       'row_diff_sparse_noswap': '.row_diff_sparse.annodbg',
                        'rb_brwt': '.rb_brwt.annodbg',
                        'brwt': '.brwt.annodbg',
                        'int_brwt': '.int_brwt.annodbg',
@@ -135,6 +136,10 @@ class TestQuery(TestingBase):
         assert('labels:  100' == params_str[0])
         if cls.graph_repr != 'hashfast' and (cls.graph_repr != 'succinct' or cls.mask_dummy):
             assert('objects: 46960' == params_str[1])
+
+        if cls.anno_repr.endswith('_noswap'):
+            cls.anno_repr = cls.anno_repr[:-len('_noswap')]
+
         assert('representation: ' + cls.anno_repr == params_str[3])
 
     def test_query(self):
@@ -832,6 +837,10 @@ class TestQueryCanonical(TestingBase):
         assert('labels:  100' == params_str[0])
         if cls.graph_repr != 'hashfast' and (cls.graph_repr != 'succinct' or cls.mask_dummy):
             assert('objects: 91584' == params_str[1])
+
+        if cls.anno_repr.endswith('_noswap'):
+            cls.anno_repr = cls.anno_repr[:-len('_noswap')]
+
         assert('representation: ' + cls.anno_repr == params_str[3])
 
     def test_query(self):
@@ -1038,6 +1047,10 @@ class TestQueryPrimary(TestingBase):
         assert('labels:  100' == params_str[0])
         if cls.graph_repr != 'hashfast' and (cls.graph_repr != 'succinct' or cls.mask_dummy):
             assert('objects: 45792' == params_str[1])
+
+        if cls.anno_repr.endswith('_noswap'):
+            cls.anno_repr = cls.anno_repr[:-len('_noswap')]
+
         assert('representation: ' + cls.anno_repr == params_str[3])
 
     def test_query(self):

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -832,23 +832,24 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
             total_num_labels += sources[s].num_labels();
         }
 
-        if (total_num_labels > MAX_COLUMNS_IN_BATCH / 2) {
-            logger->warn("The number of columns to transform is large: {}."
-                         " Consider disabling disk swap (pass --disk-swap \"\").",
-                         total_num_labels);
-        }
         if (total_num_labels > MAX_COLUMNS_IN_BATCH) {
-            logger->error("Too many columns to transform with disk swap: {} (> MAX {}).",
+            logger->error("Too many columns to transform with disk swap: {} (> MAX {})."
+                          " Disable disk swap (pass --disk-swap \"\").",
                           total_num_labels, MAX_COLUMNS_IN_BATCH);
             exit(1);
+        } else if (total_num_labels > MAX_COLUMNS_IN_BATCH / 2) {
+            logger->warn("The number of columns in batch is large: {}."
+                         " Consider disabling disk swap (pass --disk-swap \"\").",
+                         total_num_labels);
         }
         tmp_path = utils::create_temp_dir(swap_dir, "col");
 
         const uint32_t chunks_open_per_thread
                 = MAX_NUM_FILES_OPEN / std::max((uint32_t)1, num_threads) / (2 + with_values);
         if (chunks_open_per_thread < 3) {
-            logger->error("Can't merge with less than 3 chunks per thread open. "
-                          "Max num files open: {}. Current number of threads: {}.",
+            logger->error("Can't merge with less than 3 open chunks per thread. "
+                          "Max num files open: {}. Current number of threads: {}. "
+                          "Please reduce the number of threads.",
                           MAX_NUM_FILES_OPEN, num_threads);
             exit(1);
         }

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -1078,6 +1078,9 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
 
     async_writer.join();
 
+    // For transforms with disk swap, the diffs are dumped to temp chunks, so the
+    // fwd and bwd buffers can be removed. Otherwise, the diffs are stored there
+    // and hence must be kept (they are extracted in `call_diffs` invoked below).
     if (swap_disk) {
         set_rows_fwd.clear(); // free up memory
         set_rows_bwd.clear();

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -857,7 +857,7 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
         call_diffs = [&,chunks_open_per_thread](size_t s, size_t j) {
             return [&,s,j](const std::function<void(uint64_t)> &call) {
                 std::vector<std::string> filenames;
-                // skip chunk with fwd bits which have already been counted if stage 1
+                // for stage 1, fwd bits are already counted, so we skip that chunk
                 for (uint32_t chunk = compute_row_reduction ? 1 : 0;
                                     chunk < num_chunks[s][j]; ++chunk) {
                     filenames.push_back(tmp_file(s, j, chunk));


### PR DESCRIPTION
Necessary if the number of columns is too large
and either buffers or temp files can't be created.