### PR TITLE
compress node ranges index

### DIFF
--- a/metagraph/src/cli/build.cpp
+++ b/metagraph/src/cli/build.cpp
@@ -361,13 +361,15 @@ int build_graph(Config *config) {
             logger->warn("Node ranges for k-mer suffixes longer than {} cannot be indexed",
                          static_cast<int>(63 / log2(dbg_succ->get_boss().alph_size - 1)));
 
-        } else if (suffix_length) {
+        } else {
             logger->trace("Index all node ranges for suffixes of length {} in {:.2f} MB",
                           suffix_length,
                           std::pow(dbg_succ->get_boss().alph_size - 1, suffix_length)
                                 * 2. * sizeof(uint64_t) * 1e-6);
             timer.reset();
-            dbg_succ->get_boss().index_suffix_ranges(suffix_length);
+            dbg_succ->get_boss().index_suffix_ranges(suffix_length, get_num_threads());
+            logger->trace("Compressed node ranges to {:.2f} MB",
+                          dbg_succ->get_boss().get_suffix_ranges_index_size() / 8e6);
 
             logger->trace("Indexing of node ranges took {} sec", timer.elapsed());
         }
@@ -445,13 +447,15 @@ int concatenate_graph_chunks(Config *config) {
                 logger->warn("Node ranges for k-mer suffixes longer than {} cannot be indexed",
                              static_cast<int>(63 / log2(dbg_succ->get_boss().alph_size - 1)));
 
-            } else if (suffix_length) {
+            } else {
                 logger->trace("Index all node ranges for suffixes of length {} in {:.2f} MB",
                               suffix_length,
                               std::pow(dbg_succ->get_boss().alph_size - 1, suffix_length)
                                     * 2. * sizeof(uint64_t) * 1e-6);
                 timer.reset();
-                dbg_succ->get_boss().index_suffix_ranges(suffix_length);
+                dbg_succ->get_boss().index_suffix_ranges(suffix_length, get_num_threads());
+                logger->trace("Compressed node ranges to {:.2f} MB",
+                              dbg_succ->get_boss().get_suffix_ranges_index_size() / 8e6);
 
                 logger->trace("Indexing of node ranges took {} sec", timer.elapsed());
             }

--- a/metagraph/src/cli/build.cpp
+++ b/metagraph/src/cli/build.cpp
@@ -368,7 +368,7 @@ int build_graph(Config *config) {
                                 * 2. * sizeof(uint64_t) * 1e-6);
             timer.reset();
             dbg_succ->get_boss().index_suffix_ranges(suffix_length, get_num_threads());
