### PR TITLE
query expressions (counts) in labels for individual k-mers in query

### DIFF
--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -41,7 +41,7 @@ class GraphClientJson:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
-               weighted_with_counts: bool = False,
+               abundance_sum: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> Tuple[JsonDict, str]:
@@ -76,7 +76,7 @@ class GraphClientJson:
                       "discovery_fraction": discovery_threshold,
                       "num_labels": top_labels,
                       "with_signature": with_signature,
-                      "weighted_with_counts": weighted_with_counts,
+                      "abundance_sum": abundance_sum,
                       "query_coords": query_coords}
 
         search_results = self._json_seq_query(sequence, param_dict, "search")
@@ -173,7 +173,7 @@ class GraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
-               weighted_with_counts: bool = False,
+               abundance_sum: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> pd.DataFrame:
@@ -181,7 +181,7 @@ class GraphClient:
 
         json_obj = self._json_client.search(sequence, top_labels,
                                             discovery_threshold, with_signature,
-                                            weighted_with_counts, query_coords,
+                                            abundance_sum, query_coords,
                                             align, **align_params)
 
         return helpers.df_from_search_result(json_obj)
@@ -229,7 +229,7 @@ class MultiGraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
-               weighted_with_counts: bool = False,
+               abundance_sum: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> Dict[str, Union[pd.DataFrame, Future]]:
@@ -248,7 +248,7 @@ class MultiGraphClient:
             for name, graph_client in self.graphs.items():
                 result[name] = graph_client.search(sequence, top_labels,
                                                    discovery_threshold, with_signature,
-                                                   weighted_with_counts, query_coords,
+                                                   abundance_sum, query_coords,
                                                    align, **align_params)
 
             return result
@@ -263,7 +263,7 @@ class MultiGraphClient:
         for name, graph_client in self.graphs.items():
             futures[name] = executor.submit(graph_client.search, sequence,
                                             top_labels, discovery_threshold, with_signature,
-                                            weighted_with_counts, query_coords,
+                                            abundance_sum, query_coords,
                                             align, **align_params)
 
         print(f'Made {len(self.graphs)} requests with {num_processes} threads...')

--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -42,6 +42,7 @@ class GraphClientJson:
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
                abundance_sum: bool = False,
+               query_counts: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> Tuple[JsonDict, str]:
@@ -77,6 +78,7 @@ class GraphClientJson:
                       "num_labels": top_labels,
                       "with_signature": with_signature,
                       "abundance_sum": abundance_sum,
+                      "query_counts": query_counts,
                       "query_coords": query_coords}
 
         search_results = self._json_seq_query(sequence, param_dict, "search")
@@ -174,6 +176,7 @@ class GraphClient:
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
                abundance_sum: bool = False,
+               query_counts: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> pd.DataFrame:
@@ -181,7 +184,7 @@ class GraphClient:
 
         json_obj = self._json_client.search(sequence, top_labels,
                                             discovery_threshold, with_signature,
-                                            abundance_sum, query_coords,
+                                            abundance_sum, query_counts, query_coords,
                                             align, **align_params)
 
         return helpers.df_from_search_result(json_obj)
@@ -230,6 +233,7 @@ class MultiGraphClient:
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
                abundance_sum: bool = False,
+               query_counts: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> Dict[str, Union[pd.DataFrame, Future]]:
@@ -248,7 +252,7 @@ class MultiGraphClient:
             for name, graph_client in self.graphs.items():
                 result[name] = graph_client.search(sequence, top_labels,
                                                    discovery_threshold, with_signature,
-                                                   abundance_sum, query_coords,
+                                                   abundance_sum, query_counts, query_coords,
                                                    align, **align_params)
 
             return result
@@ -263,7 +267,7 @@ class MultiGraphClient:
         for name, graph_client in self.graphs.items():
             futures[name] = executor.submit(graph_client.search, sequence,
                                             top_labels, discovery_threshold, with_signature,
-                                            abundance_sum, query_coords,
+                                            abundance_sum, query_counts, query_coords,
                                             align, **align_params)
 
         print(f'Made {len(self.graphs)} requests with {num_processes} threads...')

--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -41,7 +41,7 @@ class GraphClientJson:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
-               query_counts: bool = False,
+               weighted_with_counts: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> Tuple[JsonDict, str]:
@@ -76,7 +76,7 @@ class GraphClientJson:
                       "discovery_fraction": discovery_threshold,
                       "num_labels": top_labels,
                       "with_signature": with_signature,
-                      "query_counts": query_counts,
+                      "weighted_with_counts": weighted_with_counts,
                       "query_coords": query_coords}
 
         search_results = self._json_seq_query(sequence, param_dict, "search")
@@ -173,7 +173,7 @@ class GraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
-               query_counts: bool = False,
+               weighted_with_counts: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> pd.DataFrame:
@@ -181,7 +181,7 @@ class GraphClient:
 
         json_obj = self._json_client.search(sequence, top_labels,
                                             discovery_threshold, with_signature,
-                                            query_counts, query_coords,
+                                            weighted_with_counts, query_coords,
                                             align, **align_params)
 
         return helpers.df_from_search_result(json_obj)
@@ -229,7 +229,7 @@ class MultiGraphClient:
                top_labels: int = DEFAULT_TOP_LABELS,
                discovery_threshold: float = DEFAULT_DISCOVERY_THRESHOLD,
                with_signature: bool = False,
-               query_counts: bool = False,
+               weighted_with_counts: bool = False,
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> Dict[str, Union[pd.DataFrame, Future]]:
@@ -248,7 +248,7 @@ class MultiGraphClient:
             for name, graph_client in self.graphs.items():
                 result[name] = graph_client.search(sequence, top_labels,
                                                    discovery_threshold, with_signature,
-                                                   query_counts, query_coords,
+                                                   weighted_with_counts, query_coords,
                                                    align, **align_params)
 
             return result
@@ -263,7 +263,7 @@ class MultiGraphClient:
         for name, graph_client in self.graphs.items():
             futures[name] = executor.submit(graph_client.search, sequence,
                                             top_labels, discovery_threshold, with_signature,
-                                            query_counts, query_coords,
+                                            weighted_with_counts, query_coords,
                                             align, **align_params)
 
         print(f'Made {len(self.graphs)} requests with {num_processes} threads...')

--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -180,7 +180,29 @@ class GraphClient:
                query_coords: bool = False,
                align: bool = False,
                **align_params) -> pd.DataFrame:
-        """See parameters for alignment `align_params` in align()"""
+        """
+        :param      sequence:             The query sequence
+        :type       sequence:             Union[str, Iterable[str]]
+        :param      top_labels:           The maximum number of matched labels to retrieve [default: 100]
+        :type       top_labels:           int
+        :param      discovery_threshold:  The minimum fraction (between 0.0 and 1.0) of k-mers from the query required to match a label (occur in a sample) in order for that label to show up in the result [default: 0.0]
+        :type       discovery_threshold:  float
+        :param      with_signature:       Return the signature of k-mer matches
+        :type       with_signature:       bool
+        :param      abundance_sum:        Compute the sum of abundances for all k-mers matched
+        :type       abundance_sum:        bool
+        :param      query_counts:         Query k-mer counts
+        :type       query_counts:         bool
+        :param      query_coords:         Query k-mer coordinates
+        :type       query_coords:         bool
+        :param      align:                Align the query sequence to the joint graph and query labels for that alignment instead of the original sequence
+        :type       align:                bool
+        :param      align_params:         The parameters for alignment (see method align())
+        :type       align_params:         dictionary
+
+        :return:    A data frame with query results
+        :rtype:     pandas.DataFrame
+        """
 
         json_obj = self._json_client.search(sequence, top_labels,
                                             discovery_threshold, with_signature,
@@ -193,6 +215,21 @@ class GraphClient:
               min_exact_match: float = DEFAULT_DISCOVERY_THRESHOLD,
               max_alternative_alignments: int = 1,
               max_num_nodes_per_seq_char: float = DEFAULT_NUM_NODES_PER_SEQ_CHAR) -> pd.DataFrame:
+        """
+        Align sequence(s) to the joint graph
+
+        :param      sequence:                    The query sequence
+        :type       sequence:                    Union[str, Iterable[str]]
+        :param      min_exact_match:             The minimum fraction (between 0.0 and 1.0) of matching nucleotides required to align sequence [default: 0]
+        :type       min_exact_match:             float
+        :param      max_alternative_alignments:  The number of different alignments to return [default: 1]
+        :type       max_alternative_alignments:  int
+        :param      max_num_nodes_per_seq_char:  The maximum number of nodes to consider per sequence character during extension [default: 10.0]
+        :type       max_num_nodes_per_seq_char:  float
+
+        :returns:   A data frame with alignments
+        :rtype:     pandas.DataFrame
+        """
         json_obj = self._json_client.align(sequence, min_exact_match,
                                            max_alternative_alignments,
                                            max_num_nodes_per_seq_char)

--- a/metagraph/docs/source/api.rst
+++ b/metagraph/docs/source/api.rst
@@ -17,17 +17,84 @@ Install MetaGraph API in Python::
 
 Sequence search
 ---------------
-The Python client has a ``search`` method which allows querying an index running on a server.
+The Python client has a ``search`` method for querying an index running on a server.
 The method accepts a single sequence or list of sequences represented with strings.
+
+.. py:function:: metagraph.client.GraphClient.search(self, ...)
+
+        :param      sequence:             Query sequence
+        :type       sequence:             Union[str, Iterable[str]]
+        :param      top_labels:           The maximum number of matched labels to retrieve [default: 100]
+        :type       top_labels:           int
+        :param      discovery_threshold:  The minimum fraction (between 0.0 and 1.0) of k-mers from the query required to match a label (occur in a sample) in order for that label to show up in the result [default: 0.0]
+        :type       discovery_threshold:  float
+        :param      with_signature:       Return the signature of k-mer matches
+        :type       with_signature:       bool
+        :param      abundance_sum:        Compute the sum of abundances for all k-mers matched
+        :type       abundance_sum:        bool
+        :param      query_counts:         Query k-mer counts
+        :type       query_counts:         bool
+        :param      query_coords:         Query k-mer coordinates
+        :type       query_coords:         bool
+        :param      align:                Align the query sequence to the joint graph and query labels for that alignment instead of the original sequence
+        :type       align:                bool
+        :param      align_params:         The parameters for alignment (see method align())
+        :type       align_params:         dictionary
+        :return:                          A data frame with query results
+        :rtype:                           pandas.DataFrame
+
+``GraphClient`` will return an instance of ``pandas.DataFrame`` storing the result.
+You can also use the lower level ``GraphClientJson`` to instead receive a JSON response.
+
+
+Search with alignment
+^^^^^^^^^^^^^^^^^^^^^
+It is possible to first align a sequence to the joint graph and use the aligned sequence to query the index.
+This can be done by setting ``align=True`` (default False).
+If the ``align`` flag is set, all the alignment options (explained in the :ref:`Sequence alignment <alignment>` section below) are accepted::
+
+    metasub.search(query, discovery_threshold=0.0, top_labels=200,
+                   align=True, min_exact_match=0.8, max_num_nodes_per_seq_char=10.0)
+
+Querying k-mer abundance and coordinates
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Metagraph supports k-mer count- and coordinate-aware indexes (see :ref:`Indexing k-mer counts <indexing counts>`
+and :ref:`Indexing k-mer coordinates <indexing coordinates>`).
+If you are querying such an index,
+you can also set ``abundance_sum=True``, ``query_counts=True``, or ``query_coords=True``. If you try to query an
+index which does not support either of these query types, the server will return an error.
+
+
+.. _alignment:
+
+Sequence alignment
+------------------
+The ``align`` method allows alignment of sequences to the the graph.
+The method accepts a single sequence or list of sequences represented with strings.
+Additionally, the method accepts the following keyword arguments:
+
+.. py:function:: metagraph.client.GraphClient.align(self, ...)
+
+        Align sequence(s) to the joint graph
+
+        :param      sequence:                    The query sequence
+        :type       sequence:                    Union[str, Iterable[str]]
+        :param      min_exact_match:             The minimum fraction (between 0.0 and 1.0) of matching nucleotides required to align sequence [default: 0]
+        :type       min_exact_match:             float
+        :param      max_alternative_alignments:  The number of different alignments to return [default: 1]
+        :type       max_alternative_alignments:  int
+        :param      max_num_nodes_per_seq_char:  The maximum number of nodes to consider per sequence character during extension [default: 10.0]
+        :type       max_num_nodes_per_seq_char:  float
+
+        :returns:   A data frame with alignments
+        :rtype:     pandas.DataFrame
+
+
+Examples
+--------
 
 Example of search in MetaSUB
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-For basic usage, the method accepts the following keyword arguments:
-
-- ``top_labels``: the maximum number of matched labels to retrieve [default: 100]
-- ``discovery_fraction``: a value between 0.0 and 1.0 specifying the minimum fraction of
-  matching k-mers needed to match a label [default: 0.0]
-
 ::
 
     from metagraph.client import GraphClient
@@ -37,7 +104,7 @@ For basic usage, the method accepts the following keyword arguments:
     lbls = metasub.column_labels()
 
     # >ENA|A14565|A14565.1 16S rRNA
-    query= 'TCGAACGGTAACAGGAAGAAGCTTGCTTCTTTGCTGACGAGTGGCGGACGGGTGAGTAAT\
+    query = 'TCGAACGGTAACAGGAAGAAGCTTGCTTCTTTGCTGACGAGTGGCGGACGGGTGAGTAAT\
             GTCTGGGAAACTGCCTGATGGAGGGGGATAACTACTGGAAACGGTAGCTAATACCGCATA\
             ACGTCGCAAGACCAAAGAGGGGGACCTTCGGGCCTCTTGCCATCGGATGTGCCCAGATGG\
             GATTAGCTAGTAGGTGGGGTAACGGCTCACCTAGGCGACGATCCCTAGCTGGTCTGAGAG\
@@ -65,41 +132,11 @@ For basic usage, the method accepts the following keyword arguments:
 
     metasub.search(query, discovery_threshold=0.0, top_labels=200)
 
