### PR TITLE
Reduce memory usage in seed generation, seed extension improvements

### DIFF
--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -108,7 +108,7 @@ void map_sequences_in_file(const std::string &file,
         } else {
             // TODO: make more efficient
             // TODO: canonicalization
-            const DBGSuccinct &dbg = dynamic_cast<const DBGSuccinct&>(graph);
+            const DBGSuccinct &dbg = static_cast<const DBGSuccinct&>(graph);
             if (dbg.get_mode() == DeBruijnGraph::PRIMARY)
                 logger->warn("Sub-k-mers will be mapped to unwrapped primary graph");
 
@@ -378,8 +378,6 @@ int align_to_graph(Config *config) {
 
         size_t num_batches = 0;
 
-        bool is_reverse_complement = false;
-
         while (it != end) {
             uint64_t num_bytes_read = 0;
 
@@ -394,10 +392,8 @@ int align_to_graph(Config *config) {
                             ? utils::join_strings({ it->name.s, it->comment.s },
                                                   config->fasta_anno_comment_delim, true)
                             : std::string(it->name.s);
-                seq_batch.emplace_back(std::move(header), it->seq.s, is_reverse_complement);
+                seq_batch.emplace_back(std::move(header), it->seq.s);
                 num_bytes_read += it->seq.l;
-                // alternate between forward and rc sequences if |forward_and_reverse| is true
-                is_reverse_complement ^= config->forward_and_reverse;
             }
 
             ++num_batches;

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -1211,9 +1211,9 @@ Alignment align_sequence(std::string *seq,
         // modify sequence for querying with the best alignment
         if (match.get_offset()) {
             *seq = graph.get_node_sequence(match.get_nodes()[0]).substr(0, match.get_offset())
-                  + match.get_sequence();
+                  + std::string(match.get_sequence());
         } else {
-            *seq = const_cast<std::string&&>(match.get_sequence());
+            *seq = match.get_sequence();
         }
 
         return { match.get_score(), match.get_cigar().to_string(), match.get_orientation() };

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -187,7 +187,7 @@ std::string process_align_request(const std::string &received_message,
         for (const auto &path : aligner.align(read_stream->seq.s)) {
             Json::Value a;
             a[SeqSearchResult::SCORE_JSON_FIELD] = path.get_score();
-            a[SeqSearchResult::SEQUENCE_JSON_FIELD] = path.get_sequence();
+            a[SeqSearchResult::SEQUENCE_JSON_FIELD] = std::string(path.get_sequence());
             a[SeqSearchResult::CIGAR_JSON_FIELD] = path.get_cigar().to_string();
             a[SeqSearchResult::ORIENTATION_JSON_FIELD] = path.get_orientation();
 

--- a/metagraph/src/common/algorithms.hpp
+++ b/metagraph/src/common/algorithms.hpp
@@ -150,6 +150,8 @@ namespace utils {
         }
     }
 
+    // Output the intersection of the sorted ranges a and b to intersection_out,
+    // and the elements from a not in b to diff_out (i.e., the set difference of a and b)
     template <class AIt, class BIt, class OutIt, class OutIt2>
     constexpr void set_intersection_difference(AIt a_begin, AIt a_end,
                                                BIt b_begin, BIt b_end,

--- a/metagraph/src/common/algorithms.hpp
+++ b/metagraph/src/common/algorithms.hpp
@@ -150,6 +150,26 @@ namespace utils {
         }
     }
 
+    template <class AIt, class BIt, class OutIt, class OutIt2>
+    constexpr void set_intersection_difference(AIt a_begin, AIt a_end,
+                                               BIt b_begin, BIt b_end,
+                                               OutIt intersection_out, OutIt2 diff_out) {
+        while (a_begin != a_end) {
+            if (b_begin == b_end || *a_begin < *b_begin) {
+                *diff_out = *a_begin;
+                ++diff_out;
+                ++a_begin;
+            } else if (*a_begin > *b_begin) {
+                ++b_begin;
+            } else {
+                *intersection_out = *a_begin;
+                ++intersection_out;
+                ++a_begin;
+                ++b_begin;
+            }
+        }
+    }
+
     // Intersect sorted ranges index1 and index2 with their corresponding values
     // stored in value1 and value2, respectively.
     // For each element shared between index1 and index2, invoke the callback

--- a/metagraph/src/graph/alignment/aligner_aggregator.hpp
+++ b/metagraph/src/graph/alignment/aligner_aggregator.hpp
@@ -87,7 +87,7 @@ inline bool AlignmentAggregator<AlignmentCompare>::add_alignment(Alignment&& ali
         // check for duplicates
         for (const auto &aln : queue) {
             if (*a == *aln)
-                return false;
+                return config_.post_chain_alignments;
         }
         // If post-alignment chaining is requested, never skip any alignments
         if (config_.post_chain_alignments || queue.size() < config_.num_alternative_paths) {

--- a/metagraph/src/graph/alignment/aligner_chainer.cpp
+++ b/metagraph/src/graph/alignment/aligner_chainer.cpp
@@ -374,9 +374,8 @@ std::vector<Alignment> chain_alignments(std::vector<Alignment>&& alignments,
                               b.get_sequence().size());
     });
 
-    if (common::get_verbose()) {
-        DEBUG_LOG("Chaining alignments:\n{}", fmt::join(alignments, "\t\n"));
-    }
+    DEBUG_LOG("Chaining alignments:\n{}", fmt::join(alignments, "\t\n"));
+
 
     auto run = [&](std::string_view this_query, auto begin, auto end) {
         std::vector<score_t> best_score(this_query.size() + 1, 0);

--- a/metagraph/src/graph/alignment/aligner_chainer.hpp
+++ b/metagraph/src/graph/alignment/aligner_chainer.hpp
@@ -17,9 +17,11 @@ call_seed_chains_both_strands(std::string_view forward,
                               std::string_view reverse,
                               size_t node_overlap,
                               const DBGAlignerConfig &config,
-                              std::vector<Alignment>&& fwd_seeds,
-                              std::vector<Alignment>&& bwd_seeds,
-                              const std::function<void(Chain&&, score_t)> &callback);
+                              std::vector<Seed>&& fwd_seeds,
+                              std::vector<Seed>&& bwd_seeds,
+                              const std::function<void(Chain&&, score_t)> &callback,
+                              const std::function<bool(Alignment::Column)> &skip_column
+                                  = [](Alignment::Column) { return false; });
 
 // Given a set of local alignments, use sparse dynamic programming to construct
 // longer alignments, potentially with gaps.

--- a/metagraph/src/graph/alignment/aligner_extender_methods.cpp
+++ b/metagraph/src/graph/alignment/aligner_extender_methods.cpp
@@ -279,10 +279,12 @@ void update_column(size_t prev_end,
         __m128i ins_open_next = _mm_add_epi32(match, gap_open);
         _mm_storeu_si128((__m128i*)&E_v[j + 1], ins_open_next);
 
-        size_t end = j + 4;
-        for (size_t k = j; k < end; ++k) {
-            E_v[k + 1] = std::max(E_v[k] + config_.gap_extension_penalty, E_v[k + 1]);
-        }
+        // This is rolling update is hard to vectorize
+        // E_v[j + 1] = max(E_v[j + 1], E_v[j] + gap_extend)
+        E_v[j + 1] = std::max(E_v[j] + config_.gap_extension_penalty, E_v[j + 1]);
+        E_v[j + 2] = std::max(E_v[j + 1] + config_.gap_extension_penalty, E_v[j + 2]);
+        E_v[j + 3] = std::max(E_v[j + 2] + config_.gap_extension_penalty, E_v[j + 3]);
+        E_v[j + 4] = std::max(E_v[j + 3] + config_.gap_extension_penalty, E_v[j + 4]);
 
         // S_v[j] = max(match, E_v[j])
         match = _mm_max_epi32(match, _mm_load_si128((__m128i*)&E_v[j]));

--- a/metagraph/src/graph/alignment/aligner_extender_methods.hpp
+++ b/metagraph/src/graph/alignment/aligner_extender_methods.hpp
@@ -138,7 +138,6 @@ class DefaultColumnExtender : public SeedFilteringExtender {
         ssize_t trim; // first index allocated by the vectors
                       // i.e., the maximal value is located at S[max_pos - trim]
         size_t xdrop_cutoff_i; // corresponding index in the xdrop_cutoff vector
-        size_t last_fork_i; // index of the nearest ancestor that was a fork
         score_t score; // added score when traversing to this node (typically a negative penalty)
 
         // allocate and initialize with padding to ensure that SIMD operations don't
@@ -184,6 +183,7 @@ class DefaultColumnExtender : public SeedFilteringExtender {
     virtual std::vector<Alignment> backtrack(score_t min_path_score,
                                              std::string_view window,
                                              score_t right_end_bonus,
+                                             const std::vector<size_t> &tips,
                                              node_index target_node = DeBruijnGraph::npos);
 
     /**
@@ -210,10 +210,10 @@ class DefaultColumnExtender : public SeedFilteringExtender {
                                  size_t offset,
                                  std::string_view window,
                                  const std::string &match,
-                                 score_t extra_penalty,
+                                 score_t extra_score,
                                  const std::function<void(Alignment&&)> &callback) {
         callback(construct_alignment(ops, clipping, window, path, match, end_score,
-                                     offset, extra_penalty));
+                                     offset, extra_score));
     }
 
     Alignment construct_alignment(Cigar cigar,
@@ -223,7 +223,7 @@ class DefaultColumnExtender : public SeedFilteringExtender {
                                   std::string match,
                                   score_t score,
                                   size_t offset,
-                                  score_t extra_penalty) const;
+                                  score_t extra_score) const;
 
   private:
     // compute perfect match scores for all suffixes used for branch and bound checks

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -661,8 +661,7 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
 
         std::sort(label_counts.begin(), label_counts.end(), utils::GreaterSecond());
 
-        double cutoff = std::max(this->config_.rel_score_cutoff * label_counts[0].second,
-                                 this->config_.min_exact_match * query_size);
+        double cutoff = this->config_.min_exact_match * query_size;
         auto it = std::find_if(label_counts.begin(), label_counts.end(),
                                [cutoff](const auto &a) { return a.second < cutoff; });
 

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -15,25 +15,13 @@ namespace align {
 
 using mtg::common::logger;
 
-Alignment::Alignment(std::string_view query,
-                     std::vector<node_index>&& nodes,
-                     std::string&& sequence,
-                     score_t score,
-                     size_t clipping,
-                     bool orientation,
-                     size_t offset)
-      : query_view_(query), nodes_(std::move(nodes)), sequence_(std::move(sequence)),
-        score_(score),
-        orientation_(orientation),
-        offset_(offset) {
-    assert(query_view_.size() == sequence_.size());
-    cigar_ = std::inner_product(query_view_.begin(), query_view_.end(), sequence_.begin(),
-                                Cigar(Cigar::CLIPPED, clipping),
-                                [&](Cigar &cigar, bool equal) -> Cigar& {
-                                    cigar.append(equal ? Cigar::MATCH : Cigar::MISMATCH);
-                                    return cigar;
-                                },
-                                std::equal_to<char>());
+Alignment::Alignment(const Seed &seed, const DBGAlignerConfig &config)
+      : Matching(seed), sequence_(query_view_),
+        score_(config.match_score(query_view_) + (!seed.get_clipping() ? config.left_end_bonus : 0)
+                    + (!seed.get_end_clipping() ? config.right_end_bonus : 0)),
+        cigar_(Cigar::CLIPPED, seed.get_clipping()) {
+    cigar_.append(Cigar::MATCH, query_view_.size());
+    cigar_.append(Cigar::CLIPPED, seed.get_end_clipping());
 }
 
 std::string Alignment::format_coords() const {
@@ -41,14 +29,16 @@ std::string Alignment::format_coords() const {
         return "";
 
     assert(label_columns.size());
-    assert(label_encoder);
     assert(label_coordinates.size() == label_columns.size());
 
     std::vector<std::string> decoded_labels;
     decoded_labels.reserve(label_columns.size());
 
     for (size_t i = 0; i < label_columns.size(); ++i) {
-        decoded_labels.emplace_back(label_encoder->decode(label_columns[i]));
+        decoded_labels.emplace_back(label_encoder
+            ? label_encoder->decode(label_columns[i])
+            : std::to_string(label_columns[i])
+        );
         for (uint64_t coord : label_coordinates[i]) {
             // alignment coordinates are 1-based inclusive ranges
             decoded_labels.back()
@@ -552,7 +542,7 @@ void Alignment::reverse_complement(const DeBruijnGraph &graph,
             if (canonical)
                 base_graph = &canonical->get_graph();
 
-            const auto &dbg_succ = dynamic_cast<const DBGSuccinct&>(*base_graph);
+            const auto &dbg_succ = static_cast<const DBGSuccinct&>(*base_graph);
 
             size_t num_sentinels = sequence_.find_last_of(boss::BOSS::kSentinel) + 1;
             assert(offset_ >= num_sentinels);
@@ -1302,10 +1292,10 @@ bool Alignment::is_valid(const DeBruijnGraph &graph, const DBGAlignerConfig *con
     }
 
     score_t cigar_score = config ? config->score_cigar(sequence_, query_view_, cigar_) : 0;
-    cigar_score += extra_penalty;
+    cigar_score += extra_score;
     if (config && score_ != cigar_score) {
         logger->error("Mismatch between CIGAR and score\nCigar score: {} ({} from extra)\n{}\t{}",
-                      cigar_score, extra_penalty, query_view_, *this);
+                      cigar_score, extra_score, query_view_, *this);
         return false;
     }
 
@@ -1313,7 +1303,7 @@ bool Alignment::is_valid(const DeBruijnGraph &graph, const DBGAlignerConfig *con
 }
 
 
-AlignmentResults::AlignmentResults(std::string_view query, bool is_reverse_complement) {
+AlignmentResults::AlignmentResults(std::string_view query) {
     // Pad sequences for easier access in 64-bit blocks.
     // Take the max of the query size and sizeof(query_view_) to ensure that small-string
     // optimizations are disabled. Implementation taken from:
@@ -1337,8 +1327,6 @@ AlignmentResults::AlignmentResults(std::string_view query, bool is_reverse_compl
 
     // reverse complement
     reverse_complement(query_rc_.begin(), query_rc_.end());
-    if (is_reverse_complement)
-        std::swap(query_, query_rc_);
 }
 
 } // namespace align

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -15,15 +15,6 @@ namespace align {
 
 using mtg::common::logger;
 
-Alignment::Alignment(const Seed &seed, const DBGAlignerConfig &config)
-      : Matching(seed), sequence_(query_view_),
-        score_(config.match_score(query_view_) + (!seed.get_clipping() ? config.left_end_bonus : 0)
-                    + (!seed.get_end_clipping() ? config.right_end_bonus : 0)),
-        cigar_(Cigar::CLIPPED, seed.get_clipping()) {
-    cigar_.append(Cigar::MATCH, query_view_.size());
-    cigar_.append(Cigar::CLIPPED, seed.get_end_clipping());
-}
-
 std::string Alignment::format_coords() const {
     if (!label_coordinates.size())
         return "";

--- a/metagraph/src/graph/alignment/alignment.hpp
+++ b/metagraph/src/graph/alignment/alignment.hpp
@@ -26,38 +26,116 @@ namespace align {
 // Note: this object stores pointers to the query sequence, so it is the user's
 //       responsibility to ensure that the query sequence is not destroyed when
 //       calling this class' methods
-class Alignment {
+class Matching {
   public:
     typedef DeBruijnGraph::node_index node_index;
-    typedef DBGAlignerConfig::score_t score_t;
     typedef annot::binmat::BinaryMatrix::Column Column;
     typedef SmallVector<int64_t> Tuple;
     typedef Vector<Column> Columns;
     typedef Vector<Tuple> CoordinateSet;
+
+    Matching() : orientation_(false), offset_(0) {}
+
+    Matching(std::string_view query_view,
+             std::vector<node_index>&& nodes,
+             bool orientation,
+             size_t offset)
+          : query_view_(query_view), nodes_(std::move(nodes)), orientation_(orientation),
+            offset_(offset) {}
+
+    virtual ~Matching() {}
+
+    std::string_view get_query_view() const { return query_view_; }
+
+    bool empty() const { return nodes_.empty(); }
+
+    // The matched path in the graph
+    const std::vector<node_index>& get_nodes() const { return nodes_; }
+
+    // get the spelling of the matched path
+    virtual std::string_view get_sequence() const = 0;
+
+    // The number of characters discarded from the prefix of the first node in the path.
+    size_t get_offset() const { return offset_; }
+
+    // The number of nodes in the matched path.
+    // This is equal to get_sequence().size() - graph.get_k() + 1 + get_offset()
+    size_t size() const { return nodes_.size(); }
+
+    // The orientation of the original query sequence. Return true iff the reverse
+    // complement is matched to the path.
+    bool get_orientation() const { return orientation_; }
+
+    virtual Cigar::LengthType get_clipping() const = 0;
+    virtual Cigar::LengthType get_end_clipping() const = 0;
+
+    const annot::LabelEncoder<> *label_encoder = nullptr;
+
+    Columns label_columns;
+
+    // for each column in |label_columns|, store a vector of coordinates for the
+    // alignment's first nucleotide
+    // (i.e., the first node's coordinate + the alignment offset)
+    CoordinateSet label_coordinates;
+
+  protected:
+    std::string_view query_view_;
+    std::vector<node_index> nodes_;
+    bool orientation_;
+    size_t offset_;
+};
+
+class Seed : public Matching {
+  public:
+    Seed() : Matching(), clipping_(0), end_clipping_(0) {}
+    Seed(std::string_view query_view,
+         std::vector<node_index>&& nodes,
+         bool orientation,
+         size_t offset,
+         size_t clipping,
+         size_t end_clipping)
+          : Matching(query_view, std::move(nodes), orientation, offset),
+            clipping_(clipping), end_clipping_(end_clipping) {}
+
+    virtual ~Seed() {}
+
+    virtual Cigar::LengthType get_clipping() const override final { return clipping_; }
+    virtual Cigar::LengthType get_end_clipping() const override final { return end_clipping_; }
+    virtual std::string_view get_sequence() const override final { return query_view_; }
+
+    // Add more nodes to the Seed. This assumes that the original query has |next|
+    // extra characters and that the updated path still spells the query view.
+    void expand(const std::vector<node_index> &next) {
+        query_view_ = std::string_view(query_view_.data(), query_view_.size() + next.size());
+        end_clipping_ -= next.size();
+        nodes_.insert(nodes_.end(), next.begin(), next.end());
+    }
+
+  private:
+    Cigar::LengthType clipping_;
+    Cigar::LengthType end_clipping_;
+};
+
+class Alignment : public Matching {
+  public:
+    typedef DBGAlignerConfig::score_t score_t;
     static const score_t ninf = DBGAlignerConfig::ninf;
 
-    Alignment() : score_(0), orientation_(false), offset_(0) {}
+    Alignment() {}
 
     Alignment(std::string_view query,
               std::vector<node_index>&& nodes,
               std::string&& sequence,
               score_t score,
               Cigar&& cigar,
-              size_t clipping = 0,
-              bool orientation = false,
-              size_t offset = 0)
-          : query_view_(query), nodes_(std::move(nodes)), sequence_(std::move(sequence)),
-            score_(score), cigar_(Cigar::CLIPPED, clipping), orientation_(orientation),
-            offset_(offset) { cigar_.append(std::move(cigar)); }
+              size_t clipping,
+              bool orientation,
+              size_t offset)
+          : Matching(query, std::move(nodes), orientation, offset),
+            sequence_(std::move(sequence)), score_(score),
+            cigar_(Cigar::CLIPPED, clipping) { cigar_.append(std::move(cigar)); }
 
-    // Used for constructing gapless Alignments
-    Alignment(std::string_view query,
-              std::vector<node_index>&& nodes,
-              std::string&& sequence,
-              score_t score,
-              size_t clipping = 0,
-              bool orientation = false,
-              size_t offset = 0);
+    Alignment(const Seed &seed, const DBGAlignerConfig &config);
 
     // Append |next| to the end of the current alignment. In this process, alignment
     // labels are intersected. If coordinates are present, then the append is only
@@ -78,13 +156,7 @@ class Alignment {
         return append(std::move(other));
     }
 
-    size_t size() const { return nodes_.size(); }
-    bool empty() const { return nodes_.empty(); }
-    const std::vector<node_index>& get_nodes() const { return nodes_; }
-
     score_t get_score() const { return score_; }
-
-    std::string_view get_query_view() const { return query_view_; }
 
     void extend_query_begin(const char *begin) {
         const char *full_query_begin = query_view_.data() - get_clipping();
@@ -133,13 +205,11 @@ class Alignment {
 
     void reverse_complement(const DeBruijnGraph &graph, std::string_view query_rev_comp);
 
-    const std::string& get_sequence() const { return sequence_; }
+    virtual std::string_view get_sequence() const override final { return sequence_; }
     const Cigar& get_cigar() const { return cigar_; }
     Cigar& get_cigar() { return cigar_; }
-    bool get_orientation() const { return orientation_; }
-    size_t get_offset() const { return offset_; }
-    Cigar::LengthType get_clipping() const { return cigar_.get_clipping(); }
-    Cigar::LengthType get_end_clipping() const { return cigar_.get_end_clipping(); }
+    virtual Cigar::LengthType get_clipping() const override final { return cigar_.get_clipping(); }
+    virtual Cigar::LengthType get_end_clipping() const override final { return cigar_.get_end_clipping(); }
 
     bool operator==(const Alignment &other) const {
         return orientation_ == other.orientation_
@@ -167,24 +237,14 @@ class Alignment {
 
     static bool coordinates_less(const Alignment &a, const Alignment &b);
 
-    Columns label_columns;
-    score_t extra_penalty = 0;
-
-    // for each column in |label_columns|, store a vector of coordinate ranges
-    CoordinateSet label_coordinates;
-
-    const annot::LabelEncoder<> *label_encoder = nullptr;
+    score_t extra_score = 0;
 
     std::string format_coords() const;
 
   private:
-    std::string_view query_view_;
-    std::vector<node_index> nodes_;
     std::string sequence_;
-    score_t score_;
+    score_t score_ = 0;
     Cigar cigar_;
-    bool orientation_;
-    size_t offset_;
 };
 
 inline std::ostream& operator<<(std::ostream &out, const Alignment &a) {
@@ -222,7 +282,7 @@ struct LocalAlignmentGreater {
 // ensures that the query sequence is always accessible.
 class AlignmentResults {
   public:
-    AlignmentResults(std::string_view query = {}, bool is_reverse_complement = false);
+    AlignmentResults(std::string_view query = {});
 
     // Copy constructors are disabled to ensure that the string_view pointers
     // in the Alignment objects stay valid
@@ -292,16 +352,17 @@ template <> struct formatter<mtg::graph::align::Alignment> {
         if (label_coordinates.size()) {
             format_to(ctx.out(), "\t{}", a.format_coords());
         } else if (label_columns.size()) {
-            assert(a.label_encoder);
+            if (a.label_encoder) {
+                std::vector<std::string> decoded_labels;
+                decoded_labels.reserve(label_columns.size());
+                for (size_t i = 0; i < label_columns.size(); ++i) {
+                    decoded_labels.emplace_back(a.label_encoder->decode(label_columns[i]));
+                }
 
-            std::vector<std::string> decoded_labels;
-            decoded_labels.reserve(label_columns.size());
-
-            for (size_t i = 0; i < label_columns.size(); ++i) {
-                decoded_labels.emplace_back(a.label_encoder->decode(label_columns[i]));
+                format_to(ctx.out(), "\t{}", fmt::join(decoded_labels, ";"));
+            } else {
+                format_to(ctx.out(), "\t{}", fmt::join(label_columns, ";"));
             }
-
-            format_to(ctx.out(), "\t{}", fmt::join(decoded_labels, ";"));
         }
 
         return ctx.out();

--- a/metagraph/src/graph/alignment/annotation_buffer.cpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.cpp
@@ -1,0 +1,221 @@
+#include "annotation_buffer.hpp"
+
+#include "graph/representation/rc_dbg.hpp"
+#include "graph/representation/succinct/dbg_succinct.hpp"
+#include "graph/representation/canonical_dbg.hpp"
+#include "annotation/binary_matrix/base/binary_matrix.hpp"
+#include "common/utils/template_utils.hpp"
+
+namespace mtg {
+namespace graph {
+namespace align {
+
+using mtg::common::logger;
+
+typedef annot::binmat::BinaryMatrix::Row Row;
+typedef annot::binmat::BinaryMatrix::Column Column;
+
+// dummy index for an unfetched annotations
+static constexpr size_t nannot = std::numeric_limits<size_t>::max();
+
+AnnotationBuffer::AnnotationBuffer(const DeBruijnGraph &graph, const Annotator &annotator)
+      : graph_(graph),
+        annotator_(annotator),
+        multi_int_(dynamic_cast<const annot::matrix::MultiIntMatrix*>(&annotator_.get_matrix())),
+        canonical_(dynamic_cast<const CanonicalDBG*>(&graph_)),
+        column_sets_({ {} }) {
+    if (multi_int_ && graph_.get_mode() != DeBruijnGraph::BASIC) {
+        multi_int_ = nullptr;
+        logger->warn("Coordinates not supported when aligning to CANONICAL "
+                     "or PRIMARY mode graphs");
+    }
+}
+
+void AnnotationBuffer::fetch_queued_annotations() {
+    assert(graph_.get_mode() != DeBruijnGraph::PRIMARY
+                && "PRIMARY graphs must be wrapped into CANONICAL");
+
+    std::vector<node_index> queued_nodes;
+    std::vector<Row> queued_rows;
+
+    const DeBruijnGraph *base_graph = &graph_;
+
+    if (canonical_)
+        base_graph = &canonical_->get_graph();
+
+    const auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(base_graph);
+    const boss::BOSS *boss = dbg_succ ? &dbg_succ->get_boss() : nullptr;
+
+    for (const auto &path : queued_paths_) {
+        std::vector<node_index> base_path;
+        if (base_graph->get_mode() == DeBruijnGraph::CANONICAL) {
+            // TODO: avoid this call of spell_path
+            std::string query = spell_path(graph_, path);
+            base_path = map_to_nodes(*base_graph, query);
+
+        } else if (canonical_) {
+            base_path.reserve(path.size());
+            for (node_index node : path) {
+                base_path.emplace_back(canonical_->get_base_node(node));
+            }
+
+        } else {
+            assert(graph_.get_mode() == DeBruijnGraph::BASIC);
+            base_path = path;
+            if (dynamic_cast<const RCDBG*>(&graph_))
+                std::reverse(base_path.begin(), base_path.end());
+        }
+
+        assert(base_path.size() == path.size());
+
+        for (size_t i = 0; i < path.size(); ++i) {
+            if (base_path[i] == DeBruijnGraph::npos) {
+                // this can happen when the base graph is CANONICAL and path[i] is a
+                // dummy node
+                if (node_to_cols_.try_emplace(path[i], 0).second && has_coordinates())
+                    label_coords_.emplace_back();
+
+                continue;
+            }
+
+            if (boss && !boss->get_W(dbg_succ->kmer_to_boss_index(base_path[i]))) {
+                // skip dummy nodes
+                if (node_to_cols_.try_emplace(base_path[i], 0).second && has_coordinates())
+                    label_coords_.emplace_back();
+
+                if (graph_.get_mode() == DeBruijnGraph::CANONICAL
+                        && base_path[i] != path[i]
+                        && node_to_cols_.emplace(path[i], 0).second && has_coordinates()) {
+                    label_coords_.emplace_back();
+                }
+
+                continue;
+            }
+
+            Row row = AnnotatedDBG::graph_to_anno_index(base_path[i]);
+            if (canonical_ || graph_.get_mode() == DeBruijnGraph::BASIC) {
+                if (node_to_cols_.try_emplace(base_path[i], nannot).second) {
+                    queued_rows.push_back(row);
+                    queued_nodes.push_back(base_path[i]);
+                }
+
+                continue;
+            }
+
+            assert(graph_.get_mode() == DeBruijnGraph::CANONICAL);
+
+            auto find_a = node_to_cols_.find(path[i]);
+            auto find_b = node_to_cols_.find(base_path[i]);
+
+            if (find_a == node_to_cols_.end() && find_b == node_to_cols_.end()) {
+                node_to_cols_.try_emplace(path[i], nannot);
+                queued_rows.push_back(row);
+                queued_nodes.push_back(path[i]);
+
+                if (path[i] != base_path[i]) {
+                    node_to_cols_.emplace(base_path[i], nannot);
+                    queued_rows.push_back(row);
+                    queued_nodes.push_back(base_path[i]);
+                }
+            } else if (find_a == node_to_cols_.end() && find_b != node_to_cols_.end()) {
+                node_to_cols_.try_emplace(path[i], find_b->second);
+                if (find_b->second == nannot) {
+                    queued_rows.push_back(row);
+                    queued_nodes.push_back(path[i]);
+                }
+            } else if (find_a != node_to_cols_.end() && find_b == node_to_cols_.end()) {
+                node_to_cols_.try_emplace(base_path[i], find_a->second);
+            } else {
+                size_t label_i = std::min(find_a->second, find_b->second);
+                if (label_i != nannot) {
+                    find_a.value() = label_i;
+                    find_b.value() = label_i;
+                }
+            }
+        }
+    }
+
+    queued_paths_.clear();
+
+    if (queued_nodes.empty())
+        return;
+
+    auto push_node_labels = [&](auto node_it, auto row_it, auto&& labels) {
+        assert(node_it != queued_nodes.end());
+        assert(node_to_cols_.count(*node_it));
+        assert(node_to_cols_.count(AnnotatedDBG::anno_to_graph_index(*row_it)));
+
+        size_t label_i = cache_column_set(std::move(labels));
+        node_index base_node = AnnotatedDBG::anno_to_graph_index(*row_it);
+        if (graph_.get_mode() == DeBruijnGraph::BASIC) {
+            assert(base_node == *node_it);
+            node_to_cols_[*node_it] = label_i;
+        } else if (canonical_) {
+            node_to_cols_[base_node] = label_i;
+        } else {
+            node_to_cols_[*node_it] = label_i;
+            if (base_node != *node_it && node_to_cols_.try_emplace(base_node, label_i).second
+                    && has_coordinates()) {
+                label_coords_.emplace_back(label_coords_.back());
+            }
+        }
+    };
+
+    auto node_it = queued_nodes.begin();
+    auto row_it = queued_rows.begin();
+    if (has_coordinates()) {
+        assert(multi_int_);
+        // extract both labels and coordinates, then store them separately
+        for (auto&& row_tuples : multi_int_->get_row_tuples(queued_rows)) {
+            std::sort(row_tuples.begin(), row_tuples.end(), utils::LessFirst());
+            Columns labels;
+            labels.reserve(row_tuples.size());
+            label_coords_.emplace_back();
+            label_coords_.back().reserve(row_tuples.size());
+            for (auto&& [label, coords] : row_tuples) {
+                labels.push_back(label);
+                label_coords_.back().emplace_back(coords.begin(), coords.end());
+            }
+            push_node_labels(node_it++, row_it++, std::move(labels));
+        }
+    } else {
+        for (auto&& labels : annotator_.get_matrix().get_rows(queued_rows)) {
+            std::sort(labels.begin(), labels.end());
+            push_node_labels(node_it++, row_it++, std::move(labels));
+        }
+    }
+
+#ifndef NDEBUG
+    for (const auto &[node, val] : node_to_cols_) {
+        assert(val != nannot);
+    }
+#endif
+}
+
+auto AnnotationBuffer::get_labels_and_coords(node_index node) const
+        -> std::pair<const Columns*, const CoordinateSet*> {
+    std::pair<const Columns*, const CoordinateSet*> ret_val { nullptr, nullptr };
+
+    if (canonical_)
+        node = canonical_->get_base_node(node);
+
+    auto it = node_to_cols_.find(node);
+
+    // if the node hasn't been seen before, or if its annotations haven't
+    // been fetched, return nothing
+    if (it == node_to_cols_.end() || it->second == nannot)
+        return ret_val;
+
+    ret_val.first = &column_sets_.data()[it->second];
+
+    if (has_coordinates()) {
+        assert(static_cast<size_t>(it - node_to_cols_.begin()) < label_coords_.size());
+        ret_val.second = &label_coords_[it - node_to_cols_.begin()];
+    }
+
+    return ret_val;
+}
+
+} // namespace align
+} // namespace graph
+} // namespace mtg

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -1,0 +1,89 @@
+#ifndef __ANNOTATION_BUFFER_HPP__
+#define __ANNOTATION_BUFFER_HPP__
+
+#include "alignment.hpp"
+#include "graph/annotated_dbg.hpp"
+#include "annotation/int_matrix/base/int_matrix.hpp"
+#include "common/vector_set.hpp"
+#include "common/vector_map.hpp"
+#include "common/hashers/hash.hpp"
+
+namespace mtg {
+namespace graph {
+
+class CanonicalDBG;
+
+namespace align {
+
+// caches queried annotations to speed up next queries (labels with or w/o coordinates)
+class AnnotationBuffer {
+  public:
+    typedef AnnotatedDBG::Annotator Annotator;
+    typedef DeBruijnGraph::node_index node_index;
+    typedef Alignment::Tuple Tuple;
+    typedef Alignment::Columns Columns;
+    typedef Alignment::CoordinateSet CoordinateSet;
+
+    AnnotationBuffer(const DeBruijnGraph &graph, const Annotator &annotator);
+
+    void queue_path(std::vector<node_index>&& path) {
+        queued_paths_.push_back(std::move(path));
+    }
+
+    // fetch annotations for the queued nodes from the buffer and reset the buffer
+    void fetch_queued_annotations();
+
+    bool has_coordinates() const { return multi_int_; }
+
+    // Get the annotations and coordinates of a node if they have been fetched.
+    // The returned pointers are valid until next fetch_queued_annotations().
+    std::pair<const Columns*, const CoordinateSet*>
+    get_labels_and_coords(node_index node) const;
+
+    // get the labels of a node if they have been fetched
+    inline const Columns* get_labels(node_index node) const {
+        return get_labels_and_coords(node).first;
+    }
+
+    const Annotator& get_annotator() const { return annotator_; }
+
+    size_t num_nodes_buffered() const { return node_to_cols_.size(); }
+    size_t num_column_sets() const { return column_sets_.size(); }
+
+    // This method lets the caller push additional column sets to dictionary
+    // `column_sets_`. These column sets can later be fetched with `get_cached_column_set()`
+    template <typename... Args>
+    inline size_t cache_column_set(Args&&... args) {
+        auto it = column_sets_.emplace(std::forward<Args>(args)...).first;
+        assert(std::is_sorted(it->begin(), it->end()));
+        return it - column_sets_.begin();
+    }
+
+    // Fetch a label set given its index returned by `cache_column_set()`
+    inline const Columns& get_cached_column_set(size_t i) const {
+        assert(i < column_sets_.size());
+        return column_sets_.data()[i];
+    }
+
+  private:
+    const DeBruijnGraph &graph_;
+    const Annotator &annotator_;
+    const annot::matrix::MultiIntMatrix *multi_int_;
+    const CanonicalDBG *canonical_;
+
+    // keep a unique set of annotation rows
+    // the first element is the empty label set
+    VectorSet<Columns, utils::VectorHash> column_sets_;
+     // map node to index in |column_sets_|
+    VectorMap<node_index, size_t> node_to_cols_;
+    // coordinate sets for all nodes in |node_to_cols_| in the same order
+    std::vector<CoordinateSet> label_coords_;
+    // buffer of paths to later querying with fetch_queued_annotations()
+    std::vector<std::vector<node_index>> queued_paths_;
+};
+
+} // namespace align
+} // namespace graph
+} // namespace mtg
+
+#endif // __ANNOTATION_BUFFER_HPP__

--- a/metagraph/src/graph/alignment/dbg_aligner.hpp
+++ b/metagraph/src/graph/alignment/dbg_aligner.hpp
@@ -19,9 +19,7 @@ namespace align {
 
 class IDBGAligner {
   public:
-    typedef std::tuple<std::string /* header */,
-                       std::string /* seq */,
-                       bool /* orientation of seq */> Query;
+    typedef std::pair<std::string /* header */, std::string /* seq */> Query;
     typedef std::function<void(const std::string& /* header */,
                                AlignmentResults&& /* alignments */)> AlignmentCallback;
 
@@ -35,7 +33,7 @@ class IDBGAligner {
                              const AlignmentCallback &callback) const = 0;
 
     // Convenience method
-    AlignmentResults align(std::string_view query, bool is_reverse_complement = false) const;
+    AlignmentResults align(std::string_view query) const;
 };
 
 
@@ -61,8 +59,8 @@ class DBGAligner : public IDBGAligner {
     const DeBruijnGraph &graph_;
     DBGAlignerConfig config_;
 
-    typedef std::vector<std::tuple<std::shared_ptr<ISeeder>, std::vector<node_index>,
-                                   std::shared_ptr<ISeeder>, std::vector<node_index>>> BatchSeeders;
+    typedef std::vector<std::pair<std::shared_ptr<ISeeder>, std::shared_ptr<ISeeder>>> BatchSeeders;
+
     BatchSeeders
     virtual build_seeders(const std::vector<Query> &seq_batch,
                           const std::vector<AlignmentResults> &wrapped_seqs) const;

--- a/metagraph/tests/graph/test_aligner.cpp
+++ b/metagraph/tests/graph/test_aligner.cpp
@@ -348,7 +348,7 @@ TYPED_TEST(DBGAlignerTest, align_straight_forward_and_reverse_complement_batch) 
     auto config_fwd_and_rev = config;
 
     DBGAligner<> aligner(*graph, config_fwd_and_rev);
-    std::vector<IDBGAligner::Query> query_batch { { "", query, true } };
+    std::vector<IDBGAligner::Query> query_batch { { "", query } };
     aligner.align_batch(query_batch, [&](std::string_view, auto&& paths) {
         ASSERT_EQ(1ull, paths.size());
         auto path = paths[0];
@@ -365,7 +365,7 @@ TYPED_TEST(DBGAlignerTest, align_straight_forward_and_reverse_complement_batch) 
         EXPECT_TRUE(path.is_valid(*graph, &config));
     });
 
-    auto paths = aligner.align(query, true);
+    auto paths = aligner.align(query);
     auto path = paths[0];
     EXPECT_EQ(query.size() - k + 1, path.size());
     EXPECT_EQ(reference, path.get_sequence());


### PR DESCRIPTION
- Added a `Seed` class that assumes that the stored path spells the query view. Most of the seeders now return a vector of `Seed`s
- Improved cache efficiency of extension DP steps
- Moved `AnnotationBuffer` to its own header