### PR TITLE
Support outputting alignments in GAF format

### DIFF
--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -338,6 +338,8 @@ Config::Config(int argc, char *argv[]) {
             output_compacted = true;
         } else if (!strcmp(argv[i], "--json")) {
             output_json = true;
+        } else if (!strcmp(argv[i], "--gaf")) {
+            output_gaf = true;
         } else if (!strcmp(argv[i], "--unitigs")) {
             to_fasta = true;
             unitigs = true;
@@ -1005,6 +1007,7 @@ if (advanced) {
             fprintf(stderr, "Available options for alignment:\n");
             fprintf(stderr, "\t-o --outfile-base [STR]\t\t\t\tbasename of output file []\n");
             fprintf(stderr, "\t   --json \t\t\t\t\toutput alignment in JSON format [off]\n");
+            fprintf(stderr, "\t   --gaf \t\t\t\t\toutput alignment in GAF format [off]\n");
 if (advanced) {
             fprintf(stderr, "\t   --align-only-forwards \t\t\tdo not align backwards from a seed on basic-mode graphs [off]\n");
 }

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -61,6 +61,7 @@ class Config {
     bool align_only_forwards = false;
     bool filter_by_kmer = false;
     bool output_json = false;
+    bool output_gaf = false;
     bool aggregate_columns = false;
     bool coordinates = false;
     bool advanced = false;

--- a/metagraph/src/graph/alignment/aligner_cigar.hpp
+++ b/metagraph/src/graph/alignment/aligner_cigar.hpp
@@ -40,6 +40,7 @@ class Cigar {
     bool empty() const { return cigar_.empty(); }
 
     std::string to_string() const;
+    std::string to_md_string(std::string_view reference) const;
 
     void append(Operator op, LengthType num = 1);
     void append(Cigar&& other);


### PR DESCRIPTION
This format reports the node IDs of alignment paths.

See ["The Graph Alignment Format (GAF)"](https://github.com/lh3/gfatools/blob/master/doc/rGFA.md#the-graph-alignment-format-gaf) and ["Sequence Alignment/Map Optional Fields Specification"](https://samtools.github.io/hts-specs/SAMtags.pdf)