-``GraphClient`` will return an instance of ``pandas.DataFrame`` storing the result.
-You can also use the lower level ``GraphClientJson`` to instead receive a JSON response.
-
-Search with alignment
-^^^^^^^^^^^^^^^^^^^^^
-It is possible to first align a sequence and use the aligned sequence to query the index.
-This can be done by setting ``align=True`` (default False).
-If the ``align`` flag is set, all the alignment options (explained in the alignment section below) are accepted::
-
-    metasub.search(query, discovery_threshold=0.0, top_labels=200,
-                   align=True, min_exact_match=0.8, max_num_nodes_per_seq_char=10.0)
-
-Searching count and coordinate indexes
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Metagraph supports k-mer count-aware and coordinate-aware indexes. If you are querying such an index,
-you can also set ``abundance_sum=True`` or ``query_coords=True``, respectively. If you try to query an
-index which does not support either of these query types, the server will return an error.
-
-Alignment
----------
-The ``align`` method allows alignment of sequences to the the graph.
-The method accepts a single sequence or list of sequences represented with strings.
-Additionally, the method accepts the following keyword arguments:
-
-- ``minimum_exact_match``: a value between 0.0 and 1.0 specifying the minimum fraction of
-  matching nucleotides needed to align sequence [default: 0.0]
-- ``max_alternative_alignments``: max number of different alignments to return [default: 1]
-- ``max_num_nodes_per_seq_char``: maximum number of nodes to consider during extension [default: 10.0]
-
-::
-
     metasub.align(query, min_exact_match=0.8)
 
+
 Search multiple graphs in parallel
-----------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 The API provides ``MultiGraphClient``, which can query multiple graph servers in parallel.
 Both ``search`` and ``align`` have the keyword argument ``parallel`` [default: True].
 If ``parallel=True``, the result will be a dictionary mapping specified index names to instances
@@ -155,7 +192,7 @@ be ``instances of pandas.DataFrame``.
     # or block and wait for all of the results
     result = MultiGraphClient.wait_for_result(futures)
 
-Other examples
---------------
 
+Other examples
+^^^^^^^^^^^^^^
 Find more examples `here <https://github.com/ratschlab/metagraph_paper_resources/blob/master/notebooks/>`_.

--- a/metagraph/docs/source/api.rst
+++ b/metagraph/docs/source/api.rst
@@ -80,7 +80,7 @@ If the ``align`` flag is set, all the alignment options (explained in the alignm
 Searching count and coordinate indexes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Metagraph supports k-mer count-aware and coordinate-aware indexes. If you are querying such an index,
-you can also set ``query_counts=True`` or ``query_coords=True``, respectively. If you try to query an
+you can also set ``weighted_with_counts=True`` or ``query_coords=True``, respectively. If you try to query an
 index which does not support either of these query types, the server will return an error.
 
 Alignment

--- a/metagraph/docs/source/api.rst
+++ b/metagraph/docs/source/api.rst
@@ -80,7 +80,7 @@ If the ``align`` flag is set, all the alignment options (explained in the alignm
 Searching count and coordinate indexes
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Metagraph supports k-mer count-aware and coordinate-aware indexes. If you are querying such an index,
-you can also set ``weighted_with_counts=True`` or ``query_coords=True``, respectively. If you try to query an
+you can also set ``abundance_sum=True`` or ``query_coords=True``, respectively. If you try to query an
 index which does not support either of these query types, the server will return an error.
 
 Alignment

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -319,6 +319,19 @@ The stats for a constructed graph/annotation can always be checked with ::
     metagraph stats graph.dbg
     metagraph stats -a annotation.column.annodbg
 
+.. _indexing counts:
+
+Indexing k-mer counts
+^^^^^^^^^^^^^^^^^^^^^
+TODO
+
+.. _indexing coordinates:
+
+Indexing k-mer coordinates
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+TODO
+
+
 Query index
 -----------
 

--- a/metagraph/integration_tests/base.py
+++ b/metagraph/integration_tests/base.py
@@ -38,6 +38,9 @@ class TestingBase(unittest.TestCase):
 
     @staticmethod
     def _build_graph(input, output, k, repr, mode='basic', extra_params=''):
+        if not isinstance(input, str):
+            input = ' '.join(input)
+
         if not output.endswith(graph_file_extension[repr]):
             output += graph_file_extension[repr]
 
@@ -103,6 +106,9 @@ class TestingBase(unittest.TestCase):
     def _annotate_graph(input, graph_path, output, anno_repr,
                         separate=False, no_fork_opt=False, no_anchor_opt=False,
                         anno_type='header', extra_params=''):
+        if not isinstance(input, str):
+            input = ' '.join(input)
+
         target_anno = anno_repr
 
         noswap = anno_repr.endswith('_noswap')

--- a/metagraph/integration_tests/base.py
+++ b/metagraph/integration_tests/base.py
@@ -105,7 +105,7 @@ class TestingBase(unittest.TestCase):
     @staticmethod
     def _annotate_graph(input, graph_path, output, anno_repr,
                         separate=False, no_fork_opt=False, no_anchor_opt=False,
-                        anno_type='header', extra_params=''):
+                        anno_type='header', extra_params='', num_threads=NUM_THREADS):
         if not isinstance(input, str):
             input = ' '.join(input)
 
@@ -125,7 +125,7 @@ class TestingBase(unittest.TestCase):
             target_anno = anno_repr
             anno_repr = 'row'
 
-        command = f'{METAGRAPH} annotate -p {NUM_THREADS} --anno-{anno_type}\
+        command = f'{METAGRAPH} annotate -p {num_threads} --anno-{anno_type}\
                     -i {graph_path} --anno-type {anno_repr} {extra_params} \
                     -o {output} {input}'
 
@@ -146,7 +146,7 @@ class TestingBase(unittest.TestCase):
         if final_anno.startswith('row_diff'):
             target_anno = 'row_diff'
 
-        command = f'{METAGRAPH} transform_anno -p {NUM_THREADS} \
+        command = f'{METAGRAPH} transform_anno -p {num_threads} \
                     --anno-type {target_anno} -o {output} \
                     {output + anno_file_extension[anno_repr]}'
 
@@ -184,7 +184,7 @@ class TestingBase(unittest.TestCase):
             if final_anno != target_anno:
                 rd_type = 'column' if with_counts or final_anno.endswith('_coord') else 'row_diff'
                 command = f'{METAGRAPH} transform_anno --anno-type {final_anno} --greedy -o {output} ' \
-                                   f'-i {graph_path} -p {NUM_THREADS} {output}.{rd_type}.annodbg'
+                                   f'-i {graph_path} -p {num_threads} {output}.{rd_type}.annodbg'
                 res = subprocess.run([command], shell=True)
                 assert (res.returncode == 0)
                 os.remove(output + anno_file_extension[rd_type])
@@ -192,6 +192,6 @@ class TestingBase(unittest.TestCase):
                 os.remove(output + anno_file_extension[anno_repr])
 
         if final_anno.endswith('brwt') or final_anno.endswith('brwt_coord'):
-            command = f'{METAGRAPH} relax_brwt -o {output} -p {NUM_THREADS} {output}.{final_anno}.annodbg'
+            command = f'{METAGRAPH} relax_brwt -o {output} -p {num_threads} {output}.{final_anno}.annodbg'
             res = subprocess.run([command], shell=True)
             assert (res.returncode == 0)

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -251,6 +251,7 @@ class TestAPIClient(TestAPIBase):
                                        discovery_threshold=0.01)
         df = ret[self.graph_name]
         self.assertEqual((self.sample_query_expected_rows * repetitions, 3), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381 * repetitions)
 
     def test_api_simple_query_df(self):
         ret = self.graph_client.search(self.sample_query, parallel=False,
@@ -258,6 +259,7 @@ class TestAPIClient(TestAPIBase):
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
 
     def test_api_simple_query_with_signature_df(self):
         ret = self.graph_client.search(self.sample_query, parallel=False,
@@ -265,6 +267,7 @@ class TestAPIClient(TestAPIBase):
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 4), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
 
     def test_api_simple_query_align_df(self):
         ret = self.graph_client.search(self.sample_query, parallel=False,
@@ -272,6 +275,7 @@ class TestAPIClient(TestAPIBase):
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
 
     def test_api_simple_query_align_no_result(self):
         # If aligned sequence does not have result when searched, make sure client doesn't fail
@@ -288,7 +292,7 @@ class TestAPIClient(TestAPIBase):
 
         label_list = ret[self.graph_name]
 
-        self.assertGreater(len(label_list), 0)
+        self.assertEqual(len(label_list), 100)
         self.assertTrue(all(l.startswith('ENST') for l in label_list))
 
     def test_api_align_df(self):
@@ -431,13 +435,39 @@ class TestAPIClientWithCoordinates(TestAPIBase):
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
+    def test_api_simple_query_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False)
+        df = ret[self.graph_name]
+
+        self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
+
+    def test_api_simple_query_abundance_sum_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False, abundance_sum=True)
+        df = ret[self.graph_name]
+
+        self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 2323)
+
+    def test_api_simple_query_counts_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False, query_counts=True)
+        df = ret[self.graph_name]
+
+        self.assertEqual((self.sample_query_expected_rows, 4), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
+        self.assertEqual(df['kmer_abundances'].size, self.sample_query_expected_rows)
+
     def test_api_simple_query_coords_df(self):
         ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
                                        parallel=False, query_coords=True)
         df = ret[self.graph_name]
 
-        self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
-        self.assertIn('kmer_coords', df.columns)
+        self.assertEqual((self.sample_query_expected_rows, 4), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
+        self.assertEqual(df['kmer_coords'].size, self.sample_query_expected_rows)
 
 
 @parameterized_class(('mode',), input_values=[('canonical',), ('primary',)])
@@ -458,13 +488,30 @@ class TestAPIClientWithCounts(TestAPIBase):
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
+    def test_api_simple_query_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False)
+        df = ret[self.graph_name]
+
+        self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
+
     def test_api_simple_query_abundance_sum_df(self):
         ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
                                        parallel=False, abundance_sum=True)
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
-        self.assertIn('kmer_count', df.columns)
+        self.assertEqual(df['kmer_count'].sum(), 2323)
+
+    def test_api_simple_query_counts_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False, query_counts=True)
+        df = ret[self.graph_name]
+
+        self.assertEqual((self.sample_query_expected_rows, 4), df.shape)
+        self.assertEqual(df['kmer_count'].sum(), 1381)
+        self.assertEqual(df['kmer_abundances'].size, self.sample_query_expected_rows)
 
     @unittest.expectedFailure
     def test_api_search_no_coordinate_support(self):

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -150,6 +150,7 @@ class TestAPIRaw(TestAPIBase):
         self.assertEqual(json_ret[0]['results'], [])
 
     @parameterized.expand([(1,1), (3,1)])
+    @unittest.skipIf(PROTEIN_MODE, "Protein graphs have different alignments")
     def test_api_raw_align_sequence(self, repetitions, dummy_arg):
         fasta_str = '\n'.join([ f">query{i}\nTCGATCGA" for i in range(repetitions)])
 

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -55,14 +55,8 @@ class TestAPIBase(TestingBase):
         cls.server_process.kill()
 
     def _start_server(self, graph, annotation):
-        construct_command = '{exe} server_query -i {graph} -a {annot} --port {port} --address {host} -p {threads}'.format(
-            exe=METAGRAPH,
-            graph=graph,
-            annot=annotation,
-            host=self.host,
-            port=self.port,
-            threads=2
-        )
+        construct_command = f'{METAGRAPH} server_query -i {graph} -a {annotation} \
+                                            --port {self.port} --address {self.host} -p {2}'
 
         return subprocess.Popen(shlex.split(construct_command))
 
@@ -75,10 +69,13 @@ class TestAPIRaw(TestAPIBase):
         super().setUpClass(TEST_DATA_DIR + '/transcripts_100.fa', mode=cls.mode)
 
     def setUp(self) -> None:
-        self.raw_post_request = lambda cmd, payload: requests.post(url=f'http://{self.host}:{self.port}/{cmd}', data=payload)
+        self.raw_post_request = lambda cmd, payload: requests.post(
+                                    url=f'http://{self.host}:{self.port}/{cmd}',
+                                    data=payload)
 
     def test_api_raw_incomplete_json(self):
-        ret = self.raw_post_request('search', '{"FASTA": ">query\\nAATAAAGGTGTGAGATAACCCCAGCGGTGCCAGGATCCGTGCA", "discovery_fraction": 0.1,')
+        ret = self.raw_post_request('search',
+            '{"FASTA": ">query\\nAATAAAGGTGTGAGATAACCCCAGCGGTGCCAGGATCCGTGCA", "discovery_fraction": 0.1,')
 
         self.assertEqual(ret.status_code, 400)
         self.assertIn("Bad json received:", ret.json()['error'])
@@ -279,8 +276,8 @@ class TestAPIClient(TestAPIBase):
     def test_api_simple_query_align_no_result(self):
         # If aligned sequence does not have result when searched, make sure client doesn't fail
         sample_align_query = self.sample_query[:2] + 'GG' + self.sample_query[4:]
-        ret = self.graph_client.search(sample_align_query, parallel=False, discovery_threshold=1.0,
-                                       align=True)
+        ret = self.graph_client.search(sample_align_query, parallel=False,
+                                       discovery_threshold=1.0, align=True)
         df = ret[self.graph_name]
         self.assertTrue(df.empty)
 
@@ -373,7 +370,8 @@ class TestAPIJson(TestAPIBase):
         self.assertEqual(len(res_list), repetitions)
 
         # testing if the returned query indices range from 0 to n - 1
-        self.assertEqual(sorted(range(0, repetitions)), sorted([int(a['seq_description']) for a in res_list]))
+        self.assertEqual(sorted(range(0, repetitions)),
+                         sorted([int(a['seq_description']) for a in res_list]))
 
     def test_api_stats(self):
         res = self.graph_client.stats()
@@ -427,13 +425,15 @@ class TestAPIClientWithCoordinates(TestAPIBase):
 
     @classmethod
     def setUpClass(cls):
-        super().setUpClass(TEST_DATA_DIR + '/transcripts_100.fa', mode=cls.mode, anno_repr='row_diff_brwt_coord')
+        super().setUpClass(TEST_DATA_DIR + '/transcripts_100.fa', mode=cls.mode,
+                           anno_repr='row_diff_brwt_coord')
 
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
     def test_api_simple_query_coords_df(self):
