### PR TITLE
Fix chaining corner cases

### DIFF
--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
@@ -237,7 +237,7 @@ RowDiff<BaseMatrix>::get_rows(const std::vector<Row> &row_ids) const {
     node_to_rd = VectorMap<Row, size_t>();
 
     std::vector<SetBitPositions> rd_rows = diffs_.get_rows(rd_ids);
-    common::logger->trace("Queried batch of {} diffed rows", rd_ids.size());
+    DEBUG_LOG("Queried batch of {} diffed rows", rd_ids.size());
 
     rd_ids = std::vector<Row>();
 
@@ -259,7 +259,7 @@ RowDiff<BaseMatrix>::get_rows(const std::vector<Row> &row_ids) const {
             }
         }
     }
-    common::logger->trace("Reconstructed annotations for {} rows", rows.size());
+    DEBUG_LOG("Reconstructed annotations for {} rows", rows.size());
     assert(times_traversed == std::vector<size_t>(rd_rows.size(), 0));
 
     return rows;

--- a/metagraph/src/graph/alignment/aligner_chainer.hpp
+++ b/metagraph/src/graph/alignment/aligner_chainer.hpp
@@ -8,7 +8,7 @@ namespace mtg {
 namespace graph {
 namespace align {
 
-typedef std::vector<Alignment> Chain;
+typedef std::vector<std::pair<Alignment, int64_t>> Chain;
 typedef Alignment::score_t score_t;
 
 // Given forward and reverse-complement seeds, construct and call chains of seeds

--- a/metagraph/src/graph/alignment/aligner_labeled.hpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.hpp
@@ -145,6 +145,7 @@ class LabeledExtender : public DefaultColumnExtender {
     virtual void pop(size_t i) override final {
         assert(i < node_labels_.size());
         DefaultColumnExtender::pop(i);
+        last_flushed_table_i_ = std::min(i, last_flushed_table_i_);
         node_labels_.erase(node_labels_.begin() + i);
     }
 


### PR DESCRIPTION
- Two adjacent seeds in a chain now have a well-defined coordinate distance
- Better handle cases where seeds in a chain cannot connect via extension
- Support alignment of queries with non-alphabet characters
- Detect overflows when handling the xdrop parameter
- Correctly handle label changes in unitigs with more than two nodes

Broken off from #392, overrides #393