### PR TITLE
limit the number of threads when compiling KMC

### DIFF
--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -174,7 +174,12 @@ execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
 if(result)
   message(FATAL_ERROR "CMake step for KMC failed: ${result}")
 endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build . --config Release -- -j
+include(ProcessorCount)
+ProcessorCount(N)
+if(N EQUAL 0)
+  set(N 1)
+endif()
+execute_process(COMMAND ${CMAKE_COMMAND} --build . --config Release -- -j${N}
   RESULT_VARIABLE result
   WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/KMC
 )


### PR DESCRIPTION
... to keep RAM usage during compilation under control

Hopefully this will fix the issue with compiling for bioconda https://github.com/bioconda/bioconda-recipes/pull/32025