### PR TITLE
building docker image and pushing to ghcr.io registry

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,11 @@ name: MetaGraph CI
 
 on: [push]
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+
 jobs:
 
   Linux:
@@ -172,6 +177,43 @@ jobs:
 
     - name: run integration tests
       run: cd metagraph/build && make check
+
+  Build-and-Push-Docker:
+    # adapted from https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages
+    if: github.ref == 'refs/heads/master'
+    needs: [Linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: checkout submodules
+      run: git submodule update --init --recursive
+
+    - name: Log in to the Container registry
+      uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+      with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract metadata (tags, labels) for Docker
+      id: meta
+      uses: docker/metadata-action@v3
+      with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   Release:
     name: Create Release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -182,7 +182,7 @@ jobs:
     # adapted from https://docs.github.com/en/actions/guides/publishing-docker-images#publishing-images-to-github-packages
     if: github.ref == 'refs/heads/master'
     needs: [Linux]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     permissions:
       contents: read
       packages: write

--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ FROM ubuntu:20.04
 ARG CODE_BASE
 
 # the image used in production. It contains a basic runtime environment for metagraph without build tools along with
-# the metagraph binary and python API code. This image is published on dockerhub (`ratschlab/metagraph`).
+# the metagraph binary and python API code. This image is published on github's container registry (`ghcr.io/ratschlab/metagraph`).
 
 RUN apt-get update && apt-get install -y \
     libatomic1 \

--- a/metagraph/docs/source/installation.rst
+++ b/metagraph/docs/source/installation.rst
@@ -23,13 +23,15 @@ Docker container
 
 If docker is available on your system, you can immediately get started with::
 
-    docker run -v ${DATA_DIR_HOST}:/mnt ratschlab/metagraph \
+    docker run -v ${DATA_DIR_HOST}:/mnt ghcr.io/ratschlab/metagraph:latest \
         build -v -k 10 -o /mnt/transcripts_1000 /mnt/transcripts_1000.fa
 
 
 where you'd need to replace ``${DATA_DIR_HOST}`` with a directory on the host system to map it
 under ``/mnt`` in the container. This docker container uses the latest version of MetaGraph from
 the source `GitHub repository <https://github.com/ratschlab/metagraph>`_ (branch ``master``).
+See also the `image overview <https://github.com/ratschlab/metagraph/pkgs/container/metagraph>`_ for
+other versions of the metagraph image.
 
 
 Install from source
@@ -131,7 +133,7 @@ To compile MetaGraph, please follow these steps.
     git clone --recursive https://github.com/ratschlab/metagraph.git
 
 #. Change into the ``metagraph`` directory::
-    
+
     cd metagraph
 
 #. Make sure all submodules have been downloaded::


### PR DESCRIPTION
On commits/PR merges on master, build and push docker image to github packages/containers (ghcr.io).

Moving away from dockerhub as autobuilds are no longer part of the free plan. Alternatively, with building using github actions and pushing to dockerhub handling credentials properly would be a bit involved (and possibly not free either).