### PR TITLE
Output counts for aggregated columns

### DIFF
--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -78,9 +78,10 @@ occurring at least 5 times in the input::
     ./KMC/kmc -ci5 -t4 -k$K -m5 -fm SRR403017.fasta.gz SRR403017.cutoff_5 ./KMC
     metagraph build -v -p 4 -k $K --mem-cap-gb 10 -o graph SRR403017.cutoff_5.kmc_pre
 
-.. note:: In the above example, we use ``./KMC`` as the directory where KMC will store its
-          intermediate caches. Depending on your input data, this directory should be at a location
-          with a sufficient amount of free intermediate storage space.
+.. note::
+    In the above example, we use ``./KMC`` as the directory where KMC will store its
+    intermediate caches. Depending on your input data, this directory should be at a location
+    with a sufficient amount of free intermediate storage space.
 
 Construct with disk swap
 """"""""""""""""""""""""
@@ -174,7 +175,8 @@ they are situated in a unitig with sufficiently many highly abundant k-mers.
 
     zless SRR403017_clean_contigs.fasta.gz
 
-.. note:: The default parameters in ``metagraph clean`` correspond to no cleaning. That is, an equivalent of ``metagraph transform --to-fasta``, which extracts from the input de Bruijn graph all contigs, without removing any k-mers.
+.. note::
+    The default parameters in ``metagraph clean`` correspond to no cleaning. That is, an equivalent of ``metagraph transform --to-fasta``, which extracts from the input de Bruijn graph all contigs, without removing any k-mers.
 
 For cleaning graphs constructed from high-throughput Illumina reads, the recommended parameters are
 ``--prune-tips <2k> --prune-unitigs 0 --fallback 2``, which implements the cleaning procedure proposed in `McCortex <https://github.com/mcveanlab/mccortex>`_ (Turner et al., 2018) and includes the following steps:
@@ -371,7 +373,8 @@ Examples
     metagraph transform_anno --aggregate-columns -o out \
                              --min-fraction 0.95 annotation.column.annodbg
 
-.. note:: This command (``metagraph transform_anno --aggregate-columns ...``) only supports annotations
+.. note::
+    This command (``metagraph transform_anno --aggregate-columns ...``) only supports annotations
     in the ColumnCompressed format, that is, constructed by the ``metagraph annotate`` command.
     If the input columns have associated counts (e.g., constructed with ``metagraph annotate --count-kmers ...``),
     they can be loaded and used by the aggregator as well.

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -266,7 +266,7 @@ void ColumnCompressed<Label>::serialize_counts(const std::string &filename) cons
     }
 
     logger->info("Num relation counts: {}", num_counts);
-    logger->info("Total relation count: {}", sum_counts);
+    logger->info("Relation counts sum: {}", sum_counts);
 }
 
 template <typename Label>

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -234,6 +234,7 @@ void ColumnCompressed<Label>::serialize_counts(const std::string &filename) cons
 
     for (size_t j = 0; j < relation_counts_.size(); ++j) {
         if (!relation_counts_[j].size()) {
+            // there were no counts for the column, so we're writing a vector of zeros
             sdsl::int_vector<>(bitmatrix_[j]->num_set_bits(), 0, 1).serialize(out);
 
         } else {

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -1079,6 +1079,9 @@ void Config::print_usage(const std::string &prog_name, IdentityType identity) {
             fprintf(stderr, "Available options for stats:\n");
             fprintf(stderr, "\t   --print \t\tprint graph table to the screen [off]\n");
             fprintf(stderr, "\t   --print-internal \tprint internal graph representation to screen [off]\n");
+            fprintf(stderr, "\t   --count-quantiles [FLOAT ...] \tk-mer count quantiles to compute for each label [off]\n"
+                            "\t                                 \t\tExample: --count-quantiles '0 0.33 0.5 0.66 1'\n"
+                            "\t                                 \t\t(0 corresponds to MIN, 1 corresponds to MAX)\n");
             fprintf(stderr, "\t   --print-counts-hist \tprint histogram of k-mer weights as pairs (weight: num_kmers) [off]\n");
             fprintf(stderr, "\t   --count-dummy \tshow number of dummy source and sink edges [off]\n");
             fprintf(stderr, "\t-a --annotator [STR] \tannotation []\n");


### PR DESCRIPTION
Also added support for printing statistics for counts, e.g.:
```
./metagraph stats -a annotation.column.annodbg --print-counts-hist --count-quantiles "0.0 0.5 1.0"
```