### PR TITLE
Optimize coordinate handling during alignment

### DIFF
--- a/metagraph/src/annotation/int_matrix/row_diff/tuple_row_diff.hpp
+++ b/metagraph/src/annotation/int_matrix/row_diff/tuple_row_diff.hpp
@@ -38,8 +38,6 @@ class TupleRowDiff : public binmat::IRowDiff, public MultiIntMatrix {
     std::vector<Row> get_column(Column j) const override;
     RowTuples get_row_tuples(Row i) const override;
     std::vector<RowTuples> get_row_tuples(const std::vector<Row> &rows) const override;
-    RowValues get_row_values(Row row) const override;
-    std::vector<RowValues> get_row_values(const std::vector<Row> &rows) const override;
 
     uint64_t num_columns() const override { return diffs_.num_columns(); }
     uint64_t num_relations() const override { return diffs_.num_relations(); }
@@ -128,54 +126,6 @@ TupleRowDiff<BaseMatrix>::get_row_tuples(const std::vector<Row> &row_ids) const 
         }
         assert(std::all_of(result.begin(), result.end(),
                            [](auto &p) { return p.second.size(); }));
-    }
-
-    return rows;
-}
-
-template <class BaseMatrix>
-MultiIntMatrix::RowValues TupleRowDiff<BaseMatrix>::get_row_values(Row row) const {
-    return get_row_values(std::vector<Row>{ row })[0];
-}
-
-template <class BaseMatrix>
-std::vector<MultiIntMatrix::RowValues>
-TupleRowDiff<BaseMatrix>::get_row_values(const std::vector<Row> &row_ids) const {
-    assert(graph_ && "graph must be loaded");
-    assert(anchor_.size() == diffs_.num_rows() && "anchors must be loaded");
-    assert(!fork_succ_.size() || fork_succ_.size() == graph_->get_boss().get_last().size());
-
-    // get row-diff paths
-    auto [rd_ids, rd_paths_trunc] = get_rd_ids(row_ids);
-
-    std::vector<RowTuples> rd_rows = diffs_.get_row_tuples(rd_ids);
-    for (auto &row : rd_rows) {
-        decode_diffs(&row);
-    }
-
-    rd_ids = std::vector<Row>();
-
-    // reconstruct annotation rows from row-diff
-    std::vector<RowValues> rows(row_ids.size());
-
-    for (size_t i = 0; i < row_ids.size(); ++i) {
-        RowTuples result;
-
-        auto it = rd_paths_trunc[i].rbegin();
-        std::sort(rd_rows[*it].begin(), rd_rows[*it].end());
-        result = rd_rows[*it];
-        // propagate back and reconstruct full annotations for predecessors
-        for (++it ; it != rd_paths_trunc[i].rend(); ++it) {
-            std::sort(rd_rows[*it].begin(), rd_rows[*it].end());
-            add_diff(rd_rows[*it], &result);
-            // replace diff row with full reconstructed annotation
-            rd_rows[*it] = result;
-        }
-        assert(std::all_of(result.begin(), result.end(),
-                           [](auto &p) { return p.second.size(); }));
-        rows[i].reserve(result.size());
-        std::transform(result.begin(), result.end(), std::back_inserter(rows[i]),
-                       [&](const auto &p) { return std::make_pair(p.first, p.second.size()); });
     }
 
     return rows;

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -35,6 +35,7 @@ DBGAlignerConfig initialize_aligner_config(const Config &config) {
         .min_seed_length = config.alignment_min_seed_length,
         .max_seed_length = config.alignment_max_seed_length,
         .max_num_seeds_per_locus = config.alignment_max_num_seeds_per_locus,
+        .row_batch_size = config.query_batch_size_in_bytes,
         .min_path_score = config.alignment_min_path_score,
         .xdrop = config.alignment_xdrop,
         .min_exact_match = config.alignment_min_exact_match,

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -1010,7 +1010,7 @@ if (advanced) {
             fprintf(stderr, "\t   --query-presence \t\ttest sequences for presence, report as 0 or 1 [off]\n");
             fprintf(stderr, "\t   --filter-present \t\treport only present input sequences as FASTA [off]\n");
 if (advanced) {
-            fprintf(stderr, "\t   --batch-size \t\tquery batch size (number of base pairs) [100000000]\n");
+            fprintf(stderr, "\t   --batch-size \t\tquery batch size (number of base pairs and number of rows per annotator query) [100000000]\n");
 }
             fprintf(stderr, "\n");
             fprintf(stderr, "Available options for alignment:\n");

--- a/metagraph/src/graph/alignment/aligner_chainer.hpp
+++ b/metagraph/src/graph/alignment/aligner_chainer.hpp
@@ -8,12 +8,15 @@ namespace mtg {
 namespace graph {
 namespace align {
 
+class IDBGAligner;
+
 typedef std::vector<std::pair<Alignment, int64_t>> Chain;
 typedef Alignment::score_t score_t;
 
 // Given forward and reverse-complement seeds, construct and call chains of seeds
 std::pair<size_t, size_t>
-call_seed_chains_both_strands(std::string_view forward,
+call_seed_chains_both_strands(const IDBGAligner &aligner,
+                              std::string_view forward,
                               std::string_view reverse,
                               const DBGAlignerConfig &config,
                               std::vector<Seed>&& fwd_seeds,

--- a/metagraph/src/graph/alignment/aligner_chainer.hpp
+++ b/metagraph/src/graph/alignment/aligner_chainer.hpp
@@ -15,7 +15,6 @@ typedef Alignment::score_t score_t;
 std::pair<size_t, size_t>
 call_seed_chains_both_strands(std::string_view forward,
                               std::string_view reverse,
-                              size_t node_overlap,
                               const DBGAlignerConfig &config,
                               std::vector<Seed>&& fwd_seeds,
                               std::vector<Seed>&& bwd_seeds,

--- a/metagraph/src/graph/alignment/aligner_config.hpp
+++ b/metagraph/src/graph/alignment/aligner_config.hpp
@@ -24,6 +24,7 @@ struct DBGAlignerConfig {
     size_t min_seed_length = 0;
     size_t max_seed_length = 0;
     size_t max_num_seeds_per_locus = std::numeric_limits<size_t>::max();
+    size_t row_batch_size = std::numeric_limits<size_t>::max();
 
     // Lowest possible score. 100 is added to prevent underflow during operations.
     // For this to work, all penalties should be less than 100.

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -784,7 +784,7 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
                                      std::back_inserter(next_seed.label_coordinates));
                 assert(dummy == next_seed.label_columns);
                 size_t num_coords = 0;
-                for (const auto &c : seed.label_coordinates) {
+                for (const auto &c : next_seed.label_coordinates) {
                     num_coords += c.size();
                     if (num_coords >= this->config_.max_num_seeds_per_locus)
                         break;

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -707,11 +707,12 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
 
     if (max_seed_length_ > this->config_.max_seed_length) {
         // merge seeds
+        size_t row_batch_size = annotation_buffer_.get_batch_size();
         for (size_t j = 0; j < seeds.size(); ++j) {
             Seed &seed = seeds[j];
-            if (annotation_buffer_.has_coordinates() && !(j % 100)) {
+            if (annotation_buffer_.has_coordinates() && !(j % row_batch_size)) {
                 std::vector<node_index> nodes;
-                for (size_t k = j; k < std::min(j + 100, seeds.size()); ++k) {
+                for (size_t k = j; k < std::min(j + row_batch_size, seeds.size()); ++k) {
                     if (seeds[k].size())
                         nodes.emplace_back(seeds[k].get_nodes()[0]);
                 }

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -731,6 +731,14 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
                                      std::back_inserter(dummy),
                                      std::back_inserter(seed.label_coordinates));
                 assert(dummy == seed.label_columns);
+                size_t num_coords = 0;
+                for (const auto &c : seed.label_coordinates) {
+                    num_coords += c.size();
+                    if (num_coords >= this->config_.max_num_seeds_per_locus)
+                        break;
+                }
+                if (num_coords >= this->config_.max_num_seeds_per_locus)
+                    seed = Seed();
             }
         }
 
@@ -775,6 +783,16 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
                                      std::back_inserter(dummy),
                                      std::back_inserter(next_seed.label_coordinates));
                 assert(dummy == next_seed.label_columns);
+                size_t num_coords = 0;
+                for (const auto &c : seed.label_coordinates) {
+                    num_coords += c.size();
+                    if (num_coords >= this->config_.max_num_seeds_per_locus)
+                        break;
+                }
+                if (num_coords >= this->config_.max_num_seeds_per_locus) {
+                    next_seed = Seed();
+                    continue;
+                }
             }
 
             // we want seed to have a subset of the coordinates in next_seed

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -709,7 +709,17 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
 
     if (max_seed_length_ > this->config_.max_seed_length) {
         // merge seeds
-        for (Seed &seed : seeds) {
+        for (size_t j = 0; j < seeds.size(); ++j) {
+            Seed &seed = seeds[j];
+            if (annotation_buffer_.has_coordinates() && !(j % 100)) {
+                std::vector<node_index> nodes;
+                for (size_t k = j; k < std::min(j + 100, seeds.size()); ++k) {
+                    if (seeds[k].size())
+                        nodes.emplace_back(seeds[k].get_nodes()[0]);
+                }
+                annotation_buffer_.prefetch_coords(nodes);
+            }
+
             if (seed.empty() || !seed.get_end_clipping() || !seed.label_encoder)
                 continue;
 

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -251,6 +251,12 @@ void LabeledExtender
         return;
     }
 
+    std::vector<node_index> outnodes(outgoing.size());
+    for (const auto &[next, c, score] : outgoing) {
+        outnodes.push_back(next);
+    }
+    annotation_buffer_.prefetch_coords(outnodes);
+
     // check label and coordinate consistency
     // use the seed as the basis for labels and coordinates
     assert(seed_->label_coordinates.size());
@@ -263,6 +269,7 @@ void LabeledExtender
         std::shared_ptr<const CoordinateSet> base_coords {
             std::shared_ptr<const CoordinateSet>{}, &base_coords_
         };
+
         auto [next_labels, next_coords]
             = annotation_buffer_.get_labels_and_coords(next, false);
 

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -738,8 +738,6 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
             continue;
         }
 
-        continue;
-
         node_index next_node = this->graph_.traverse(
             seed.get_nodes().back(),
             seed.get_query_view().data()[seed.get_query_view().size()]
@@ -756,8 +754,9 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
             auto &next_seed = seeds[j];
             if (next_seed.empty() || !next_seed.label_encoder
                     || next_seed.label_columns != seed.label_columns
-                    || seed.get_query_view().data() + seed.get_query_view().size() - this->graph_.get_k() + 1
-                        != next_seed.get_query_view().data() - next_seed.get_offset()) {
+                    || seed.get_query_view().data() + seed.get_query_view().size()
+                        - this->graph_.get_k() + 1
+                            != next_seed.get_query_view().data() - next_seed.get_offset()) {
                 continue;
             }
 

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -351,7 +351,7 @@ void LabeledExtender::call_alignments(score_t end_score,
     alignment.label_encoder = &annotation_buffer_.get_annotator().get_label_encoder();
 
     auto [base_labels, base_coords]
-        = annotation_buffer_.get_labels_and_coords(alignment.get_nodes().front(), false);
+        = annotation_buffer_.get_labels_and_coords(alignment.get_nodes().front(), clipping);
     assert(base_labels);
     assert(base_labels->size());
 

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -643,9 +643,12 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
             if (max_seed_length_ > this->config_.max_seed_length)
                 node_to_seeds[node].emplace_back(j);
 
-            assert(annotation_buffer_.get_labels(node));
+            auto [labels, coords] = annotation_buffer_.get_labels_and_coords(node);
+            assert(labels);
+            if (coords && coords->empty())
+                continue;
 
-            for (uint64_t label : *annotation_buffer_.get_labels(node)) {
+            for (uint64_t label : *labels) {
                 auto &indicator = label_mapper[label];
                 if (indicator.empty())
                     indicator = sdsl::bit_vector(query_size, false);

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -229,7 +229,7 @@ void LabeledExtender
     const auto &columns = annotation_buffer_.get_cached_column_set(node_labels_[table_i]);
 
     // no coordinates are present in the annotation
-    if (!annotation_buffer_.get_labels_and_coords(node).second) {
+    if (!annotation_buffer_.has_coordinates()) {
         // label consistency (weaker than coordinate consistency):
         // checks if there is at least one label shared between adjacent nodes
         for (const auto &[next, c, score] : outgoing) {
@@ -737,6 +737,8 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
                 || max_seed_length_ <= this->config_.max_seed_length) {
             continue;
         }
+
+        continue;
 
         node_index next_node = this->graph_.traverse(
             seed.get_nodes().back(),

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -463,7 +463,7 @@ LabeledAligner<Seeder, Extender, AlignmentCompare>
                  const DBGAlignerConfig &config,
                  const Annotator &annotator)
       : DBGAligner<Seeder, Extender, AlignmentCompare>(graph, config),
-        annotation_buffer_(graph, annotator),
+        annotation_buffer_(graph, annotator, config.row_batch_size),
         max_seed_length_(config.max_seed_length) {
     // do not use a global xdrop cutoff since we need separate cutoffs for each label
     if (annotation_buffer_.has_coordinates())

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -803,6 +803,8 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
 
             if (removed_labels == seed.label_coordinates.size())
                 seed.label_encoder = nullptr;
+        } else if (annotation_buffer_.has_coordinates() && seed.label_columns.size()) {
+            seed.label_encoder = nullptr;
         }
     }
 

--- a/metagraph/src/graph/alignment/aligner_labeled.cpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.cpp
@@ -709,13 +709,16 @@ size_t LabeledAligner<Seeder, Extender, AlignmentCompare>
     size_t row_batch_size = annotation_buffer_.get_batch_size();
     for (size_t j = 0; j < seeds.size(); ++j) {
         Seed &seed = seeds[j];
-        if (annotation_buffer_.has_coordinates() && !(j % row_batch_size)) {
-            std::vector<node_index> nodes;
-            for (size_t k = j; k < std::min(j + row_batch_size, seeds.size()); ++k) {
-                if (seeds[k].size())
-                    nodes.emplace_back(seeds[k].get_nodes()[0]);
+        if (annotation_buffer_.has_coordinates()) {
+            if (!(j % row_batch_size)) {
+                std::vector<node_index> nodes;
+                for (size_t k = j; k < std::min(j + row_batch_size, seeds.size()); ++k) {
+                    if (seeds[k].size())
+                        nodes.emplace_back(seeds[k].get_nodes()[0]);
+                }
+                annotation_buffer_.prefetch_coords(nodes);
             }
-            annotation_buffer_.prefetch_coords(nodes);
+
             if (seed.label_coordinates.size() != seed.label_columns.size()) {
                 auto [fetch_labels, fetch_coords]
                     = annotation_buffer_.get_labels_and_coords(seed.get_nodes()[0], false);

--- a/metagraph/src/graph/alignment/aligner_labeled.hpp
+++ b/metagraph/src/graph/alignment/aligner_labeled.hpp
@@ -114,11 +114,16 @@ class LabeledExtender : public DefaultColumnExtender {
     Columns label_diff_;
 };
 
+class ILabeledAligner {
+  public:
+    virtual AnnotationBuffer& get_annotation_buffer() const = 0;
+};
+
 
 template <class Seeder = SuffixSeeder<UniMEMSeeder>,
           class Extender = LabeledExtender,
           class AlignmentCompare = LocalAlignmentLess>
-class LabeledAligner : public DBGAligner<Seeder, Extender, AlignmentCompare> {
+class LabeledAligner : public DBGAligner<Seeder, Extender, AlignmentCompare>, public ILabeledAligner {
     friend class LabeledExtender;
   public:
     typedef AnnotatedDBG::Annotator Annotator;
@@ -129,6 +134,14 @@ class LabeledAligner : public DBGAligner<Seeder, Extender, AlignmentCompare> {
 
     virtual ~LabeledAligner();
 
+    virtual AnnotationBuffer& get_annotation_buffer() const override final {
+        return annotation_buffer_;
+    }
+
+    virtual bool has_coordinates() const override final {
+        return annotation_buffer_.has_coordinates();
+    }
+
   private:
     mutable AnnotationBuffer annotation_buffer_;
     size_t max_seed_length_;
@@ -136,7 +149,7 @@ class LabeledAligner : public DBGAligner<Seeder, Extender, AlignmentCompare> {
     typedef typename DBGAligner<Seeder, Extender, AlignmentCompare>::BatchSeeders BatchSeeders;
     BatchSeeders
     virtual build_seeders(const std::vector<IDBGAligner::Query> &seq_batch,
-                          const std::vector<AlignmentResults> &wrapped_seqs) const override;
+                          const std::vector<AlignmentResults> &wrapped_seqs) const override final;
 
     // helper for the build_seeders method
     size_t filter_seeds(std::vector<Seed> &seeds) const;

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -15,29 +15,38 @@ namespace align {
 
 using mtg::common::logger;
 
-std::string Alignment::format_coords() const {
-    if (!label_coordinates.size())
+template <class Matching>
+std::string format_coords(const Matching &a) {
+    if (!a.label_coordinates.size())
         return "";
 
-    assert(label_columns.size());
-    assert(label_coordinates.size() == label_columns.size());
+    assert(a.label_columns.size());
+    assert(a.label_coordinates.size() == a.label_columns.size());
 
     std::vector<std::string> decoded_labels;
-    decoded_labels.reserve(label_columns.size());
+    decoded_labels.reserve(a.label_columns.size());
 
-    for (size_t i = 0; i < label_columns.size(); ++i) {
-        decoded_labels.emplace_back(label_encoder
-            ? label_encoder->decode(label_columns[i])
-            : std::to_string(label_columns[i])
+    for (size_t i = 0; i < a.label_columns.size(); ++i) {
+        decoded_labels.emplace_back(a.label_encoder
+            ? a.label_encoder->decode(a.label_columns[i])
+            : std::to_string(a.label_columns[i])
         );
-        for (uint64_t coord : label_coordinates[i]) {
+        for (uint64_t coord : a.label_coordinates[i]) {
             // alignment coordinates are 1-based inclusive ranges
             decoded_labels.back()
-                += fmt::format(":{}-{}", coord + 1, coord + sequence_.size());
+                += fmt::format(":{}-{}", coord + 1, coord + a.get_sequence().size());
         }
     }
 
     return fmt::format("{}", fmt::join(decoded_labels, ";"));
+}
+
+std::string Seed::format_coords() const {
+    return ::mtg::graph::align::format_coords(*this);
+}
+
+std::string Alignment::format_coords() const {
+    return ::mtg::graph::align::format_coords(*this);
 }
 
 bool Alignment::append(Alignment&& other) {

--- a/metagraph/src/graph/alignment/alignment.hpp
+++ b/metagraph/src/graph/alignment/alignment.hpp
@@ -86,6 +86,8 @@ class Seed {
     // (i.e., the first node's coordinate + the alignment offset)
     CoordinateSet label_coordinates;
 
+    std::string format_coords() const;
+
   private:
     std::string_view query_view_;
     std::vector<node_index> nodes_;
@@ -276,6 +278,10 @@ class Alignment {
     Cigar cigar_;
 };
 
+inline std::ostream& operator<<(std::ostream &out, const Seed &a) {
+    return out << fmt::format("{}", a);
+}
+
 inline std::ostream& operator<<(std::ostream &out, const Alignment &a) {
     return out << fmt::format("{}", a);
 }
@@ -373,6 +379,47 @@ template <> struct formatter<mtg::graph::align::Alignment> {
                   a.get_score(),
                   a.get_cigar().get_num_matches(),
                   a.get_cigar().to_string(),
+                  a.get_offset());
+
+        const auto &label_columns = a.label_columns;
+        const auto &label_coordinates = a.label_coordinates;
+
+        if (label_coordinates.size()) {
+            format_to(ctx.out(), "\t{}", a.format_coords());
+        } else if (label_columns.size()) {
+            if (a.label_encoder) {
+                std::vector<std::string> decoded_labels;
+                decoded_labels.reserve(label_columns.size());
+                for (size_t i = 0; i < label_columns.size(); ++i) {
+                    decoded_labels.emplace_back(a.label_encoder->decode(label_columns[i]));
+                }
+
+                format_to(ctx.out(), "\t{}", fmt::join(decoded_labels, ";"));
+            } else {
+                format_to(ctx.out(), "\t{}", fmt::join(label_columns, ";"));
+            }
+        }
+
+        return ctx.out();
+    }
+};
+
+template <> struct formatter<mtg::graph::align::Seed> {
+    // Parses format specifications of the form ['f' | 'e'].
+    constexpr auto parse(format_parse_context& ctx) -> decltype(ctx.begin()) {
+        // we have only one format, so nothing to parse
+        return ctx.end();
+    }
+
+    template <typename FormatContext>
+    auto format(const mtg::graph::align::Seed &a, FormatContext &ctx) -> decltype(ctx.out()) {
+        format_to(ctx.out(), "{}\t{}\t{}\t{}{}={}\t{}",
+                  a.get_orientation() ? "-" : "+",
+                  a.get_sequence(),
+                  a.get_sequence().size(),
+                  a.get_clipping() ? std::to_string(a.get_clipping()) + "S" : "",
+                  a.get_sequence().size(),
+                  a.get_end_clipping() ? std::to_string(a.get_end_clipping()) + "S" : "",
                   a.get_offset());
 
         const auto &label_columns = a.label_columns;

--- a/metagraph/src/graph/alignment/annotation_buffer.cpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.cpp
@@ -62,15 +62,14 @@ void AnnotationBuffer::fetch_queued_annotations() {
 
             size_t label_i = cache_column_set(std::move(labels));
             node_index base_node = AnnotatedDBG::anno_to_graph_index(*row_it);
-            if (graph_.get_mode() == DeBruijnGraph::BASIC) {
-                assert(base_node == *node_it);
-                node_to_cols_[*node_it] = label_i;
-            } else if (canonical_) {
+            if (canonical_) {
                 node_to_cols_[base_node] = label_i;
             } else {
                 node_to_cols_[*node_it] = label_i;
-                if (base_node != *node_it)
+                if (base_node != *node_it) {
+                    assert(graph_.get_mode() != DeBruijnGraph::BASIC);
                     node_to_cols_.try_emplace(base_node, label_i);
+                }
             }
             ++node_it;
             ++row_it;

--- a/metagraph/src/graph/alignment/annotation_buffer.cpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.cpp
@@ -21,13 +21,13 @@ static constexpr size_t nannot = std::numeric_limits<size_t>::max();
 AnnotationBuffer::AnnotationBuffer(const DeBruijnGraph &graph,
                                    const Annotator &annotator,
                                    size_t row_batch_size,
-                                   size_t max_coords_per_node)
+                                   size_t max_coords_buffered)
       : graph_(graph),
         annotator_(annotator),
         multi_int_(dynamic_cast<const annot::matrix::MultiIntMatrix*>(&annotator_.get_matrix())),
         canonical_(dynamic_cast<const CanonicalDBG*>(&graph_)),
         column_sets_({ {} }),
-        label_coords_cache_(max_coords_per_node),
+        label_coords_cache_(max_coords_buffered),
         row_batch_size_(row_batch_size) {
     if (multi_int_ && graph_.get_mode() != DeBruijnGraph::BASIC) {
         multi_int_ = nullptr;

--- a/metagraph/src/graph/alignment/annotation_buffer.cpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.cpp
@@ -155,6 +155,11 @@ void AnnotationBuffer::fetch_queued_annotations() {
                 if (node_to_cols_.try_emplace(base_path[i], nannot).second) {
                     queued_rows.push_back(row);
                     queued_nodes.push_back(base_path[i]);
+                    if (queued_rows.size() >= row_batch_size_) {
+                        fetch_row_batch(std::move(queued_nodes), std::move(queued_rows));
+                        queued_nodes = decltype(queued_nodes){};
+                        queued_rows = decltype(queued_rows){};
+                    }
                 }
 
                 continue;

--- a/metagraph/src/graph/alignment/annotation_buffer.cpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.cpp
@@ -240,7 +240,9 @@ auto AnnotationBuffer::get_labels_and_coords(node_index node, bool skip_unfetche
             return ret_val;
         }
 
-        if (auto fetch = label_coords_cache_.TryGet(it - node_to_cols_.begin())) {
+        size_t index = it - node_to_cols_.begin();
+
+        if (auto fetch = label_coords_cache_.TryGet(index)) {
             ret_val.second = std::make_shared<const CoordinateSet>(std::move(*fetch));
         } else if (!skip_unfetched) {
             node_index base_node = node;
@@ -259,7 +261,7 @@ auto AnnotationBuffer::get_labels_and_coords(node_index node, bool skip_unfetche
                 assert(column == (*ret_val.first)[i]);
                 coord_set.emplace_back(coords.begin(), coords.end());
             }
-            label_coords_cache_.Put(it - node_to_cols_.begin(), coord_set);
+            label_coords_cache_.Put(index, coord_set);
             ret_val.second = std::make_shared<const CoordinateSet>(std::move(coord_set));
         }
     }

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -30,7 +30,7 @@ class AnnotationBuffer {
     AnnotationBuffer(const DeBruijnGraph &graph,
                      const Annotator &annotator,
                      size_t row_batch_size = std::numeric_limits<size_t>::max(),
-                     size_t max_coords_per_node = std::numeric_limits<size_t>::max());
+                     size_t max_coords_buffered = std::numeric_limits<size_t>::max());
 
     void queue_path(std::vector<node_index>&& path) {
         queued_paths_.push_back(std::move(path));

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -73,6 +73,8 @@ class AnnotationBuffer {
         return column_sets_.data()[i];
     }
 
+    size_t get_batch_size() const { return row_batch_size_; }
+
   private:
     const DeBruijnGraph &graph_;
     const Annotator &annotator_;

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -24,7 +24,9 @@ class AnnotationBuffer {
     typedef Alignment::Columns Columns;
     typedef Alignment::CoordinateSet CoordinateSet;
 
-    AnnotationBuffer(const DeBruijnGraph &graph, const Annotator &annotator);
+    AnnotationBuffer(const DeBruijnGraph &graph,
+                     const Annotator &annotator,
+                     size_t row_batch_size = std::numeric_limits<size_t>::max());
 
     void queue_path(std::vector<node_index>&& path) {
         queued_paths_.push_back(std::move(path));
@@ -80,6 +82,8 @@ class AnnotationBuffer {
     std::vector<CoordinateSet> label_coords_;
     // buffer of paths to later querying with fetch_queued_annotations()
     std::vector<std::vector<node_index>> queued_paths_;
+
+    size_t row_batch_size_;
 };
 
 } // namespace align

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -46,6 +46,8 @@ class AnnotationBuffer {
     std::pair<const Columns*, std::shared_ptr<const CoordinateSet>>
     get_labels_and_coords(node_index node, bool skip_unfetched = true) const;
 
+    void prefetch_coords(const std::vector<node_index> &nodes) const;
+
     // get the labels of a node if they have been fetched
     inline const Columns* get_labels(node_index node) const {
         return get_labels_and_coords(node).first;

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -26,7 +26,8 @@ class AnnotationBuffer {
 
     AnnotationBuffer(const DeBruijnGraph &graph,
                      const Annotator &annotator,
-                     size_t row_batch_size = std::numeric_limits<size_t>::max());
+                     size_t row_batch_size = std::numeric_limits<size_t>::max(),
+                     size_t max_coords_per_node = std::numeric_limits<size_t>::max());
 
     void queue_path(std::vector<node_index>&& path) {
         queued_paths_.push_back(std::move(path));
@@ -84,6 +85,7 @@ class AnnotationBuffer {
     std::vector<std::vector<node_index>> queued_paths_;
 
     size_t row_batch_size_;
+    size_t max_coords_per_node_;
 };
 
 } // namespace align

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -40,8 +40,8 @@ class AnnotationBuffer {
 
     // Get the annotations and coordinates of a node if they have been fetched.
     // The returned pointers are valid until next fetch_queued_annotations().
-    std::pair<const Columns*, const CoordinateSet*>
-    get_labels_and_coords(node_index node) const;
+    std::pair<const Columns*, std::shared_ptr<const CoordinateSet>>
+    get_labels_and_coords(node_index node, bool skip_unfetched = true) const;
 
     // get the labels of a node if they have been fetched
     inline const Columns* get_labels(node_index node) const {

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -1,6 +1,9 @@
 #ifndef __ANNOTATION_BUFFER_HPP__
 #define __ANNOTATION_BUFFER_HPP__
 
+#include <cache.hpp>
+#include <lru_cache_policy.hpp>
+
 #include "alignment.hpp"
 #include "graph/annotated_dbg.hpp"
 #include "annotation/int_matrix/base/int_matrix.hpp"
@@ -79,13 +82,13 @@ class AnnotationBuffer {
     VectorSet<Columns, utils::VectorHash> column_sets_;
      // map node to index in |column_sets_|
     VectorMap<node_index, size_t> node_to_cols_;
-    // coordinate sets for all nodes in |node_to_cols_| in the same order
-    std::vector<CoordinateSet> label_coords_;
+    // cache the coordinate sets for the nodes in |node_to_cols_|
+    mutable caches::fixed_sized_cache<size_t, CoordinateSet,
+                                      caches::LRUCachePolicy<node_index>> label_coords_cache_;
     // buffer of paths to later querying with fetch_queued_annotations()
     std::vector<std::vector<node_index>> queued_paths_;
 
     size_t row_batch_size_;
-    size_t max_coords_per_node_;
 };
 
 } // namespace align

--- a/metagraph/src/graph/alignment/annotation_buffer.hpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.hpp
@@ -46,6 +46,11 @@ class AnnotationBuffer {
     std::pair<const Columns*, std::shared_ptr<const CoordinateSet>>
     get_labels_and_coords(node_index node, bool skip_unfetched = true) const;
 
+    std::shared_ptr<const CoordinateSet>
+    get_coords(node_index node,
+               bool skip_unfetched = true,
+               const Columns *label_subset_begin = nullptr) const;
+
     void prefetch_coords(const std::vector<node_index> &nodes) const;
 
     // get the labels of a node if they have been fetched

--- a/metagraph/src/graph/alignment/dbg_aligner.cpp
+++ b/metagraph/src/graph/alignment/dbg_aligner.cpp
@@ -540,6 +540,12 @@ DBGAligner<Seeder, Extender, AlignmentCompare>
                 forward, reverse, graph_.get_k() - 1, config_,
                 std::move(fwd_seeds), std::move(bwd_seeds),
                 [&](Chain&& chain, score_t score) {
+#ifndef NDEBUG
+                    DEBUG_LOG("Chain: score: {}", score);
+                    for (const auto &[chain, dist] : chain) {
+                        DEBUG_LOG("\t{}\tdist: {}", chain, dist);
+                    }
+#endif
                     std::ignore = score;
                     bool any_added = false;
                     extend_chain(chain[0].first.get_orientation() ? reverse : forward,

--- a/metagraph/src/graph/alignment/dbg_aligner.cpp
+++ b/metagraph/src/graph/alignment/dbg_aligner.cpp
@@ -539,13 +539,10 @@ DBGAligner<Seeder, Extender, AlignmentCompare>
             std::tie(num_seeds, this_num_explored) = call_seed_chains_both_strands(
                 forward, reverse, config_, std::move(fwd_seeds), std::move(bwd_seeds),
                 [&](Chain&& chain, score_t score) {
-#ifndef NDEBUG
-                    DEBUG_LOG("Chain: score: {}", score);
+                    logger->trace("Chain: score: {}", score);
                     for (const auto &[chain, dist] : chain) {
-                        DEBUG_LOG("\t{}\tdist: {}", chain, dist);
+                        logger->trace("\t{}\tdist: {}", chain, dist);
                     }
-#endif
-                    std::ignore = score;
                     bool any_added = false;
                     extend_chain(chain[0].first.get_orientation() ? reverse : forward,
                                  chain[0].first.get_orientation() ? forward : reverse,

--- a/metagraph/src/graph/alignment/dbg_aligner.cpp
+++ b/metagraph/src/graph/alignment/dbg_aligner.cpp
@@ -537,8 +537,7 @@ DBGAligner<Seeder, Extender, AlignmentCompare>
             tsl::hopscotch_set<Alignment::Column> finished_columns;
             size_t this_num_explored;
             std::tie(num_seeds, this_num_explored) = call_seed_chains_both_strands(
-                forward, reverse, graph_.get_k() - 1, config_,
-                std::move(fwd_seeds), std::move(bwd_seeds),
+                forward, reverse, config_, std::move(fwd_seeds), std::move(bwd_seeds),
                 [&](Chain&& chain, score_t score) {
 #ifndef NDEBUG
                     DEBUG_LOG("Chain: score: {}", score);

--- a/metagraph/src/graph/alignment/dbg_aligner.hpp
+++ b/metagraph/src/graph/alignment/dbg_aligner.hpp
@@ -34,6 +34,8 @@ class IDBGAligner {
 
     // Convenience method
     AlignmentResults align(std::string_view query) const;
+
+    virtual bool has_coordinates() const = 0;
 };
 
 
@@ -52,6 +54,8 @@ class DBGAligner : public IDBGAligner {
     const DeBruijnGraph& get_graph() const override { return graph_; }
     const DBGAlignerConfig& get_config() const override { return config_; }
 
+    virtual bool has_coordinates() const override { return false; }
+
   protected:
     typedef typename Seeder::node_index node_index;
     typedef Alignment::score_t score_t;
@@ -61,9 +65,8 @@ class DBGAligner : public IDBGAligner {
 
     typedef std::vector<std::pair<std::shared_ptr<ISeeder>, std::shared_ptr<ISeeder>>> BatchSeeders;
 
-    BatchSeeders
-    virtual build_seeders(const std::vector<Query> &seq_batch,
-                          const std::vector<AlignmentResults> &wrapped_seqs) const;
+    virtual BatchSeeders build_seeders(const std::vector<Query> &seq_batch,
+                                       const std::vector<AlignmentResults> &wrapped_seqs) const;
 
   private:
 // there are no reverse-complement for protein sequences


### PR DESCRIPTION
This can help prevent buffering a large number of annotation to RAM.

TODO:
- [x] Skip seeds that have too many coordinates
- [x] Only store coordinates in a cache. Fetch them when needed.
- [ ] When an element gets popped off the DP table, also pop its annotation from the buffer if the annotation is unique (later?)