-        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, parallel=False, query_coords=True)
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False, query_coords=True)
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
@@ -459,7 +459,8 @@ class TestAPIClientWithCounts(TestAPIBase):
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
     def test_api_simple_query_abundance_sum_df(self):
-        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, parallel=False, abundance_sum=True)
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False, abundance_sum=True)
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)
@@ -467,7 +468,8 @@ class TestAPIClientWithCounts(TestAPIBase):
 
     @unittest.expectedFailure
     def test_api_search_no_coordinate_support(self):
-        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, parallel=False, query_coords=True)
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01,
+                                       parallel=False, query_coords=True)
 
 
 @parameterized_class(('mode',), input_values=[('canonical',), ('primary',)])

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -225,7 +225,7 @@ class TestAPIRaw(TestAPIBase):
     def test_api_raw_search_no_count_support(self):
         fasta_str = ">query\nCCTCTGTGGAATCCAATCTGTCTTCCATCCTGCGTGGCCGAGGG"
         payload = json.dumps({"FASTA": fasta_str, 'num_labels': 5, 'min_exact_match': 0.1,
-                              'query_counts': True})
+                              'weighted_with_counts': True})
 
         ret = self.raw_post_request('search', payload)
 
@@ -326,7 +326,7 @@ class TestAPIClient(TestAPIBase):
     @unittest.expectedFailure
     def test_api_search_no_count_support(self):
         ret = self.graph_client.search(self.sample_query, parallel=False,
-                                       discovery_threshold=0.01, query_counts=True)
+                                       discovery_threshold=0.01, weighted_with_counts=True)
 
 
 @parameterized_class(('mode',), input_values=[('canonical',), ('primary',)])
@@ -458,8 +458,8 @@ class TestAPIClientWithCounts(TestAPIBase):
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
-    def test_api_simple_query_counts_df(self):
-        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, parallel=False, query_counts=True)
+    def test_api_simple_query_weighted_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, parallel=False, weighted_with_counts=True)
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -247,6 +247,8 @@ class TestAPIClient(TestAPIBase):
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
+        # 'canonical' and 'primary' graphs represent more k-mers than 'basic', so
+        # they get more matches
         cls.sample_query_expected_rows = 98 if cls.mode == 'basic' else 99
         cls.expected_matches = 840 if cls.mode == 'basic' else 1381
 
@@ -349,6 +351,8 @@ class TestAPIJson(TestAPIBase):
 
         cls.graph_client = GraphClientJson(cls.host, cls.port)
 
+        # 'canonical' and 'primary' graphs represent more k-mers than 'basic', so
+        # they get more matches
         cls.sample_query_expected_rows = 98 if cls.mode == 'basic' else 99
 
     def setUp(self):
@@ -443,6 +447,8 @@ class TestAPIClientWithCoordinates(TestAPIBase):
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
+        # 'canonical' and 'primary' graphs represent more k-mers than 'basic', so
+        # they get more matches
         cls.sample_query_expected_rows = 98 if cls.mode == 'basic' else 99
         cls.expected_matches = 840 if cls.mode == 'basic' else 1381
         cls.expected_abundance_sum = 1176 if cls.mode == 'basic' else 2323
@@ -500,6 +506,8 @@ class TestAPIClientWithCounts(TestAPIBase):
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
+        # 'canonical' and 'primary' graphs represent more k-mers than 'basic', so
+        # they get more matches
         cls.sample_query_expected_rows = 98 if cls.mode == 'basic' else 99
         cls.expected_matches = 840 if cls.mode == 'basic' else 1381
         cls.expected_abundance_sum = 1176 if cls.mode == 'basic' else 2323
@@ -558,6 +566,8 @@ class TestAPIClientParallel(TestAPIBase):
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_names[0])
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_names[1])
 
+        # 'canonical' and 'primary' graphs represent more k-mers than 'basic', so
+        # they get more matches
         cls.sample_query_expected_rows = 98 if cls.mode == 'basic' else 99
 
     def test_api_parallel_query_df(self):

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -225,7 +225,7 @@ class TestAPIRaw(TestAPIBase):
     def test_api_raw_search_no_count_support(self):
         fasta_str = ">query\nCCTCTGTGGAATCCAATCTGTCTTCCATCCTGCGTGGCCGAGGG"
         payload = json.dumps({"FASTA": fasta_str, 'num_labels': 5, 'min_exact_match': 0.1,
-                              'weighted_with_counts': True})
+                              'abundance_sum': True})
 
         ret = self.raw_post_request('search', payload)
 
@@ -326,7 +326,7 @@ class TestAPIClient(TestAPIBase):
     @unittest.expectedFailure
     def test_api_search_no_count_support(self):
         ret = self.graph_client.search(self.sample_query, parallel=False,
-                                       discovery_threshold=0.01, weighted_with_counts=True)
+                                       discovery_threshold=0.01, abundance_sum=True)
 
 
 @parameterized_class(('mode',), input_values=[('canonical',), ('primary',)])
@@ -458,8 +458,8 @@ class TestAPIClientWithCounts(TestAPIBase):
         cls.graph_client = MultiGraphClient()
         cls.graph_client.add_graph(cls.host, cls.port, cls.graph_name)
 
-    def test_api_simple_query_weighted_df(self):
-        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, parallel=False, weighted_with_counts=True)
+    def test_api_simple_query_abundance_sum_df(self):
+        ret = self.graph_client.search(self.sample_query, discovery_threshold=0.01, parallel=False, abundance_sum=True)
         df = ret[self.graph_name]
 
         self.assertEqual((self.sample_query_expected_rows, 3), df.shape)

--- a/metagraph/integration_tests/test_assemble.py
+++ b/metagraph/integration_tests/test_assemble.py
@@ -240,12 +240,9 @@ class TestDiffAssembly(TestingBase):
         assert(res.returncode == 0)
 
         if cls.with_bloom:
-            convert_command = '{exe} transform -o {outfile} --initialize-bloom {bloom_param} {input}'.format(
-                exe=METAGRAPH,
-                outfile=cls.tempdir.name + '/graph',
-                bloom_param='--bloom-fpp 0.1',
-                input=cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
-            )
+            convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
+                                --initialize-bloom --bloom-fpp 0.1 \
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -976,7 +976,6 @@ class TestQueryCounts(TestingBase):
         query_command[4] = ' '.join([str(p) for p in quantiles])
         res = subprocess.run(query_command, stdout=PIPE)
         self.assertEqual(res.returncode, 0)
-        self.assertEqual(len(res.stdout.decode()), 6590)
 
 
 @parameterized_class(('graph_repr', 'anno_repr'),

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -524,7 +524,7 @@ class TestQuery(TestingBase):
         if not self.anno_repr.endswith('_coord'):
             self.skipTest('annotation does not support coordinates')
 
-        query_command = f'{METAGRAPH} query --query-coords --verbose-coords \
+        query_command = f'{METAGRAPH} query --query-coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa'
@@ -533,7 +533,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 1619883)
 
-        query_command = f'{METAGRAPH} query --query-coords --verbose-coords \
+        query_command = f'{METAGRAPH} query --query-coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa'
@@ -607,7 +607,7 @@ class TestQueryTinyLinear(TestingBase):
         if not self.anno_repr.endswith('_coord'):
             self.skipTest('annotation does not support coordinates')
 
-        query_command = f'{METAGRAPH} query --query-coords  --verbose-coords \
+        query_command = f'{METAGRAPH} query --query-coords  --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.05 {self.fasta_graph}'

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -87,12 +87,9 @@ class TestQuery(TestingBase):
         assert('mode: basic' == out[2])
 
         if cls.with_bloom:
-            convert_command = '{exe} transform -o {outfile} --initialize-bloom {bloom_param} {input}'.format(
-                exe=METAGRAPH,
-                outfile=cls.tempdir.name + '/graph',
-                bloom_param='--bloom-fpp 0.1',
-                input=cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
-            )
+            convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
+                                --initialize-bloom --bloom-fpp 0.1 \
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -659,12 +656,9 @@ class TestQuery1Column(TestingBase):
         assert('mode: basic' == out[2])
 
         if cls.with_bloom:
-            convert_command = '{exe} transform -o {outfile} --initialize-bloom {bloom_param} {input}'.format(
-                exe=METAGRAPH,
-                outfile=cls.tempdir.name + '/graph',
-                bloom_param='--bloom-fpp 0.1',
-                input=cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
-            )
+            convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
+                                --initialize-bloom --bloom-fpp 0.1 \
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -795,12 +789,9 @@ class TestQueryCounts(TestingBase):
         assert('mode: basic' == out[2])
 
         if cls.with_bloom:
-            convert_command = '{exe} transform -o {outfile} --initialize-bloom {bloom_param} {input}'.format(
-                exe=METAGRAPH,
-                outfile=cls.tempdir.name + '/graph',
-                bloom_param='--bloom-fpp 0.1',
-                input=cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
-            )
+            convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
+                                --initialize-bloom --bloom-fpp 0.1 \
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -809,6 +800,7 @@ class TestQueryCounts(TestingBase):
             cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
             cls.tempdir.name + '/annotation',
             cls.anno_repr,
+            num_threads=1,
             anno_type='filename'
         )
 
@@ -1013,12 +1005,9 @@ class TestQueryCanonical(TestingBase):
         assert('mode: canonical' == out[2])
 
         if cls.with_bloom:
-            convert_command = '{exe} transform -o {outfile} --initialize-bloom {bloom_param} {input}'.format(
-                exe=METAGRAPH,
-                outfile=cls.tempdir.name + '/graph',
-                bloom_param='--bloom-fpp 0.1',
-                input=cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
-            )
+            convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
+                                --initialize-bloom --bloom-fpp 0.1 \
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -1183,12 +1172,9 @@ class TestQueryPrimary(TestingBase):
         assert('mode: primary' == out[2])
 
         if cls.with_bloom:
-            convert_command = '{exe} transform -o {outfile} --initialize-bloom {bloom_param} {input}'.format(
-                exe=METAGRAPH,
-                outfile=cls.tempdir.name + '/graph',
-                bloom_param='--bloom-fpp 0.1',
-                input=cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
-            )
+            convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
+                                --initialize-bloom --bloom-fpp 0.1 \
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -845,7 +845,7 @@ class TestQueryCounts(TestingBase):
             'ACACACACACACATTTAAACCCGGG',
         ]
 
-    def test_weighted_query(self):
+    def test_abundance_sum_query(self):
         query_file = self.tempdir.name + '/query.fa'
         for discovery_rate in np.linspace(0, 1, 5):
             expected_output = ''

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -725,7 +725,7 @@ class TestQuery1Column(TestingBase):
 @parameterized_class(('graph_repr', 'anno_repr'),
     input_values=product(
         [repr for repr in GRAPH_TYPES if not (repr == 'bitmap' and PROTEIN_MODE)],
-        ['int_brwt', 'row_diff_int_brwt']
+        [anno_type for anno_type in ANNO_TYPES if anno_type.endswith('int_brwt') or anno_type.endswith('_coord')]
     ),
     class_name_func=get_test_class_name
 )
@@ -763,10 +763,10 @@ class TestQueryCounts(TestingBase):
         fasta_file = cls.tempdir.name + '/file.fa'
         with open(fasta_file, 'w') as f:
             for kmer, count in cls.kmer_counts_1.items():
-                f.write(f'>L1\n{kmer}\n' * count)
+                f.write(f'>L1\n{(kmer + "$") * count}\n')
 
             for kmer, count in cls.kmer_counts_2.items():
-                f.write(f'>L2\n{kmer}\n' * count)
+                f.write(f'>L2\n{(kmer + "$") * count}\n')
 
         cls.k = 3
 
@@ -801,24 +801,11 @@ class TestQueryCounts(TestingBase):
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
-        def check_suffix(anno_repr, suffix):
-            match = anno_repr.endswith(suffix)
-            if match:
-                anno_repr = anno_repr[:-len(suffix)]
-            return anno_repr, match
-
-        cls.anno_repr, separate = check_suffix(cls.anno_repr, '_separate')
-        cls.anno_repr, no_fork_opt = check_suffix(cls.anno_repr, '_no_fork_opt')
-        cls.anno_repr, no_anchor_opt = check_suffix(cls.anno_repr, '_no_anchor_opt')
-
         cls._annotate_graph(
             fasta_file,
             cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
             cls.tempdir.name + '/annotation',
-            cls.anno_repr,
-            separate,
-            no_fork_opt,
-            no_anchor_opt
+            cls.anno_repr
         )
 
         # check annotation

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -800,7 +800,6 @@ class TestQueryCounts(TestingBase):
             cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr],
             cls.tempdir.name + '/annotation',
             cls.anno_repr,
-            num_threads=1,
             anno_type='filename'
         )
 
@@ -827,6 +826,14 @@ class TestQueryCounts(TestingBase):
             'TTTAAACCCGGG',
             'ACACACACACACATTTAAACCCGGG',
         ]
+
+    def _compare_unsorted_results(self, output, expected):
+        self.assertEqual(len(output), len(expected))
+        output_lines = output.split('\n')
+        expected_lines = expected.split('\n')
+        self.assertEqual(len(output_lines), len(expected_lines))
+        for output_line, expected_line in zip(output_lines, expected_lines):
+            self.assertCountEqual(output_line.split('\t'), expected_line.split('\t'))
 
     def test_abundance_sum_query(self):
         query_file = self.tempdir.name + '/query.fa'
@@ -864,7 +871,7 @@ class TestQueryCounts(TestingBase):
 
             res = subprocess.run(query_command.split(), stdout=PIPE)
             self.assertEqual(res.returncode, 0)
-            self.assertEqual(res.stdout.decode(), expected_output)
+            self._compare_unsorted_results(res.stdout.decode(), expected_output)
 
     def test_count_query(self):
         query_file = self.tempdir.name + '/query.fa'
@@ -903,7 +910,7 @@ class TestQueryCounts(TestingBase):
 
             res = subprocess.run(query_command.split(), stdout=PIPE)
             self.assertEqual(res.returncode, 0)
-            self.assertEqual(res.stdout.decode(), expected_output)
+            self._compare_unsorted_results(res.stdout.decode(), expected_output)
 
         query_command = f'{METAGRAPH} query --fast --query-counts \
                         -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