-            logger->trace("Compressed node ranges to {:.2f} MB",
+            logger->trace("Compressed node ranges to approx. {:.2f} MB",
                           dbg_succ->get_boss().get_suffix_ranges_index_size() / 8e6);
 
             logger->trace("Indexing of node ranges took {} sec", timer.elapsed());
@@ -454,7 +454,7 @@ int concatenate_graph_chunks(Config *config) {
                                     * 2. * sizeof(uint64_t) * 1e-6);
                 timer.reset();
                 dbg_succ->get_boss().index_suffix_ranges(suffix_length, get_num_threads());
-                logger->trace("Compressed node ranges to {:.2f} MB",
+                logger->trace("Compressed node ranges to approx. {:.2f} MB",
                               dbg_succ->get_boss().get_suffix_ranges_index_size() / 8e6);
 
                 logger->trace("Indexing of node ranges took {} sec", timer.elapsed());

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -20,7 +20,7 @@ using mtg::graph::DeBruijnGraph;
 
 
 const size_t Config::kDefaultIndexSuffixLen
-    = 20 / std::log2(kmer::KmerExtractor2Bit().alphabet.size());
+    = 24 / std::log2(kmer::KmerExtractor2Bit().alphabet.size());
 
 void print_welcome_message() {
     fprintf(stderr, "#############################\n");

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -69,8 +69,8 @@ class Config {
     unsigned int k = 3;
 
     // Cache ranges of nodes in succinct graphs to search faster.
-    // For DNA4, index nodes for all possible suffixes of length 10.
-    // In general, the default value is: log_{|Sigma|}(2^20)
+    // For DNA4, index nodes for all possible suffixes of length 12.
+    // In general, the default value is: log_{|Sigma|}(2^24)
     static const size_t kDefaultIndexSuffixLen;
     unsigned int node_suffix_length = kDefaultIndexSuffixLen;
     unsigned int distance = 0;

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -70,7 +70,7 @@ class Config {
 
     // Cache ranges of nodes in succinct graphs to search faster.
     // For DNA4, index nodes for all possible suffixes of length 10.
-    // In general, the default value is: 20/log2(|Sigma|)
+    // In general, the default value is: log_{|Sigma|}(2^20)
     static const size_t kDefaultIndexSuffixLen;
     unsigned int node_suffix_length = kDefaultIndexSuffixLen;
     unsigned int distance = 0;

--- a/metagraph/src/cli/transform_graph.cpp
+++ b/metagraph/src/cli/transform_graph.cpp
@@ -91,8 +91,7 @@ int transform_graph(Config *config) {
         timer.reset();
     }
 
-    if (config->node_suffix_length
-            && config->node_suffix_length != dbg_succ->get_boss().get_indexed_suffix_length()) {
+    if (config->node_suffix_length != dbg_succ->get_boss().get_indexed_suffix_length()) {
         size_t suffix_length = std::min((size_t)config->node_suffix_length,
                                         dbg_succ->get_boss().get_k());
 
@@ -106,9 +105,11 @@ int transform_graph(Config *config) {
                       suffix_length,
                       std::pow(dbg_succ->get_boss().alph_size - 1, suffix_length)
                             * 2. * sizeof(uint64_t) * 1e-6);
+        logger->trace("Compressed node ranges to {:.2f} MB",
+                      dbg_succ->get_boss().get_suffix_ranges_index_size() / 8e6);
         timer.reset();
 
-        dbg_succ->get_boss().index_suffix_ranges(suffix_length);
+        dbg_succ->get_boss().index_suffix_ranges(suffix_length, get_num_threads());
 
         logger->trace("Indexing of node ranges took {} sec", timer.elapsed());
         timer.reset();

--- a/metagraph/src/cli/transform_graph.cpp
+++ b/metagraph/src/cli/transform_graph.cpp
@@ -105,7 +105,7 @@ int transform_graph(Config *config) {
                       suffix_length,
                       std::pow(dbg_succ->get_boss().alph_size - 1, suffix_length)
                             * 2. * sizeof(uint64_t) * 1e-6);
-        logger->trace("Compressed node ranges to {:.2f} MB",
+        logger->trace("Compressed node ranges to approx. {:.2f} MB",
                       dbg_succ->get_boss().get_suffix_ranges_index_size() / 8e6);
         timer.reset();
 

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -1663,7 +1663,7 @@ BOSS::erase_redundant_dummy_edges(sdsl::bit_vector *source_dummy_edges,
                                   size_t num_threads,
                                   bool verbose) {
     // reset the index of suffix ranges
-    index_suffix_ranges(0, 0);
+    index_suffix_ranges(0);
 
     sdsl::bit_vector redundant_dummy_edges_mask(W_->size(), false);
 

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -923,7 +923,7 @@ std::vector<TAlphabet> BOSS::get_node_seq(edge_index x) const {
 
         // find end of range with binary search
         uint64_t index = 0;
-        uint64_t end = indexed_suffix_ranges_.size() / 2;
+        uint64_t end = indexed_suffix_ranges_rk1_(indexed_suffix_ranges_.size()) / 2;
         while (index != end) {
             auto mid = index + (end - index) / 2;
             if (get_suffix_range(2 * mid + 1) > x) {
@@ -933,7 +933,7 @@ std::vector<TAlphabet> BOSS::get_node_seq(edge_index x) const {
             }
         }
 
-        if (index < indexed_suffix_ranges_.size() / 2 && get_suffix_range(2 * index) <= x) {
+        if (index < indexed_suffix_ranges_rk1_(indexed_suffix_ranges_.size()) / 2 && get_suffix_range(2 * index) <= x) {
             assert(x < get_suffix_range(2 * index + 1));
             for (i = 0; i < indexed_suffix_length_; ++i) {
                 uint64_t next_index = index / (alph_size - 1);

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -386,6 +386,9 @@ bool BOSS::load_suffix_ranges(std::ifstream &instream) {
             throw std::ifstream::failure("");
 
         indexed_suffix_ranges_.load(instream);
+        indexed_suffix_ranges_rk1_ = decltype(indexed_suffix_ranges_rk1_)(&indexed_suffix_ranges_);
+        indexed_suffix_ranges_slct1_ = decltype(indexed_suffix_ranges_slct1_)(&indexed_suffix_ranges_);
+        indexed_suffix_ranges_slct0_ = decltype(indexed_suffix_ranges_slct0_)(&indexed_suffix_ranges_);
 
         if (!instream.good())
             throw std::ifstream::failure("");
@@ -3186,7 +3189,14 @@ void BOSS::index_suffix_ranges(size_t suffix_length, size_t num_threads) {
 
     assert(std::is_sorted(suffix_ranges.begin(), suffix_ranges.end()));
 
-    indexed_suffix_ranges_ = decltype(indexed_suffix_ranges_)(suffix_ranges);
+    sdsl::sd_vector_builder builder(W_->size() + suffix_ranges.size(), suffix_ranges.size());
+    for (auto pos : suffix_ranges) {
+        builder.set(pos);
+    }
+    indexed_suffix_ranges_ = sdsl::sd_vector<>(builder);
+    indexed_suffix_ranges_rk1_ = decltype(indexed_suffix_ranges_rk1_)(&indexed_suffix_ranges_);
+    indexed_suffix_ranges_slct1_ = decltype(indexed_suffix_ranges_slct1_)(&indexed_suffix_ranges_);
+    indexed_suffix_ranges_slct0_ = decltype(indexed_suffix_ranges_slct0_)(&indexed_suffix_ranges_);
 }
 
 bool BOSS::is_valid() const {

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -926,6 +926,7 @@ std::vector<TAlphabet> BOSS::get_node_seq(edge_index x) const {
         //    [  ]    [ ]   []
         uint64_t index = indexed_suffix_ranges_slct0_(x + 1) - x;
 
+        // check if the index is in an indexed range (k-mer without dummy characters)
         if (index % 2) {
             index /= 2;
             assert(x < get_suffix_range(2 * index + 1));

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -909,6 +909,7 @@ std::vector<TAlphabet> BOSS::get_node_seq(edge_index x) const {
     std::vector<TAlphabet> ret(k_);
     size_t i = k_;
 
+    // TODO: benchmark: short indexed suffix might be slower to query with binary search...
     if (indexed_suffix_length_) {
         while (i > indexed_suffix_length_) {
             CHECK_INDEX(x);

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -3,9 +3,8 @@
 
 #include <type_traits>
 
-#include <sdsl/enc_vector.hpp>
-
 #include "common/vectors/bit_vector.hpp"
+#include "common/vectors/bit_vector_sd.hpp"
 #include "common/vectors/wavelet_tree.hpp"
 #include "kmer/kmer_extractor.hpp"
 #include "graph/representation/base/sequence_graph.hpp"
@@ -81,8 +80,13 @@ class BOSS {
      */
     bool load_suffix_ranges(std::ifstream &instream);
     void serialize_suffix_ranges(std::ofstream &outstream) const;
-    // return the size of the compressed index in bits
-    uint64_t get_suffix_ranges_index_size() const { return indexed_suffix_ranges_.compressed_size(); }
+    // Estimate the size of the compressed index in bits
+    uint64_t get_suffix_ranges_index_size() const {
+        return indexed_suffix_ranges_.size()
+            ? footprint_sd_vector(indexed_suffix_ranges_.size(),
+                                  indexed_suffix_ranges_rk1_(indexed_suffix_ranges_.size()))
+            : 0;
+    }
 
     // Traverse graph mapping k-mers from sequence to the graph edges
     // and run callback for each edge until the termination condition is satisfied
@@ -519,10 +523,15 @@ class BOSS {
     State state = State::DYN;
 
     size_t indexed_suffix_length_ = 0;
-    // element `i` stores value[i] + i to make it strictly increasing for sdsl::enc_vector
-    sdsl::enc_vector<> indexed_suffix_ranges_;
+    // Range (begin[i], end[i]) is represented as (select[2i+1]-2i, select[2i+2]-2i-1)
+    // Use sdsl::sd_vector<> instead of bit_vector_sd to ensure it's not inverted
+    // even if dense, so the select queries are fast.
+    sdsl::sd_vector<> indexed_suffix_ranges_;
+    sdsl::sd_vector<>::rank_1_type indexed_suffix_ranges_rk1_;
+    sdsl::sd_vector<>::select_1_type indexed_suffix_ranges_slct1_;
+    sdsl::sd_vector<>::select_0_type indexed_suffix_ranges_slct0_;
 
-    inline uint64_t get_suffix_range(uint64_t i) const { return indexed_suffix_ranges_[i] - i; }
+    inline uint64_t get_suffix_range(uint64_t i) const { return indexed_suffix_ranges_slct1_(i + 1) - i; }
 
     /**
      * This function gets a character c and updates the edge offsets F_


### PR DESCRIPTION
Add compression of the node ranges index.

Now allows indexing all 10-mers with ~1 MB and all 15-mers using ~400 MB.