### PR TITLE
Workaround for bug in g++-8.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ ifeq ($(env), docker)
  	$(shell mkdir -p $(BUILD_DIR_HOST_DOCKER) $(BUILD_DIR_STATIC_HOST_DOCKER) )
 	EXEC_CMD := $(DOCKER_BASE_CMD) bash -c
 else
-	EXEC_CMD := bash -l -c
+	EXEC_CMD := bash -c
 endif
 
 all: update build test

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -1015,7 +1015,9 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
                 uint64_t r = 0;
                 set_rows[l_idx][j].for_each([&](const auto &v) {
                     call(utils::get_first(v));
-                    if constexpr(with_values) {
+                    // TODO: this should be constexpr(with_values), but due to a bug
+                    //       in g++-8.2, that doesn't compile
+                    if constexpr(utils::is_pair_v<T>) {
                         assert(v.second && "zero diffs must have been skipped");
                         values[l_idx][j][r++] = matrix::encode_diff(v.second);
                     }


### PR DESCRIPTION
This reverts commit f2fb5beadd2150ee81b4424c67dcb1f0ec609571.