@@ -912,7 +919,7 @@ class TestQueryCounts(TestingBase):
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
-        self.assertEqual(res.stdout.decode(),
+        self._compare_unsorted_results(res.stdout.decode(),
             f"0\ts0\t<{self.fasta_file_1}>:0=1\t<{self.fasta_file_2}>:0=11\n"
             f"1\ts1\t<{self.fasta_file_1}>:0-1=1\t<{self.fasta_file_2}>:0-1=11\n"
             f"2\ts2\t<{self.fasta_file_1}>:0-10=1\t<{self.fasta_file_2}>:0-10=11\n"
@@ -957,7 +964,7 @@ class TestQueryCounts(TestingBase):
         query_command[4] = ' '.join([str(p) for p in quantiles])
         res = subprocess.run(query_command, stdout=PIPE)
         self.assertEqual(res.returncode, 0)
-        self.assertEqual(res.stdout.decode(), expected_output)
+        self._compare_unsorted_results(res.stdout.decode(), expected_output)
 
         query_command = f'{METAGRAPH} query --fast --count-quantiles <SET_BELOW> \
                         -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -286,7 +286,11 @@ void ColumnCompressed<Label>::serialize_coordinates(const std::string &filename)
         auto &c_v = const_cast<ColumnCompressed*>(this)->coords_[j];
 
         ips4o::parallel::sort(c_v.begin(), c_v.end(), std::less<>(), get_num_threads());
-        c_v.erase(std::unique(c_v.begin(), c_v.end()), c_v.end());
+        if (std::unique(c_v.begin(), c_v.end()) != c_v.end()) {
+            logger->error("Found repeated coordinates. If flag --anno-header is passed,"
+                          " make sure sequence headers don't repeat.");
+            exit(1);
+        }
 
         #pragma omp parallel for num_threads(get_num_threads())
         for (size_t i = 0; i < c_v.size(); ++i) {

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -214,7 +214,7 @@ std::string sequence_to_gfa_path(const std::string &seq,
                                  const DeBruijnGraph &graph,
                                  const tsl::ordered_set<uint64_t> &is_unitig_end_node,
                                  const Config *config) {
-    auto path_nodes = map_sequence_to_nodes(graph, seq);
+    auto path_nodes = map_to_nodes_sequentially(graph, seq);
 
     std::string nodes_on_path;
     std::string cigars_on_path;

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -1290,7 +1290,7 @@ if (advanced) {
             fprintf(stderr, "Advanced options for seeding:\n");
             fprintf(stderr, "\t   --align-min-seed-length [INT]\t\tthe minimum length of a seed [graph k]\n");
             fprintf(stderr, "\t   --align-max-seed-length [INT]\t\tthe maximum length of a seed [graph k]\n");
-            fprintf(stderr, "\t   --align-min-exact-match [FLOAT] fraction of matching nucleotides required to align sequence [0.0]\n");
+            fprintf(stderr, "\t   --align-min-exact-match [FLOAT]\t\tfraction of matching nucleotides required to align sequence [0.0]\n");
             fprintf(stderr, "\t   --align-max-num-seeds-per-locus [INT]\tthe maximum number of allowed inexact seeds per locus [inf]\n");
         } break;
         case SERVER_QUERY: {

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -220,6 +220,8 @@ Config::Config(int argc, char *argv[]) {
             presence_fraction = std::stof(get_value(i++));
         } else if (!strcmp(argv[i], "--query-presence")) {
             query_presence = true;
+        } else if (!strcmp(argv[i], "--query-counts")) {
+            query_counts = true;
         } else if (!strcmp(argv[i], "--query-coords")) {
             query_coords = true;
         } else if (!strcmp(argv[i], "--verbose-coords")) {
@@ -1247,6 +1249,7 @@ if (advanced) {
             fprintf(stderr, "\t   --count-quantiles [FLOAT ...] \tk-mer count quantiles to compute for each label [off]\n"
                             "\t                                 \t\tExample: --count-quantiles '0 0.33 0.5 0.66 1'\n"
                             "\t                                 \t\t(0 corresponds to MIN, 1 corresponds to MAX)\n");
+            fprintf(stderr, "\t   --query-counts \t\tquery k-mer counts (requires count or coord annotation) [off]\n");
             fprintf(stderr, "\t   --query-coords \t\tquery k-mer coordinates (requires coord annotation) [off]\n");
             fprintf(stderr, "\t   --verbose-coords \t\tdo not collapse continuous matched coord ranges in result (for query-coords) [off]\n");
             fprintf(stderr, "\t   --print-signature \t\tprint vectors indicating present/absent k-mers [off]\n");

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -224,8 +224,8 @@ Config::Config(int argc, char *argv[]) {
             query_counts = true;
         } else if (!strcmp(argv[i], "--query-coords")) {
             query_coords = true;
-        } else if (!strcmp(argv[i], "--verbose-coords")) {
-            verbose_coords = true;
+        } else if (!strcmp(argv[i], "--verbose-output")) {
+            verbose_output = true;
         } else if (!strcmp(argv[i], "--filter-present")) {
             filter_present = true;
         } else if (!strcmp(argv[i], "--count-labels")) {
@@ -1243,6 +1243,7 @@ if (advanced) {
 if (advanced) {
             fprintf(stderr, "\t   --sparse \t\tuse row-major sparse matrix for row annotation [off]\n");
 }
+            fprintf(stderr, "\t   --json \t\toutput query results in JSON format [off]\n");
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --count-labels \t\tcount labels for k-mers from querying sequences [off]\n");
             fprintf(stderr, "\t   --count-kmers \t\tweight k-mers with their annotated counts (requires count annotation) [off]\n");
@@ -1251,7 +1252,7 @@ if (advanced) {
                             "\t                                 \t\t(0 corresponds to MIN, 1 corresponds to MAX)\n");
             fprintf(stderr, "\t   --query-counts \t\tquery k-mer counts (requires count or coord annotation) [off]\n");
             fprintf(stderr, "\t   --query-coords \t\tquery k-mer coordinates (requires coord annotation) [off]\n");
-            fprintf(stderr, "\t   --verbose-coords \t\tdo not collapse continuous matched coord ranges in result (for query-coords) [off]\n");
+            fprintf(stderr, "\t   --verbose-output \t\tdo not collapse continuous coord or count ranges (for query-coords and query-counts) [off]\n");
             fprintf(stderr, "\t   --print-signature \t\tprint vectors indicating present/absent k-mers [off]\n");
             fprintf(stderr, "\t   --num-top-labels [INT] \tmaximum number of frequent labels to print [inf]\n");
             fprintf(stderr, "\t   --discovery-fraction [FLOAT] fraction of labeled k-mers required for annotation [0.7]\n");

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -1248,9 +1248,9 @@ if (advanced) {
                             "\t                                 \t\tExample: --count-quantiles '0 0.33 0.5 0.66 1'\n"
                             "\t                                 \t\t(0 corresponds to MIN, 1 corresponds to MAX)\n");
             fprintf(stderr, "\t   --query-coords \t\tquery k-mer coordinates (requires coord annotation) [off]\n");
-            fprintf(stderr, "\t   --verbose-coords \t\tdo not collapse continuous matched coord ranges in result (for query-coords) [off]");
+            fprintf(stderr, "\t   --verbose-coords \t\tdo not collapse continuous matched coord ranges in result (for query-coords) [off]\n");
             fprintf(stderr, "\t   --print-signature \t\tprint vectors indicating present/absent k-mers [off]\n");
-            fprintf(stderr, "\t   --num-top-labels \t\tmaximum number of frequent labels to print [off]\n");
+            fprintf(stderr, "\t   --num-top-labels [INT] \tmaximum number of frequent labels to print [inf]\n");
             fprintf(stderr, "\t   --discovery-fraction [FLOAT] fraction of labeled k-mers required for annotation [0.7]\n");
             fprintf(stderr, "\t   --presence-fraction [FLOAT] \tfraction of k-mers required to be present in the graph [0.0]\n");
             fprintf(stderr, "\t   --labels-delimiter [STR]\tdelimiter for annotation labels [\":\"]\n");

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -40,6 +40,7 @@ class Config {
     bool count_kmers = false;
     bool print_signature = false;
     bool query_presence = false;
+    bool query_counts = false;
     bool query_coords = false;
     bool verbose_coords = false;
     bool filter_present = false;

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -42,7 +42,7 @@ class Config {
     bool query_presence = false;
     bool query_counts = false;
     bool query_coords = false;
-    bool verbose_coords = false;
+    bool verbose_output = false;
     bool filter_present = false;
     bool dump_text_anno = false;
     bool sparse = false;

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -310,7 +310,7 @@ std::string SeqSearchResult::to_string(const std::string delimiter,
         for (const auto &[label, counts] : *v) {
             output += "\t<" + label + ">";
             if (verbose_output) {
-                output += fmt::format(":{}", label, fmt::join(counts, ":"));
+                output += fmt::format(":{}", fmt::join(counts, ":"));
             } else {
                 std::pair<size_t, size_t> last(0, counts.at(0));
                 for (size_t i = 1; i <= counts.size(); ++i) {

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -515,7 +515,7 @@ void call_hull_sequences(const DeBruijnGraph &full_dbg,
         }
 
         assert(path.size() == seq.length() - full_dbg.get_k() + 1);
-        assert(path == map_sequence_to_nodes(full_dbg, seq));
+        assert(path == map_to_nodes_sequentially(full_dbg, seq));
 
         callback(seq, path);
 
@@ -735,7 +735,7 @@ void add_nodes_with_suffix_matches(const DBGSuccinct &full_dbg,
             std::string rev_contig = contig;
             reverse_complement(rev_contig);
             call_suffix_match_sequences(full_dbg, rev_contig,
-                                        map_sequence_to_nodes(full_dbg, rev_contig),
+                                        map_to_nodes_sequentially(full_dbg, rev_contig),
                                         callback, sub_k, max_num_nodes_per_suffix);
         }
 

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -314,6 +314,7 @@ SeqSearchResult QueryExecutor::execute_query(QuerySequence&& sequence,
                                              const graph::AnnotatedDBG &anno_graph,
                                              bool with_kmer_counts,
                                              const std::vector<double> &count_quantiles,
+                                             bool query_counts,
                                              bool query_coords) {
     // Perform a different action depending on the type (specified by config flags)
     SeqSearchResult::result_type result;
@@ -330,6 +331,12 @@ SeqSearchResult QueryExecutor::execute_query(QuerySequence&& sequence,
                                                  num_top_labels,
                                                  discovery_fraction,
                                                  presence_fraction);
+    } else if (query_counts) {
+        // Get labels with k-mer counts
+        result = anno_graph.get_kmer_counts(sequence.sequence,
+                                            num_top_labels,
+                                            discovery_fraction,
+                                            presence_fraction);
     } else if (count_quantiles.size()) {
         // Get labels with count quantiles
         result = anno_graph.get_label_count_quantiles(sequence.sequence,
@@ -1175,7 +1182,7 @@ SeqSearchResult query_sequence(QuerySequence&& sequence,
             config.num_top_labels, config.discovery_fraction,
             config.presence_fraction, anno_graph,
             config.count_kmers, config.count_quantiles,
-            config.query_coords);
+            config.query_counts, config.query_coords);
 
     if (aligner_config)
         result.get_alignment() = alignment;

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -1169,13 +1169,13 @@ int query_graph(Config *config) {
                              (const SeqSearchResult &result) {
             if (config->output_json) {
                 std::cout << result.to_json(config->verbose_output
-                                              && (config->query_counts || config->query_coords),
+                                              || !(config->query_counts || config->query_coords),
                                             anno_graph) << "\n";
             } else {
                 std::cout << result.to_string(config->anno_labels_delimiter,
                                               config->suppress_unlabeled,
                                               config->verbose_output
-                                                && (config->query_counts || config->query_coords),
+                                                || !(config->query_counts || config->query_coords),
                                               anno_graph) << "\n";
             }
         });

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -325,7 +325,7 @@ SeqSearchResult QueryExecutor::execute_query(QuerySequence&& sequence,
                                                      discovery_fraction,
                                                      presence_fraction);
     } else if (query_coords) {
-        // Get labels with query coordinates
+        // Get labels with k-mer coordinates
         result = anno_graph.get_kmer_coordinates(sequence.sequence,
                                                  num_top_labels,
                                                  discovery_fraction,

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -94,21 +94,21 @@ class SeqSearchResult {
     typedef std::vector<Label> LabelVec;
     typedef std::vector<std::pair<Label, size_t>> LabelCountVec;
     typedef std::vector<std::pair<Label, sdsl::bit_vector>> LabelSigVec;
-    typedef std::vector<std::pair<Label, std::vector<size_t>>> LabelAbundanceVec;
-    typedef std::vector<std::pair<Label, std::vector<SmallVector<uint64_t>>>> LabelCoordVec;
+    typedef std::vector<std::tuple<Label, size_t, std::vector<size_t>>> LabelCountAbundancesVec;
+    typedef std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>> LabelCountCoordsVec;
 
     typedef std::variant<LabelVec,
                          LabelCountVec,
                          LabelSigVec,
-                         LabelAbundanceVec,
-                         LabelCoordVec> result_type;
+                         LabelCountAbundancesVec,
+                         LabelCountCoordsVec> result_type;
 
     // JSON Field Keys
     static constexpr auto SEQ_DESCRIPTION_JSON_FIELD = "seq_description";
     static constexpr auto KMER_COUNT_FIELD = "kmer_count";
     static constexpr auto KMER_COORDINATE_FIELD = "kmer_coords";
     static constexpr auto SIGNATURE_FIELD = "signature";
-    static constexpr auto KMER_ABUNDANCE_FIELD = "kmer_abundance";
+    static constexpr auto KMER_ABUNDANCE_FIELD = "kmer_abundances";
     static constexpr auto SCORE_JSON_FIELD = "score";
     static constexpr auto SEQUENCE_JSON_FIELD = "sequence";
     static constexpr auto ALIGNMENT_JSON_FIELD = "alignments";

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -201,6 +201,7 @@ class QueryExecutor {
                                          const graph::AnnotatedDBG &anno_graph,
                                          bool with_kmer_counts = false,
                                          const std::vector<double> &count_quantiles = {},
+                                         bool query_counts = false,
                                          bool query_coords = false);
 
   private:

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -141,11 +141,10 @@ class SeqSearchResult {
      *
      * @param counts_kmers      should counts be labeled kmer (t) or label (f) counts?
      * @param anno_graph        reference to annotated dbg for kmer presence mask scoring
-     * @param verbose_coords    do not collapse continuous ranges of coords (query_coords)
+     * @param verbose_output    do not collapse continuous ranges of coords (or counts)
      * @return  Json::Value instance representing sequence result
      */
-    Json::Value to_json(bool verbose_coords,
-                        const graph::AnnotatedDBG &anno_graph) const;
+    Json::Value to_json(bool verbose_output, const graph::AnnotatedDBG &anno_graph) const;
 
     /**
      * Returns a string representing the individual query result for the represented sequence.
@@ -155,12 +154,12 @@ class SeqSearchResult {
      *
      * @param delimiter             the delimiter between labels for that sequence
      * @param suppress_unlabeled    do not print seq_name if sequence is unlabeled
-     * @param verbose_coords        do not collapse continuous ranges of coords (query_coords)
+     * @param verbose_output        do not collapse continuous ranges of coords or counts
      * @param anno_graph            reference to annotated dbg for kmer presence mask scoring
      */
     std::string to_string(std::string delimiter,
                           bool suppress_unlabeled,
-                          bool verbose_coords,
+                          bool verbose_output,
                           const graph::AnnotatedDBG &anno_graph) const;
 
   private:

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -94,13 +94,13 @@ class SeqSearchResult {
     typedef std::vector<Label> LabelVec;
     typedef std::vector<std::pair<Label, size_t>> LabelCountVec;
     typedef std::vector<std::pair<Label, sdsl::bit_vector>> LabelSigVec;
-    typedef std::vector<std::pair<Label, std::vector<size_t>>> LabelQuantileVec;
+    typedef std::vector<std::pair<Label, std::vector<size_t>>> LabelAbundanceVec;
     typedef std::vector<std::pair<Label, std::vector<SmallVector<uint64_t>>>> LabelCoordVec;
 
     typedef std::variant<LabelVec,
                          LabelCountVec,
                          LabelSigVec,
-                         LabelQuantileVec,
+                         LabelAbundanceVec,
                          LabelCoordVec> result_type;
 
     // JSON Field Keys
@@ -108,7 +108,7 @@ class SeqSearchResult {
     static constexpr auto KMER_COUNT_FIELD = "kmer_count";
     static constexpr auto KMER_COORDINATE_FIELD = "kmer_coords";
     static constexpr auto SIGNATURE_FIELD = "signature";
-    static constexpr auto KMER_COUNT_QUANTILE_FIELD = "kmer_count_quantile";
+    static constexpr auto KMER_ABUNDANCE_FIELD = "kmer_abundance";
     static constexpr auto SCORE_JSON_FIELD = "score";
     static constexpr auto SEQUENCE_JSON_FIELD = "sequence";
     static constexpr auto ALIGNMENT_JSON_FIELD = "alignments";
@@ -118,19 +118,22 @@ class SeqSearchResult {
      * Construct an instance of SeqSearchResult by providing QuerySequence instance describing
      * sequence and result from that query on an annotated DBG. Will move both into this instance.
      *
-     * @param sequence  rvalue reference to QuerySequence (WILL BE MOVED)
-     * @param result    rvalue reference to result_type (WILL BE MOVED)
+     * @param sequence rvalue reference to QuerySequence
+     * @param result rvalue reference to result_type
+     * @param alignment alignment to graph (how the query was transformed)
      */
     SeqSearchResult(QuerySequence&& sequence,
                     result_type&& result,
                     std::optional<Alignment>&& alignment = {})
-          : sequence(std::move(sequence)), alignment(alignment), result(std::move(result)) {}
+          : sequence_(std::move(sequence)),
+            alignment_(std::move(alignment)),
+            result_(std::move(result)) {}
 
     /** Const reference getters */
-    const QuerySequence& get_sequence() const { return sequence; }
-    const std::optional<Alignment>& get_alignment() const { return alignment; }
-    std::optional<Alignment>& get_alignment() { return alignment; }
-    const result_type& get_result() const { return result; }
+    const QuerySequence& get_sequence() const { return sequence_; }
+    const std::optional<Alignment>& get_alignment() const { return alignment_; }
+    std::optional<Alignment>& get_alignment() { return alignment_; }
+    const result_type& get_result() const { return result_; }
 
     /**
      * Returns a Json object representing the individual query result for the
@@ -161,9 +164,9 @@ class SeqSearchResult {
                           const graph::AnnotatedDBG &anno_graph) const;
 
   private:
-    QuerySequence sequence;             // query sequence this result represents
-    std::optional<Alignment> alignment; // optional wrapper for alignment struct
-    result_type result;                 // result vector of labels and additional info
+    QuerySequence sequence_;             // query sequence this result represents
+    std::optional<Alignment> alignment_; // optional wrapper for alignment struct
+    result_type result_;                 // result vector of labels and additional info
 };
 
 

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -68,10 +68,12 @@ std::string process_search_request(const std::string &received_message,
     config.print_signature = json.get("with_signature", config.print_signature).asBool();
     config.query_coords = json.get("query_coords", config.query_coords).asBool();
     config.count_kmers = json.get("abundance_sum", config.count_kmers).asBool();
+    config.query_counts = json.get("query_counts", config.query_counts).asBool();
 
     // Throw client an error if they try to query coordinates/kmer-counts on unsupported indexes
-    if (config.count_kmers && !(dynamic_cast<const annot::matrix::IntMatrix *>(
-                                        &anno_graph.get_annotation().get_matrix()))) {
+    if ((config.count_kmers || config.query_counts)
+            && !(dynamic_cast<const annot::matrix::IntMatrix *>(
+                            &anno_graph.get_annotation().get_matrix()))) {
         throw std::invalid_argument("Annotation does not support k-mer count queries");
     }
 

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -128,7 +128,7 @@ std::string process_search_request(const std::string &received_message,
     // Create full JSON object
     Json::Value search_response(Json::arrayValue);
     for (const auto &seq_result : search_results) {
-        search_response.append(seq_result.to_json(config.verbose_coords, anno_graph));
+        search_response.append(seq_result.to_json(config.verbose_output, anno_graph));
     }
 
     // Return JSON string

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -67,7 +67,7 @@ std::string process_search_request(const std::string &received_message,
     config.fast = json.get("fast", config.fast).asBool();
     config.print_signature = json.get("with_signature", config.print_signature).asBool();
     config.query_coords = json.get("query_coords", config.query_coords).asBool();
-    config.count_kmers = json.get("query_counts", config.count_kmers).asBool();
+    config.count_kmers = json.get("weighted_with_counts", config.count_kmers).asBool();
 
     // Throw client an error if they try to query coordinates/kmer-counts on unsupported indexes
     if (config.count_kmers && !(dynamic_cast<const annot::matrix::IntMatrix *>(

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -67,7 +67,7 @@ std::string process_search_request(const std::string &received_message,
     config.fast = json.get("fast", config.fast).asBool();
     config.print_signature = json.get("with_signature", config.print_signature).asBool();
     config.query_coords = json.get("query_coords", config.query_coords).asBool();
-    config.count_kmers = json.get("weighted_with_counts", config.count_kmers).asBool();
+    config.count_kmers = json.get("abundance_sum", config.count_kmers).asBool();
 
     // Throw client an error if they try to query coordinates/kmer-counts on unsupported indexes
     if (config.count_kmers && !(dynamic_cast<const annot::matrix::IntMatrix *>(

--- a/metagraph/src/cli/stats.cpp
+++ b/metagraph/src/cli/stats.cpp
@@ -251,7 +251,8 @@ void print_annotation_stats(const std::string &fname, const Config &config) {
         std::cout << "===================== COUNTS STATS =====================" << std::endl;
         if (!dynamic_cast<const annot::ColumnCompressed<> *>(&annotation)) {
             logger->error("Printing statistics for counts is currently only supported for"
-                          " ColumnCompressed annotations");
+                          " ColumnCompressed ({}) annotations with counts",
+                          Config::annotype_to_string(Config::ColumnCompressed));
             exit(1);
         }
         // the annotation is not needed anymore -> free memory

--- a/metagraph/src/cli/transform_annotation.cpp
+++ b/metagraph/src/cli/transform_annotation.cpp
@@ -383,7 +383,9 @@ int transform_annotation(Config *config) {
     if (input_anno_type != Config::ColumnCompressed
         && input_anno_type != Config::RowDiff && files.size() > 1) {
         logger->error("Conversion of multiple annotators is only "
-                      "supported for ColumnCompressed and ColumnRowDiff");
+                      "supported for {} and {}",
+                      Config::annotype_to_string(Config::ColumnCompressed),
+                      Config::annotype_to_string(Config::RowDiff));
         exit(1);
     }
 
@@ -659,9 +661,9 @@ int transform_annotation(Config *config) {
     if (config->cluster_linkage) {
         if (input_anno_type != Config::ColumnCompressed
             && input_anno_type != Config::RowDiff) {
-            logger->error(
-                    "Column clustering is only supported for ColumnCompressed and "
-                    "RowDiff");
+            logger->error("Column clustering is only supported for {} and {}",
+                          Config::annotype_to_string(Config::ColumnCompressed),
+                          Config::annotype_to_string(Config::RowDiff));
             exit(1);
         }
 

--- a/metagraph/src/graph/alignment/aligner_alignment.cpp
+++ b/metagraph/src/graph/alignment/aligner_alignment.cpp
@@ -260,7 +260,7 @@ void Alignment::reverse_complement(const DeBruijnGraph &graph,
             assert(sequence_.size() == dbg_succ.get_k() + offset_);
             sequence_ = sequence_.substr(offset_);
 
-            assert(nodes_ == map_sequence_to_nodes(graph, sequence_));
+            assert(nodes_ == map_to_nodes_sequentially(graph, sequence_));
             reverse_complement_seq_path(graph, sequence_, nodes_);
 
             assert(std::find(nodes_.begin(), nodes_.end(), DeBruijnGraph::npos)
@@ -270,7 +270,7 @@ void Alignment::reverse_complement(const DeBruijnGraph &graph,
 
         } else {
             assert(nodes_.size() == 1);
-            assert(nodes_ == map_sequence_to_nodes(graph, sequence_));
+            assert(nodes_ == map_to_nodes_sequentially(graph, sequence_));
             reverse_complement_seq_path(graph, sequence_, nodes_);
 
             assert(std::find(nodes_.begin(), nodes_.end(), DeBruijnGraph::npos)

--- a/metagraph/src/graph/alignment/dbg_aligner.cpp
+++ b/metagraph/src/graph/alignment/dbg_aligner.cpp
@@ -58,7 +58,7 @@ void ISeedAndExtendAligner<AlignmentCompare>
         std::string_view this_query = paths.get_query(is_reverse_complement);
         assert(this_query == query);
 
-        std::vector<node_index> nodes = map_sequence_to_nodes(graph_, query);
+        std::vector<node_index> nodes = map_to_nodes_sequentially(graph_, query);
 
         auto seeder = build_seeder(this_query, is_reverse_complement, nodes);
         auto extender = build_extender(this_query, aggregator);

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -346,7 +346,7 @@ AnnotatedDBG::get_top_labels(std::string_view sequence,
     return top_labels;
 }
 
-std::vector<std::pair<std::string, std::vector<size_t>>>
+std::vector<std::tuple<std::string, size_t, std::vector<size_t>>>
 AnnotatedDBG::get_label_count_quantiles(std::string_view sequence,
                                         size_t num_top_labels,
                                         double discovery_fraction,
@@ -417,7 +417,7 @@ AnnotatedDBG::get_label_count_quantiles(std::string_view sequence,
     if (code_counts.size() > num_top_labels)
         code_counts.resize(num_top_labels);
 
-    std::vector<std::pair<Label, std::vector<size_t>>> label_quantiles;
+    std::vector<std::tuple<Label, size_t, std::vector<size_t>>> label_quantiles;
     label_quantiles.reserve(code_counts.size());
     // Quantiles are defined as `count[i]` where `i < q * N <= i + 1`
     for (auto &[j, counts] : code_counts) {
@@ -425,9 +425,10 @@ AnnotatedDBG::get_label_count_quantiles(std::string_view sequence,
         const size_t num_zeros = num_kmers - counts.size();
 
         label_quantiles.emplace_back(annotator_->get_label_encoder().decode(j),
+                                     counts.size(),
                                      std::vector<size_t>(q_low.size()));
 
-        std::vector<size_t> &quantiles = label_quantiles.back().second;
+        std::vector<size_t> &quantiles = std::get<2>(label_quantiles.back());
         for (size_t q = 0; q < q_low.size(); ++q) {
             if (q_low[q] < num_zeros) {
                 quantiles[q] = 0;
@@ -440,7 +441,7 @@ AnnotatedDBG::get_label_count_quantiles(std::string_view sequence,
     return label_quantiles;
 }
 
-std::vector<std::pair<std::string, std::vector<size_t>>>
+std::vector<std::tuple<std::string, size_t, std::vector<size_t>>>
 AnnotatedDBG::get_kmer_counts(std::string_view sequence,
                               size_t num_top_labels,
                               double discovery_fraction,
@@ -449,7 +450,7 @@ AnnotatedDBG::get_kmer_counts(std::string_view sequence,
     return get_kmer_counts(nodes, num_top_labels, discovery_fraction, presence_fraction);
 }
 
-std::vector<std::pair<std::string, std::vector<size_t>>>
+std::vector<std::tuple<std::string, size_t, std::vector<size_t>>>
 AnnotatedDBG::get_kmer_counts(const std::vector<node_index> &nodes,
                               size_t num_top_labels,
                               double discovery_fraction,
@@ -517,11 +518,12 @@ AnnotatedDBG::get_kmer_counts(const std::vector<node_index> &nodes,
         code_counts.end()
     );
 
-    std::vector<std::pair<std::string, std::vector<size_t>>> result(code_counts.size());
+    std::vector<std::tuple<std::string, size_t, std::vector<size_t>>> result(code_counts.size());
 
     for (size_t j = 0; j < result.size(); ++j) {
-        result[j].first = annotator_->get_label_encoder().decode(code_counts[j].first);
-        auto &counts = result[j].second;
+        auto &[label, num_kmer_matches, counts] = result[j];
+        label = annotator_->get_label_encoder().decode(code_counts[j].first);
+        num_kmer_matches = code_counts[j].second.size();
         counts.resize(nodes.size(), 0);
         // fill the non-zero counts
         for (auto &[i, c] : code_counts[j].second) {
@@ -532,7 +534,7 @@ AnnotatedDBG::get_kmer_counts(const std::vector<node_index> &nodes,
     return result;
 }
 
-std::vector<std::pair<std::string, std::vector<SmallVector<uint64_t>>>>
+std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
 AnnotatedDBG::get_kmer_coordinates(std::string_view sequence,
                                    size_t num_top_labels,
                                    double discovery_fraction,
@@ -541,7 +543,7 @@ AnnotatedDBG::get_kmer_coordinates(std::string_view sequence,
     return get_kmer_coordinates(nodes, num_top_labels, discovery_fraction, presence_fraction);
 }
 
-std::vector<std::pair<std::string, std::vector<SmallVector<uint64_t>>>>
+std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
 AnnotatedDBG::get_kmer_coordinates(const std::vector<node_index> &nodes,
                                    size_t num_top_labels,
                                    double discovery_fraction,
@@ -614,16 +616,18 @@ AnnotatedDBG::get_kmer_coordinates(const std::vector<node_index> &nodes,
 
     code_to_count = VectorMap<size_t, size_t>(code_counts.begin(), code_counts.end());
 
-    std::vector<std::pair<std::string, std::vector<SmallVector<uint64_t>>>> result(code_to_count.size());
+    std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>> result(code_to_count.size());
 
     for (size_t j = 0; j < result.size(); ++j) {
-        result[j].first = annotator_->get_label_encoder().decode(code_counts[j].first);
+        auto &[label, count, _] = result[j];
+        label = annotator_->get_label_encoder().decode(code_counts[j].first);
+        count = code_counts[j].second;
     }
 
     for (size_t i : ids) {
         for (size_t j = 0; j < result.size(); ++j) {
             // append empty tuple
-            result[j].second.emplace_back();
+            std::get<2>(result[j]).emplace_back();
         }
 
         // leave all tuples empty if the k-mer is missing
@@ -634,7 +638,7 @@ AnnotatedDBG::get_kmer_coordinates(const std::vector<node_index> &nodes,
         for (auto &[j, tuple] : rows_tuples[i]) {
             auto it = code_to_count.find(j);
             if (it != code_to_count.end())
-                result[it - code_to_count.begin()].second.back() = std::move(tuple);
+                std::get<2>(result[it - code_to_count.begin()]).back() = std::move(tuple);
         }
     }
 

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -410,8 +410,8 @@ AnnotatedDBG::get_label_count_quantiles(std::string_view sequence,
     // sort by the number of matched k-mers
     std::sort(code_counts.begin(), code_counts.end(),
               [](const auto &x, const auto &y) {
-                  return x.second.size() > y.second.size()
-                      || (x.second.size() == y.second.size() && x.first < y.first);
+                  return std::make_pair(y.second.size(), x.first)
+                        < std::make_pair(x.second.size(), y.first);
               });
     // keep only the first |num_top_labels| top labels
     if (code_counts.size() > num_top_labels)
@@ -453,7 +453,7 @@ AnnotatedDBG::sequence_to_path(std::string_view sequence) const {
     return path;
 }
 
-std::vector<std::pair<Label, std::vector<size_t>>>
+std::vector<std::pair<std::string, std::vector<size_t>>>
 AnnotatedDBG::get_kmer_counts(std::string_view sequence,
                               size_t num_top_labels,
                               double discovery_fraction,
@@ -462,7 +462,7 @@ AnnotatedDBG::get_kmer_counts(std::string_view sequence,
     return get_kmer_counts(path, num_top_labels, discovery_fraction, presence_fraction);
 }
 
-std::vector<std::pair<Label, std::vector<size_t>>>
+std::vector<std::pair<std::string, std::vector<size_t>>>
 AnnotatedDBG::get_kmer_counts(const std::vector<node_index> &path,
                               size_t num_top_labels,
                               double discovery_fraction,
@@ -543,7 +543,8 @@ AnnotatedDBG::get_kmer_coordinates(const std::vector<node_index> &path,
     // sort by the number of matched k-mers
     std::sort(code_counts.begin(), code_counts.end(),
               [](const auto &x, const auto &y) {
-                  return x.second > y.second || (x.second == y.second && x.first < y.first);
+                  return std::make_pair(y.second, x.first)
+                        < std::make_pair(x.second, y.first);
               });
 
     // keep only the first |num_top_labels| top labels
@@ -672,9 +673,9 @@ AnnotatedDBG::get_top_label_signatures(std::string_view sequence,
     // sort to get top |num_top_labels| labels
     if (vector.size() > num_top_labels) {
         std::sort(vector.begin(), vector.end(),
-                  [](const auto &a, const auto &b) {
-                      return a.second.second > b.second.second
-                          || (a.second.second == b.second.second && a.first < b.first);
+                  [](const auto &x, const auto &y) {
+                      return std::make_pair(y.second.second, x.first)
+                            < std::make_pair(x.second.second, y.first);
                   });
         vector.resize(num_top_labels);
     }
@@ -728,9 +729,9 @@ std::vector<StringCountPair> top_labels(Container&& code_counts,
     if (code_counts.size() > num_top_labels) {
         // sort labels by counts to get the top |num_top_labels|
         std::sort(code_counts.begin(), code_counts.end(),
-                  [](const auto &first, const auto &second) {
-                      return first.second > second.second
-                          || (first.second == second.second && first.first < second.first);
+                  [](const auto &x, const auto &y) {
+                      return std::make_pair(y.second, x.first)
+                            < std::make_pair(x.second, y.first);
                   });
         // leave only the first |num_top_labels| top labels
         code_counts.resize(num_top_labels);

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -515,8 +515,8 @@ AnnotatedDBG::get_kmer_counts(const std::vector<node_index> &path,
     // sort by the number of matched k-mers
     std::sort(code_counts.begin(), code_counts.end(),
               [](const auto &x, const auto &y) {
-                  return std::make_pair(y.second, x.first)
-                        < std::make_pair(x.second, y.first);
+                  return std::make_pair(y.second.size(), x.first)
+                        < std::make_pair(x.second.size(), y.first);
               });
 
     // keep only the first |num_top_labels| top labels

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -407,7 +407,7 @@ AnnotatedDBG::get_label_count_quantiles(std::string_view sequence,
         if (counts.size() >= min_count)
             code_counts.emplace_back(j, std::move(counts));
     }
-    // sort by the number of matched k-mers
+    // sort by the number of k-mer matches
     std::sort(code_counts.begin(), code_counts.end(),
               [](const auto &x, const auto &y) {
                   return std::make_pair(y.second.size(), x.first)

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -138,7 +138,7 @@ void AnnotatedDBG::add_kmer_coord(std::string_view sequence,
     if (sequence.size() < dbg_.get_k())
         return;
 
-    std::vector<row_index> indices = seq_to_lnodes(sequence);
+    std::vector<row_index> indices = map_to_nodes(dbg_, sequence);
 
     std::lock_guard<std::mutex> lock(mutex_);
 
@@ -158,7 +158,7 @@ void AnnotatedDBG::add_kmer_coords(
     ids.reserve(data.size());
     for (const auto &[sequence, labels, _] : data) {
         if (sequence.size() >= dbg_.get_k())
-            ids.push_back(seq_to_lnodes(sequence));
+            ids.push_back(map_to_nodes(dbg_, sequence));
     }
 
     std::lock_guard<std::mutex> lock(mutex_);
@@ -440,26 +440,12 @@ AnnotatedDBG::get_label_count_quantiles(std::string_view sequence,
     return label_quantiles;
 }
 
-// map sequence to labeled nodes
-std::vector<AnnotatedDBG::node_index>
-AnnotatedDBG::seq_to_lnodes(std::string_view sequence) const {
-    if (sequence.size() < dbg_.get_k())
-        return {};
-
-    std::vector<node_index> nodes;
-    nodes.reserve(sequence.size() - dbg_.get_k() + 1);
-
-    graph_->map_to_nodes(sequence, [&](node_index i) { nodes.push_back(i); });
-
-    return nodes;
-}
-
 std::vector<std::pair<std::string, std::vector<size_t>>>
 AnnotatedDBG::get_kmer_counts(std::string_view sequence,
                               size_t num_top_labels,
                               double discovery_fraction,
                               double presence_fraction) const {
-    std::vector<node_index> nodes = seq_to_lnodes(sequence);
+    std::vector<node_index> nodes = map_to_nodes(dbg_, sequence);
     return get_kmer_counts(nodes, num_top_labels, discovery_fraction, presence_fraction);
 }
 
@@ -551,7 +537,7 @@ AnnotatedDBG::get_kmer_coordinates(std::string_view sequence,
                                    size_t num_top_labels,
                                    double discovery_fraction,
                                    double presence_fraction) const {
-    std::vector<node_index> nodes = seq_to_lnodes(sequence);
+    std::vector<node_index> nodes = map_to_nodes(dbg_, sequence);
     return get_kmer_coordinates(nodes, num_top_labels, discovery_fraction, presence_fraction);
 }
 

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -80,9 +80,6 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
 
     bool check_compatibility() const;
 
-    // map sequence to labeled nodes
-    std::vector<node_index> seq_to_lnodes(std::string_view sequence) const;
-
     // add k-mer counts to the annotation, thread-safe for concurrent calls
     void add_kmer_counts(std::string_view sequence,
                          const std::vector<Label> &labels,

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -127,32 +127,32 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                    size_t min_count = 0,
                    bool with_kmer_counts = false) const;
 
-    std::vector<std::pair<Label, std::vector<size_t>>>
+    std::vector<std::tuple<Label, size_t, std::vector<size_t>>>
     get_label_count_quantiles(std::string_view sequence,
                               size_t num_top_labels,
                               double discovery_fraction,
                               double presence_fraction,
                               const std::vector<double> &count_quantiles) const;
 
-    std::vector<std::pair<Label, std::vector<size_t>>>
+    std::vector<std::tuple<Label, size_t, std::vector<size_t>>>
     get_kmer_counts(std::string_view sequence,
                     size_t num_top_labels,
                     double discovery_fraction,
                     double presence_fraction) const;
 
-    std::vector<std::pair<Label, std::vector<size_t>>>
+    std::vector<std::tuple<Label, size_t, std::vector<size_t>>>
     get_kmer_counts(const std::vector<node_index> &nodes,
                     size_t num_top_labels,
                     double discovery_fraction,
                     double presence_fraction) const;
 
-    std::vector<std::pair<Label, std::vector<SmallVector<uint64_t>>>>
+    std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
     get_kmer_coordinates(std::string_view sequence,
                          size_t num_top_labels,
                          double discovery_fraction,
                          double presence_fraction) const;
 
-    std::vector<std::pair<Label, std::vector<SmallVector<uint64_t>>>>
+    std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
     get_kmer_coordinates(const std::vector<node_index> &nodes,
                          size_t num_top_labels,
                          double discovery_fraction,

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -80,7 +80,8 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
 
     bool check_compatibility() const;
 
-    std::vector<node_index> sequence_to_path(std::string_view sequence) const;
+    // map sequence to labeled nodes
+    std::vector<node_index> seq_to_lnodes(std::string_view sequence) const;
 
     // add k-mer counts to the annotation, thread-safe for concurrent calls
     void add_kmer_counts(std::string_view sequence,
@@ -143,7 +144,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                     double presence_fraction) const;
 
     std::vector<std::pair<Label, std::vector<size_t>>>
-    get_kmer_counts(const std::vector<node_index> &path,
+    get_kmer_counts(const std::vector<node_index> &nodes,
                     size_t num_top_labels,
                     double discovery_fraction,
                     double presence_fraction) const;
@@ -155,7 +156,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                          double presence_fraction) const;
 
     std::vector<std::pair<Label, std::vector<SmallVector<uint64_t>>>>
-    get_kmer_coordinates(const std::vector<node_index> &path,
+    get_kmer_coordinates(const std::vector<node_index> &nodes,
                          size_t num_top_labels,
                          double discovery_fraction,
                          double presence_fraction) const;

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -127,7 +127,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                    size_t min_count = 0,
                    bool with_kmer_counts = false) const;
 
-    // returns tuples (label, num_kmer_matches, count_quantiles)
+    // returns tuples (label, num_kmer_matches, kmer_abundance_quantiles)
     std::vector<std::tuple<Label, size_t, std::vector<size_t>>>
     get_label_count_quantiles(std::string_view sequence,
                               size_t num_top_labels,

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -80,6 +80,8 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
 
     bool check_compatibility() const;
 
+    std::vector<node_index> sequence_to_path(std::string_view sequence) const;
+
     // add k-mer counts to the annotation, thread-safe for concurrent calls
     void add_kmer_counts(std::string_view sequence,
                          const std::vector<Label> &labels,
@@ -133,6 +135,18 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                               double discovery_fraction,
                               double presence_fraction,
                               const std::vector<double> &count_quantiles) const;
+
+    std::vector<std::pair<Label, std::vector<size_t>>>
+    get_kmer_counts(std::string_view sequence,
+                    size_t num_top_labels,
+                    double discovery_fraction,
+                    double presence_fraction) const;
+
+    std::vector<std::pair<Label, std::vector<size_t>>>
+    get_kmer_counts(const std::vector<node_index> &path,
+                    size_t num_top_labels,
+                    double discovery_fraction,
+                    double presence_fraction) const;
 
     std::vector<std::pair<Label, std::vector<SmallVector<uint64_t>>>>
     get_kmer_coordinates(std::string_view sequence,

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -127,6 +127,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                    size_t min_count = 0,
                    bool with_kmer_counts = false) const;
 
+    // returns tuples (label, num_kmer_matches, count_quantiles)
     std::vector<std::tuple<Label, size_t, std::vector<size_t>>>
     get_label_count_quantiles(std::string_view sequence,
                               size_t num_top_labels,
@@ -134,24 +135,28 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                               double presence_fraction,
                               const std::vector<double> &count_quantiles) const;
 
+    // returns tuples (label, num_kmer_matches, kmer_abundances)
     std::vector<std::tuple<Label, size_t, std::vector<size_t>>>
     get_kmer_counts(std::string_view sequence,
                     size_t num_top_labels,
                     double discovery_fraction,
                     double presence_fraction) const;
 
+    // returns tuples (label, num_kmer_matches, kmer_abundances)
     std::vector<std::tuple<Label, size_t, std::vector<size_t>>>
     get_kmer_counts(const std::vector<node_index> &nodes,
                     size_t num_top_labels,
                     double discovery_fraction,
                     double presence_fraction) const;
 
+    // returns tuples (label, num_kmer_matches, kmer_coordinates)
     std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
     get_kmer_coordinates(std::string_view sequence,
                          size_t num_top_labels,
                          double discovery_fraction,
                          double presence_fraction) const;
 
+    // returns tuples (label, num_kmer_matches, kmer_coordinates)
     std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
     get_kmer_coordinates(const std::vector<node_index> &nodes,
                          size_t num_top_labels,

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -35,6 +35,7 @@ class SequenceGraph {
 
     // Traverse graph mapping sequence to the graph nodes
     // and run callback for each node until the termination condition is satisfied
+    // TODO: move to AnnotatedSequenceGraph?
     virtual void map_to_nodes(std::string_view sequence,
                               const std::function<void(node_index)> &callback,
                               const std::function<bool()> &terminate = [](){ return false; }) const = 0;
@@ -238,7 +239,10 @@ size_t incoming_edge_rank(const SequenceGraph &graph,
                           SequenceGraph::node_index target);
 
 std::vector<SequenceGraph::node_index>
-map_sequence_to_nodes(const SequenceGraph &graph, std::string_view sequence);
+map_to_nodes(const SequenceGraph &graph, std::string_view sequence);
+
+std::vector<SequenceGraph::node_index>
+map_to_nodes_sequentially(const SequenceGraph &graph, std::string_view sequence);
 
 void reverse_complement_seq_path(const SequenceGraph &graph,
                                  std::string &seq,

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -87,7 +87,7 @@ void CanonicalDBG
     std::string rev_seq(sequence);
     ::reverse_complement(rev_seq.begin(), rev_seq.end());
     // map the reverse-complement
-    std::vector<node_index> rev_path = map_sequence_to_nodes(*graph_, rev_seq);
+    std::vector<node_index> rev_path = graph::map_to_nodes_sequentially(*graph_, rev_seq);
 
     // map the forward
     const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(graph_.get());
@@ -121,7 +121,7 @@ void CanonicalDBG
         assert(it == rev_path.rend());
 
     } else {
-        path = map_sequence_to_nodes(*graph_, sequence);
+        path = graph::map_to_nodes_sequentially(*graph_, sequence);
     }
 
     assert(path.size() == rev_path.size());

--- a/metagraph/src/graph/representation/rc_dbg.hpp
+++ b/metagraph/src/graph/representation/rc_dbg.hpp
@@ -35,7 +35,7 @@ class RCDBG : public DBGWrapper<DeBruijnGraph> {
 
         std::string rc(sequence);
         ::reverse_complement(rc.begin(), rc.end());
-        std::vector<node_index> nodes = map_sequence_to_nodes(*graph_, rc);
+        std::vector<node_index> nodes = graph::map_to_nodes_sequentially(*graph_, rc);
 
         for (auto it = nodes.rbegin(); it != nodes.rend() && !terminate(); ++it) {
             callback(*it);

--- a/metagraph/tests/graph/all/test_dbg_contigs.cpp
+++ b/metagraph/tests/graph/all/test_dbg_contigs.cpp
@@ -26,7 +26,7 @@ TYPED_TEST(DeBruijnGraphTest, CallPathsEmptyGraph) {
             std::vector<std::string> sequences;
             std::mutex seq_mutex;
             empty->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*empty, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*empty, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 sequences.push_back(sequence);
             }, num_threads);
@@ -45,7 +45,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsEmptyGraph) {
             std::vector<std::string> sequences;
             std::mutex seq_mutex;
             empty->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*empty, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*empty, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 sequences.push_back(sequence);
             }, num_threads);
@@ -68,12 +68,12 @@ TYPED_TEST(DeBruijnGraphTest, CallPathsOneSelfLoop) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -95,12 +95,12 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsOneSelfLoop) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -124,12 +124,12 @@ TYPED_TEST(DeBruijnGraphTest, CallPathsThreeSelfLoops) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -150,7 +150,7 @@ TYPED_TEST(DeBruijnGraphTest, CallPathsExtractsLongestOneLoop) {
             std::vector<std::string> contigs;
             std::mutex seq_mutex;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 contigs.push_back(sequence);
             }, num_threads);
@@ -173,7 +173,7 @@ TYPED_TEST(DeBruijnGraphTest, CallPathsExtractsLongestTwoLoops) {
             std::vector<std::string> contigs;
             std::mutex seq_mutex;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 contigs.push_back(sequence);
             }, num_threads);
@@ -194,7 +194,7 @@ TYPED_TEST(DeBruijnGraphTest, CallContigsUniqueKmers) {
 
         std::atomic<size_t> num_kmers = 0;
         graph->call_sequences([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_kmers += sequence.size() - 2;
         }, num_threads);
 
@@ -211,7 +211,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsUniqueKmersCycle) {
         std::atomic<size_t> num_unitigs = 0;
         std::atomic<size_t> num_kmers = 0;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_unitigs++;
             num_kmers += sequence.size() - k + 1;
         }, num_threads);
@@ -230,7 +230,7 @@ TYPED_TEST(DeBruijnGraphTest, CallContigsUniqueKmersCycle) {
         std::atomic<size_t> num_contigs = 0;
         std::atomic<size_t> num_kmers = 0;
         graph->call_sequences([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_contigs++;
             num_kmers += sequence.size() - k + 1;
         }, num_threads);
@@ -253,12 +253,12 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsFourLoops) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -285,7 +285,7 @@ TYPED_TEST(StableDeBruijnGraphTest, CallPaths) {
                 std::vector<std::string> reconst;
                 std::mutex seq_mutex;
                 graph->call_sequences([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     reconst.push_back(sequence);
                 }, num_threads);
@@ -313,7 +313,7 @@ TYPED_TEST(StableDeBruijnGraphTest, CallUnitigs) {
                 std::vector<std::string> reconst;
                 std::mutex seq_mutex;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     reconst.push_back(sequence);
                 }, num_threads);
@@ -342,7 +342,7 @@ TYPED_TEST(StableDeBruijnGraphTest, CallPathsFromCanonical) {
                 std::vector<std::string> reconst;
                 std::mutex seq_mutex;
                 graph->call_sequences([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     reconst.push_back(sequence);
                 }, num_threads);
@@ -370,7 +370,7 @@ TYPED_TEST(StableDeBruijnGraphTest, CallPathsFromCanonicalSingleKmerForm) {
                 std::vector<std::string> reconst;
                 std::mutex seq_mutex;
                 graph->call_sequences([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     reconst.push_back(sequence);
                 }, num_threads, true);
@@ -398,7 +398,7 @@ TYPED_TEST(StableDeBruijnGraphTest, CallUnitigsFromCanonical) {
                 std::vector<std::string> reconst;
                 std::mutex seq_mutex;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     reconst.push_back(sequence);
                 }, num_threads);
@@ -427,7 +427,7 @@ TYPED_TEST(StableDeBruijnGraphTest, CallUnitigsFromCanonicalSingleKmerForm) {
                 std::mutex seq_mutex;
                 // TODO: why is min_tip_size == 0?
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     reconst.push_back(sequence);
                 }, num_threads, 0, true);
@@ -462,7 +462,7 @@ TYPED_TEST(DeBruijnGraphTest, CallPaths) {
                     k,
                     [&](const auto &callback) {
                         graph->call_sequences([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads);
@@ -497,7 +497,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigs) {
                     k,
                     [&](const auto &callback) {
                         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads, 1);
@@ -520,7 +520,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
         std::set<std::string> unitigs;
         std::mutex seq_mutex;
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -528,7 +528,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -536,7 +536,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -544,7 +544,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -557,7 +557,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -565,7 +565,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -573,7 +573,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -581,7 +581,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -595,7 +595,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -604,7 +604,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -613,7 +613,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -622,7 +622,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -631,7 +631,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -646,7 +646,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -654,7 +654,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -662,7 +662,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -670,7 +670,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -678,7 +678,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -692,7 +692,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -700,7 +700,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -708,7 +708,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -716,7 +716,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -724,7 +724,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -744,7 +744,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips2) {
         std::set<std::string> unitigs;
         std::mutex seq_mutex;
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -752,7 +752,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -760,7 +760,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -768,7 +768,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -811,7 +811,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsCheckDegree) {
         std::multiset<std::string> obs_unitigs;
         std::mutex seq_mutex;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             std::unique_lock<std::mutex> lock(seq_mutex);
             obs_unitigs.insert(sequence);
         }, num_threads, 2);
@@ -840,7 +840,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsIndegreeFirstNodeIsZero) {
         std::multiset<std::string> obs_unitigs;
         std::mutex seq_mutex;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             std::unique_lock<std::mutex> lock(seq_mutex);
             obs_unitigs.insert(sequence);
         }, num_threads, 2);
@@ -885,7 +885,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsCross) {
             for (size_t t = 0; t <= 2; ++t) {
                 std::multiset<std::string> obs_unitigs;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     obs_unitigs.insert(sequence);
                 }, num_threads, t);
@@ -899,7 +899,7 @@ TYPED_TEST(DeBruijnGraphTest, CallUnitigsCross) {
             for (size_t t = 3; t <= 10; ++t) {
                 std::multiset<std::string> obs_long_unitigs;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     obs_long_unitigs.insert(sequence);
                 }, num_threads, 3);

--- a/metagraph/tests/graph/test_canonical_dbg.cpp
+++ b/metagraph/tests/graph/test_canonical_dbg.cpp
@@ -181,7 +181,7 @@ TYPED_TEST(CanonicalDBGTest, CallPathsEmptyGraphCanonical) {
             std::vector<std::string> sequences;
             std::mutex seq_mutex;
             empty->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*empty, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*empty, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 sequences.push_back(sequence);
             }, num_threads);
@@ -200,7 +200,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsEmptyGraph) {
             std::vector<std::string> sequences;
             std::mutex seq_mutex;
             empty->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*empty, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*empty, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 sequences.push_back(sequence);
             }, num_threads);
@@ -223,12 +223,12 @@ TYPED_TEST(CanonicalDBGTest, CallPathsOneSelfLoop) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -250,12 +250,12 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsOneSelfLoop) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -279,12 +279,12 @@ TYPED_TEST(CanonicalDBGTest, CallPathsThreeSelfLoops) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -305,7 +305,7 @@ TYPED_TEST(CanonicalDBGTest, CallPathsExtractsLongestOneLoop) {
             std::vector<std::string> contigs;
             std::mutex seq_mutex;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 contigs.push_back(sequence);
             }, num_threads);
@@ -325,7 +325,7 @@ TYPED_TEST(CanonicalDBGTest, CallContigsUniqueKmers) {
 
         std::atomic<size_t> num_kmers = 0;
         graph->call_sequences([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_kmers += sequence.size() - 2;
         }, num_threads);
 
@@ -342,7 +342,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsUniqueKmersCycle) {
         std::atomic<size_t> num_unitigs = 0;
         std::atomic<size_t> num_kmers = 0;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_unitigs++;
             num_kmers += sequence.size() - k + 1;
         }, num_threads);
@@ -361,7 +361,7 @@ TYPED_TEST(CanonicalDBGTest, CallContigsUniqueKmersCycle) {
         std::atomic<size_t> num_contigs = 0;
         std::atomic<size_t> num_kmers = 0;
         graph->call_sequences([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_contigs++;
             num_kmers += sequence.size() - k + 1;
         }, num_threads);
@@ -384,12 +384,12 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsFourLoops) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -429,7 +429,7 @@ TYPED_TEST(CanonicalDBGTest, CallPaths) {
                     k,
                     [&](const auto &callback) {
                         graph->call_sequences([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads);
@@ -466,7 +466,7 @@ TYPED_TEST(CanonicalDBGTest, CallPaths) {
 //                     k,
 //                     [&](const auto &callback) {
 //                         graph->call_sequences([&](const auto &sequence, const auto &path) {
-//                             ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+//                             ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
 //                             std::unique_lock<std::mutex> lock(seq_mutex);
 //                             callback(sequence);
 //                         }, num_threads, true);
@@ -495,13 +495,13 @@ TYPED_TEST(CanonicalDBGTest, CallPathsCheckHalfSingleKmerForm) {
 
                 std::atomic<size_t> num_kmers_both = 0;
                 graph->call_sequences([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers_both += path.size();
                 }, num_threads);
 
                 std::atomic<size_t> num_kmers = 0;
                 graph->call_sequences([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers += path.size();
                 }, num_threads, true);
 
@@ -544,7 +544,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigs) {
                     k,
                     [&](const auto &callback) {
                         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads);
@@ -592,7 +592,7 @@ TYPED_TEST(CanonicalDBGTest, WrapCanonicalGraphFail) {
 //                     k,
 //                     [&](const auto &callback) {
 //                         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-//                             ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+//                             ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
 //                             std::unique_lock<std::mutex> lock(seq_mutex);
 //                             callback(sequence);
 //                         }, num_threads, 1, true);
@@ -621,13 +621,13 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsCheckHalfSingleKmerForm) {
 
                 std::atomic<size_t> num_kmers_both = 0;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers_both += path.size();
                 }, num_threads);
 
                 std::atomic<size_t> num_kmers = 0;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers += path.size();
                 }, num_threads, 1, true);
 
@@ -652,7 +652,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
         ASSERT_EQ(12u, graph->num_nodes());
 
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -661,7 +661,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -670,7 +670,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -679,7 +679,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -692,7 +692,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -700,7 +700,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -708,7 +708,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -716,7 +716,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -729,7 +729,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -740,7 +740,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -751,7 +751,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -762,7 +762,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -773,7 +773,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -793,7 +793,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -803,7 +803,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -813,7 +813,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -823,7 +823,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -833,7 +833,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -848,7 +848,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -859,7 +859,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -870,7 +870,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -881,7 +881,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -892,7 +892,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -915,7 +915,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips2) {
         ASSERT_EQ(34u, graph->num_nodes());
         std::set<std::string> unitigs;
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -928,7 +928,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -941,7 +941,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -953,7 +953,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -1045,7 +1045,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsCheckDegree) {
         std::mutex seq_mutex;
         std::multiset<std::string> obs_unitigs;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             std::unique_lock<std::mutex> lock(seq_mutex);
             obs_unitigs.insert(sequence);
         }, num_threads, 2);
@@ -1076,7 +1076,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsIndegreeFirstNodeIsZero) {
         std::multiset<std::string> obs_unitigs;
         std::mutex seq_mutex;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             std::unique_lock<std::mutex> lock(seq_mutex);
             obs_unitigs.insert(sequence);
         }, num_threads, 2);
@@ -1122,7 +1122,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsCross) {
             for (size_t t = 0; t <= 2; ++t) {
                 std::multiset<std::string> obs_unitigs;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     obs_unitigs.insert(sequence);
                 }, num_threads, t);
@@ -1139,7 +1139,7 @@ TYPED_TEST(CanonicalDBGTest, CallUnitigsCross) {
             for (size_t t = 3; t <= 10; ++t) {
                 std::multiset<std::string> obs_long_unitigs;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     obs_long_unitigs.insert(sequence);
                 }, num_threads, 3);

--- a/metagraph/tests/graph/test_dbg_canonical.cpp
+++ b/metagraph/tests/graph/test_dbg_canonical.cpp
@@ -430,7 +430,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallPathsEmptyGraphCanonical) {
             std::vector<std::string> sequences;
             std::mutex seq_mutex;
             empty->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*empty, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*empty, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 sequences.push_back(sequence);
             }, num_threads);
@@ -449,7 +449,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsEmptyGraph) {
             std::vector<std::string> sequences;
             std::mutex seq_mutex;
             empty->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*empty, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*empty, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 sequences.push_back(sequence);
             }, num_threads);
@@ -472,12 +472,12 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallPathsOneSelfLoop) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -499,12 +499,12 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsOneSelfLoop) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -528,12 +528,12 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallPathsThreeSelfLoops) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -554,7 +554,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallPathsExtractsLongestOneLoop) {
             std::vector<std::string> contigs;
             std::mutex seq_mutex;
             graph->call_sequences([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 std::unique_lock<std::mutex> lock(seq_mutex);
                 contigs.push_back(sequence);
             }, num_threads);
@@ -574,7 +574,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallContigsUniqueKmers) {
 
         std::atomic<size_t> num_kmers = 0;
         graph->call_sequences([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_kmers += sequence.size() - 2;
         }, num_threads);
 
@@ -591,7 +591,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsUniqueKmersCycle) {
         std::atomic<size_t> num_unitigs = 0;
         std::atomic<size_t> num_kmers = 0;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_unitigs++;
             num_kmers += sequence.size() - k + 1;
         }, num_threads);
@@ -610,7 +610,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallContigsUniqueKmersCycle) {
         std::atomic<size_t> num_contigs = 0;
         std::atomic<size_t> num_kmers = 0;
         graph->call_sequences([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             num_contigs++;
             num_kmers += sequence.size() - k + 1;
         }, num_threads);
@@ -633,12 +633,12 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsFourLoops) {
 
             std::atomic<size_t> num_sequences = 0;
             graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                 num_sequences++;
             }, num_threads);
             std::atomic<size_t> num_sequences_batch = 0;
             graph_batch->call_unitigs([&](const auto &sequence, const auto &path) {
-                ASSERT_EQ(path, map_sequence_to_nodes(*graph_batch, sequence));
+                ASSERT_EQ(path, map_to_nodes_sequentially(*graph_batch, sequence));
                 num_sequences_batch++;
             }, num_threads);
 
@@ -671,7 +671,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallPaths) {
                     k,
                     [&](const auto &callback) {
                         graph->call_sequences([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads);
@@ -707,7 +707,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallPathsSingleKmerForm) {
                     k,
                     [&](const auto &callback) {
                         graph->call_sequences([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads, true);
@@ -736,13 +736,13 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallPathsCheckHalfSingleKmerForm) {
 
                 std::atomic<size_t> num_kmers_both = 0;
                 graph->call_sequences([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers_both += path.size();
                 }, num_threads);
 
                 std::atomic<size_t> num_kmers = 0;
                 graph->call_sequences([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers += path.size();
                 }, num_threads, true);
 
@@ -774,7 +774,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigs) {
                     k,
                     [&](const auto &callback) {
                         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads);
@@ -810,7 +810,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsSingleKmerForm) {
                     k,
                     [&](const auto &callback) {
                         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                             std::unique_lock<std::mutex> lock(seq_mutex);
                             callback(sequence);
                         }, num_threads, 1, true);
@@ -839,13 +839,13 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsCheckHalfSingleKmerForm) {
 
                 std::atomic<size_t> num_kmers_both = 0;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers_both += path.size();
                 }, num_threads);
 
                 std::atomic<size_t> num_kmers = 0;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     num_kmers += path.size();
                 }, num_threads, 1, true);
 
@@ -866,7 +866,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
         ASSERT_EQ(12u, graph->num_nodes());
 
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -875,7 +875,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -884,7 +884,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -893,7 +893,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -906,7 +906,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -914,7 +914,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -922,7 +922,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -930,7 +930,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -943,7 +943,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -954,7 +954,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -965,7 +965,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -976,7 +976,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -987,7 +987,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -1007,7 +1007,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -1017,7 +1017,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -1027,7 +1027,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -1037,7 +1037,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -1047,7 +1047,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -1062,7 +1062,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -1073,7 +1073,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -1084,7 +1084,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -1095,7 +1095,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 3);
@@ -1106,7 +1106,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -1129,7 +1129,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips2) {
         ASSERT_EQ(34u, graph->num_nodes());
         std::set<std::string> unitigs;
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 0);
@@ -1142,7 +1142,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 1);
@@ -1155,7 +1155,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 2);
@@ -1167,7 +1167,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsWithoutTips2) {
 
         unitigs.clear();
         graph->call_unitigs([&](const auto &unitig, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, unitig));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, unitig));
             std::unique_lock<std::mutex> lock(seq_mutex);
             unitigs.insert(unitig);
         }, num_threads, 10);
@@ -1259,7 +1259,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsCheckDegree) {
         std::mutex seq_mutex;
         std::multiset<std::string> obs_unitigs;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             std::unique_lock<std::mutex> lock(seq_mutex);
             obs_unitigs.insert(sequence);
         }, num_threads, 2);
@@ -1290,7 +1290,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsIndegreeFirstNodeIsZero) {
         std::multiset<std::string> obs_unitigs;
         std::mutex seq_mutex;
         graph->call_unitigs([&](const auto &sequence, const auto &path) {
-            ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+            ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
             std::unique_lock<std::mutex> lock(seq_mutex);
             obs_unitigs.insert(sequence);
         }, num_threads, 2);
@@ -1336,7 +1336,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsCross) {
             for (size_t t = 0; t <= 2; ++t) {
                 std::multiset<std::string> obs_unitigs;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     obs_unitigs.insert(sequence);
                 }, num_threads, t);
@@ -1353,7 +1353,7 @@ TYPED_TEST(DeBruijnGraphCanonicalTest, CallUnitigsCross) {
             for (size_t t = 3; t <= 10; ++t) {
                 std::multiset<std::string> obs_long_unitigs;
                 graph->call_unitigs([&](const auto &sequence, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(*graph, sequence));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(*graph, sequence));
                     std::unique_lock<std::mutex> lock(seq_mutex);
                     obs_long_unitigs.insert(sequence);
                 }, num_threads, 3);

--- a/metagraph/tests/graph/test_masked_graph.cpp
+++ b/metagraph/tests/graph/test_masked_graph.cpp
@@ -48,7 +48,7 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallPathsNoMask) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<TypeParam>(k, [&](const auto &callback) {
                     masked.call_sequences([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(masked, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(masked, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -79,7 +79,7 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallUnitigsNoMask) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<TypeParam>(k, [&](const auto &callback) {
                     masked.call_unitigs([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(masked, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(masked, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -112,7 +112,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallPathsNoMask) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<DBGSuccinct>(k, [&](const auto &callback) {
                     masked.call_sequences([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(masked, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(masked, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -145,7 +145,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallUnitigsNoMask) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<DBGSuccinct>(k, [&](const auto &callback) {
                     masked.call_unitigs([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(masked, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(masked, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -184,7 +184,7 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallPathsMaskFirstKmer) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<TypeParam>(k, [&](const auto &callback) {
                     graph.call_sequences([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(graph, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(graph, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -248,7 +248,7 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallUnitigsMaskFirstKmer) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<TypeParam>(k, [&](const auto &callback) {
                     graph.call_unitigs([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(graph, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(graph, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -312,7 +312,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallPathsMaskFirstKmer) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<DBGSuccinct>(k, [&](const auto &callback) {
                     graph.call_sequences([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(graph, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(graph, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -376,7 +376,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallUnitigsMaskFirstKmer) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<DBGSuccinct>(k, [&](const auto &callback) {
                     graph.call_unitigs([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(graph, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(graph, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -453,7 +453,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallContigsMaskPath) {
                 std::mutex seq_mutex;
                 auto reconstructed = build_graph_iterative<TypeParam>(k, [&](const auto &callback) {
                     graph.call_sequences([&](const auto &seq, const auto &path) {
-                        ASSERT_EQ(path, map_sequence_to_nodes(graph, seq));
+                        ASSERT_EQ(path, map_to_nodes_sequentially(graph, seq));
                         std::lock_guard<std::mutex> lock(seq_mutex);
                         callback(seq);
                     }, num_threads);
@@ -532,7 +532,7 @@ TYPED_TEST(MaskedDeBruijnGraphTest, CallUnitigsMaskPath) {
             std::mutex seq_mutex;
             graph.call_unitigs(
                 [&](const auto &unitig, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(graph, unitig));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(graph, unitig));
                     graph.map_to_nodes(
                         unitig,
                         [&](const auto &index) {
@@ -618,7 +618,7 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallUnitigsSingleKmerFormCanonical) {
                     [&](const auto &callback) {
                         stable_masked_graph.call_unitigs(
                             [&](const auto &sequence, const auto &path) {
-                                ASSERT_EQ(path, map_sequence_to_nodes(stable_masked_graph, sequence));
+                                ASSERT_EQ(path, map_to_nodes_sequentially(stable_masked_graph, sequence));
                                 std::unique_lock<std::mutex> lock(seq_mutex);
                                 callback(sequence);
                             },
@@ -634,7 +634,7 @@ TYPED_TEST(MaskedStableDeBruijnGraphTest, CallUnitigsSingleKmerFormCanonical) {
                     [&](const auto &callback) {
                         graph.call_unitigs(
                             [&](const auto &sequence, const auto &path) {
-                                ASSERT_EQ(path, map_sequence_to_nodes(graph, sequence));
+                                ASSERT_EQ(path, map_to_nodes_sequentially(graph, sequence));
                                 std::unique_lock<std::mutex> lock(seq_mutex);
                                 callback(sequence);
                             },
@@ -681,7 +681,7 @@ TEST(MaskedDBGSuccinct, CallUnitigsMaskLastEdges) {
                 MaskedDeBruijnGraph masked_graph(graph, std::make_unique<bit_vector_stat>(std::move(mask)));
                 std::atomic<size_t> counted_kmers(0);
                 masked_graph.call_unitigs([&](const auto &seq, const auto &path) {
-                    ASSERT_EQ(path, map_sequence_to_nodes(masked_graph, seq));
+                    ASSERT_EQ(path, map_to_nodes_sequentially(masked_graph, seq));
                     counted_kmers += path.size();
                 }, num_threads);
                 EXPECT_EQ(num_kmers, counted_kmers);


### PR DESCRIPTION
* Support for querying abundances of individual k-mers
* Other refactorings and improvements
* Support for printing query results with CLI in JSON

Example:
```
./metagraph build -k 31 -o test_1 ../tests/data/transcripts_1000.fa
./metagraph annotate --anno-header -o test_1 -i test_1.dbg ../tests/data/transcripts_1000.fa --count-kmers
./metagraph transform_anno --anno-type int_brwt test_1.column.annodbg -v -o test_1
./metagraph query -i test_1.dbg  -a test_1.int_brwt.annodbg ../tests/data/transcripts_100.fa --query-counts --suppress-unlabeled | less
./metagraph query -i test_1.dbg  -a test_1.int_brwt.annodbg ../tests/data/transcripts_100.fa --query-counts --suppress-unlabeled --json | less
```

Output format: `POS_FIRST-POS_LAST=COUNT` for a run of k-mers in query at positions [POS_FIRST, POS_LAST] with abundance `COUNT`, or `POS=COUNT` for isolated k-mer matches. Skipped k-mers have count 0.

Example:
```
{
        "results" : 
        [seq_description" : "ENST00000450305.2..."
                {
                        "kmer_abundances" : 
                        [
                                "0-1626=1"
                        ],
                        "kmer_count" : 1627,
                        "sample" : "ENST00000456328.2..."
                }
        ],
        "seq_description" : "ENST00000456328.2..."
}
{
        "results" : 
        [
                {
                        "kmer_abundances" : 
                        [
                                "0-601=1"
                        ],
                        "kmer_count" : 602,
                        "sample" : "ENST00000450305.2..."
                },
                {
                        "kmer_abundances" : 
                        [
                                "0-17=1",
                                "48-151=1",
                                "258-383=1",
                                "414-601=1"
                        ],
                        "kmer_count" : 436,
                        "sample" : "ENST00000456328.2..."
                },
                {
                        "kmer_abundances" : 
                        [
                                "68-310=1",
                                "367-383=1",
                                "423-586=1"
                        ],
                        "kmer_count" : 424,
                        "sample" : "ENST00000624431.2..."
                }
        ],
        "seq_description" : "ENST00000450305.2..."
}
...
```

TODO: add docs