### PR TITLE
support memory mapping

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,7 +135,7 @@ jobs:
       run: mv metagraph/build/metagraph_${{ matrix.alphabet }} metagraph/build/metagraph_${{ matrix.alphabet }}_noAVX
     - name: upload static binary
       if: ${{ matrix.build_static == 'ON' && matrix.compiler == 'g++-11' }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: metagraph_${{ matrix.alphabet }}_linux_x86
         path: metagraph/build/metagraph_${{ matrix.alphabet }}${{ matrix.with_avx == 'OFF' && '_noAVX' || '' }}

--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -539,7 +539,7 @@ target_include_directories(unit_tests PRIVATE "${PROJECT_SOURCE_DIR}")
 target_compile_definitions(unit_tests PRIVATE TEST_DATA_DIR="${PROJECT_SOURCE_DIR}/tests/data")
 target_link_libraries(unit_tests gtest_main gtest gmock metagraph-core metagraph-cli)
 
-target_compile_options(unit_tests PRIVATE -Wno-undefined-var-template ${DEATH_TEST_FLAG})
+target_compile_options(unit_tests PRIVATE -Wno-uninitialized ${DEATH_TEST_FLAG})
 
 #-------------------
 # Benchmarks
@@ -556,7 +556,7 @@ add_executable(benchmarks ${benchmark_files})
 target_compile_definitions(benchmarks PRIVATE TEST_DATA_DIR="${PROJECT_SOURCE_DIR}/tests/data")
 target_link_libraries(benchmarks benchmark_main benchmark metagraph-core metagraph-cli -lsdsl)
 
-target_compile_options(benchmarks PRIVATE -Wno-undefined-var-template)
+target_compile_options(benchmarks PRIVATE)
 
 #-------------------
 # Tests

--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -291,6 +291,8 @@ endif()
 
 # makes ASIO not depend on boost
 add_definitions(-DASIO_STANDALONE -DUSE_STANDALONE_ASIO)
+set(USE_STANDALONE_ASIO ON)
+set(ASIO_PATH external-libraries/asio/asio)
 
 # assume built-in pthreads on MacOS
 IF(APPLE)

--- a/metagraph/integration_tests/base.py
+++ b/metagraph/integration_tests/base.py
@@ -24,6 +24,9 @@ GRAPH_TYPES = [graph_type for graph_type, _ in graph_file_extension.items()]
 
 NUM_THREADS = 4
 
+MEMORY_MAPPING = True
+MMAP_FLAG = ' --mmap' if MEMORY_MAPPING else ''
+
 
 class TestingBase(unittest.TestCase):
     @classmethod
@@ -32,7 +35,7 @@ class TestingBase(unittest.TestCase):
 
     @staticmethod
     def _get_stats(graph_path):
-        stats_command = METAGRAPH + ' stats ' + graph_path
+        stats_command = METAGRAPH + ' stats ' + graph_path + MMAP_FLAG
         res = subprocess.run(stats_command.split(), stdout=PIPE, stderr=PIPE)
         return res
 
@@ -56,7 +59,7 @@ class TestingBase(unittest.TestCase):
             mode='basic' if mode == 'basic' else 'canonical',
             outfile=output,
             input=input
-        )
+        ) + MMAP_FLAG
 
         res = subprocess.run([construct_command], shell=True)
         assert res.returncode == 0
@@ -70,7 +73,7 @@ class TestingBase(unittest.TestCase):
                 repr=repr,
                 outfile='{}.fasta.gz'.format(output),
                 input=output
-            )
+            ) + MMAP_FLAG
 
             res = subprocess.run([transform_command], shell=True)
             assert res.returncode == 0
@@ -84,7 +87,7 @@ class TestingBase(unittest.TestCase):
                 repr=repr,
                 outfile=output,
                 input='{}.fasta.gz'.format(output)
-            )
+            ) + MMAP_FLAG
 
             res = subprocess.run([construct_command], shell=True)
             assert res.returncode == 0
@@ -98,7 +101,7 @@ class TestingBase(unittest.TestCase):
             outfile=output,
             extra_params=extra_params,
             input=graph
-        )
+        ) + MMAP_FLAG
         res = subprocess.run([clean_command], shell=True)
         assert res.returncode == 0
 
@@ -127,7 +130,7 @@ class TestingBase(unittest.TestCase):
 
         command = f'{METAGRAPH} annotate -p {num_threads} --anno-{anno_type}\
                     -i {graph_path} --anno-type {anno_repr} {extra_params} \
-                    -o {output} {input}'
+                    -o {output} {input}' + MMAP_FLAG
 
         if target_anno.endswith('_coord'):
             command += ' --coordinates'
@@ -146,7 +149,7 @@ class TestingBase(unittest.TestCase):
         if final_anno.startswith('row_diff'):
             target_anno = 'row_diff'
 
-        command = f'{METAGRAPH} transform_anno -p {num_threads} \
+        command = f'{METAGRAPH} transform_anno {MMAP_FLAG} -p {num_threads} \
                     --anno-type {target_anno} -o {output} \
                     {output + anno_file_extension[anno_repr]}'
 
@@ -186,7 +189,7 @@ class TestingBase(unittest.TestCase):
             if final_anno != target_anno:
                 rd_type = 'column' if with_counts or final_anno.endswith('_coord') else 'row_diff'
                 command = f'{METAGRAPH} transform_anno --anno-type {final_anno} --greedy -o {output} ' \
-                                   f'-i {graph_path} -p {num_threads} {output}.{rd_type}.annodbg'
+                                   f'-i {graph_path} -p {num_threads} {output}.{rd_type}.annodbg' + MMAP_FLAG
                 res = subprocess.run([command], shell=True)
                 assert (res.returncode == 0)
                 subprocess.run([f'rm {output}{anno_file_extension[rd_type]}*'], shell=True)
@@ -194,6 +197,6 @@ class TestingBase(unittest.TestCase):
                 subprocess.run([f'rm {output}{anno_file_extension[anno_repr]}*'], shell=True)
 
         if final_anno.endswith('brwt') or final_anno.endswith('brwt_coord'):
-            command = f'{METAGRAPH} relax_brwt -o {output} -p {num_threads} {output}.{final_anno}.annodbg'
+            command = f'{METAGRAPH} relax_brwt -o {output} -p {num_threads} {output}.{final_anno}.annodbg' + MMAP_FLAG
             res = subprocess.run([command], shell=True)
             assert (res.returncode == 0)

--- a/metagraph/integration_tests/base.py
+++ b/metagraph/integration_tests/base.py
@@ -200,6 +200,8 @@ class TestingBase(unittest.TestCase):
                 subprocess.run([f'rm {output}{anno_file_extension[anno_repr]}*'], shell=True)
 
         if final_anno.endswith('brwt') or final_anno.endswith('brwt_coord'):
-            command = f'{METAGRAPH} relax_brwt -o {output} -p {num_threads} {output}.{final_anno}.annodbg' + MMAP_FLAG
+            # write to a new file to avoid overwrites when memory mapping is enabled
+            command = f'{METAGRAPH} relax_brwt -o {output}_relaxed -p {num_threads} {output}.{final_anno}.annodbg' + MMAP_FLAG
             res = subprocess.run([command], shell=True)
             assert (res.returncode == 0)
+            subprocess.run([f'mv {output}_relaxed.{final_anno}.annodbg {output}.{final_anno}.annodbg'], shell=True)

--- a/metagraph/integration_tests/base.py
+++ b/metagraph/integration_tests/base.py
@@ -35,6 +35,9 @@ class TestingBase(unittest.TestCase):
 
     @staticmethod
     def _get_stats(graph_path):
+        stats_command = METAGRAPH + ' stats ' + graph_path + ' --mmap'
+        res = subprocess.run(stats_command.split(), stdout=PIPE, stderr=PIPE)
+        assert(res.returncode == 0)
         stats_command = METAGRAPH + ' stats ' + graph_path + MMAP_FLAG
         res = subprocess.run(stats_command.split(), stdout=PIPE, stderr=PIPE)
         return res

--- a/metagraph/integration_tests/base.py
+++ b/metagraph/integration_tests/base.py
@@ -200,8 +200,6 @@ class TestingBase(unittest.TestCase):
                 subprocess.run([f'rm {output}{anno_file_extension[anno_repr]}*'], shell=True)
 
         if final_anno.endswith('brwt') or final_anno.endswith('brwt_coord'):
-            # write to a new file to avoid overwrites when memory mapping is enabled
-            command = f'{METAGRAPH} relax_brwt -o {output}_relaxed -p {num_threads} {output}.{final_anno}.annodbg' + MMAP_FLAG
+            command = f'{METAGRAPH} relax_brwt -o {output} -p {num_threads} {output}.{final_anno}.annodbg' + MMAP_FLAG
             res = subprocess.run([command], shell=True)
             assert (res.returncode == 0)
-            subprocess.run([f'mv {output}_relaxed.{final_anno}.annodbg {output}.{final_anno}.annodbg'], shell=True)

--- a/metagraph/integration_tests/test_annotate.py
+++ b/metagraph/integration_tests/test_annotate.py
@@ -6,14 +6,12 @@ from tempfile import TemporaryDirectory
 import filecmp
 import glob
 import os
-from base import TestingBase
+from base import TestingBase, METAGRAPH, TEST_DATA_DIR, NUM_THREADS
 
 
 """Test graph annotation"""
 
-METAGRAPH = './metagraph'
 PROTEIN_MODE = os.readlink(METAGRAPH).endswith("_Protein")
-TEST_DATA_DIR = os.path.dirname(os.path.realpath(__file__)) + '/../tests/data'
 
 graph_file_extension = {'succinct': '.dbg',
                         'bitmap': '.bitmapdbg',
@@ -25,8 +23,6 @@ anno_file_extension = {'column': '.column.annodbg',
                        'row': '.row.annodbg'}
 
 GRAPH_TYPES = [graph_type for graph_type, _ in graph_file_extension.items()]
-
-NUM_THREADS = 4
 
 
 class TestAnnotate(TestingBase):

--- a/metagraph/integration_tests/test_assemble.py
+++ b/metagraph/integration_tests/test_assemble.py
@@ -6,15 +6,13 @@ import os
 import gzip
 import itertools
 from helpers import get_test_class_name
-from base import TestingBase, graph_file_extension
+from base import TestingBase, graph_file_extension, METAGRAPH, TEST_DATA_DIR, NUM_THREADS
 from test_query import anno_file_extension, GRAPH_TYPES, ANNO_TYPES, product
 
 
 """Test graph assemble"""
 
-METAGRAPH = './metagraph'
 PROTEIN_MODE = os.readlink(METAGRAPH).endswith("_Protein")
-TEST_DATA_DIR = os.path.dirname(os.path.realpath(__file__)) + '/../tests/data'
 
 gfa_tests = {
     'compacted': {
@@ -43,8 +41,6 @@ gfa_tests = {
 
 GFAs = [name for name, _ in gfa_tests.items()]
 MASKED = ['','--mask-dummy']
-
-NUM_THREADS = 4
 
 
 class TestAnnotate(unittest.TestCase):

--- a/metagraph/integration_tests/test_build.py
+++ b/metagraph/integration_tests/test_build.py
@@ -5,15 +5,13 @@ from subprocess import PIPE
 from tempfile import TemporaryDirectory
 import glob
 import os
-from base import TestingBase
+from base import TestingBase, METAGRAPH, TEST_DATA_DIR
 
 
 """Test graph construction"""
 
-METAGRAPH = './metagraph'
 PROTEIN_MODE = os.readlink(METAGRAPH).endswith("_Protein")
 DNA_MODE = os.readlink(METAGRAPH).endswith("_DNA")
-TEST_DATA_DIR = os.path.dirname(os.path.realpath(__file__)) + '/../tests/data'
 
 graph_file_extension = {'succinct': '.dbg',
                         'bitmap': '.bitmapdbg',

--- a/metagraph/integration_tests/test_build_weighted.py
+++ b/metagraph/integration_tests/test_build_weighted.py
@@ -7,14 +7,12 @@ from tempfile import TemporaryDirectory
 import glob
 import os
 import gzip
-from base import TestingBase
+from base import TestingBase, METAGRAPH, TEST_DATA_DIR
 
 
 """Test graph construction"""
 
-METAGRAPH = './metagraph'
 PROTEIN_MODE = os.readlink(METAGRAPH).endswith("_Protein")
-TEST_DATA_DIR = os.path.dirname(os.path.realpath(__file__)) + '/../tests/data'
 
 graph_file_extension = {'succinct': '.dbg',
                         'bitmap': '.bitmapdbg',

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -43,6 +43,10 @@ ANNO_TYPES = [anno_type for anno_type, _ in anno_file_extension.items()]
 
 NUM_THREADS = 4
 
+MEMORY_MAPPING = True
+MMAP_FLAG = ' --mmap' if MEMORY_MAPPING else ''
+
+
 def product(graph_types, anno_types):
     result  = []
     for graph in graph_types:
@@ -92,7 +96,7 @@ class TestQuery(TestingBase):
         if cls.with_bloom:
             convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
                                 --initialize-bloom --bloom-fpp 0.1 \
-                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}' + MMAP_FLAG
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -135,7 +139,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
@@ -145,7 +149,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 136959)
@@ -158,7 +162,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
@@ -168,7 +172,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 260215)
@@ -181,7 +185,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
@@ -192,7 +196,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 136959)
@@ -206,7 +210,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
@@ -217,7 +221,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 260215)
@@ -228,7 +232,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         if DNA_MODE:
@@ -241,7 +245,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         if DNA_MODE:
@@ -256,7 +260,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         if DNA_MODE:
@@ -270,7 +274,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         if DNA_MODE:
@@ -287,7 +291,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24567)
@@ -298,7 +302,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24779)
@@ -309,7 +313,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
@@ -319,7 +323,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 136959)
@@ -332,7 +336,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
@@ -342,7 +346,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 260215)
@@ -355,7 +359,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_threads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
@@ -366,7 +370,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_threads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 136959)
@@ -380,7 +384,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
@@ -391,7 +395,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 260215)
@@ -402,7 +406,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         if DNA_MODE:
@@ -430,7 +434,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_threads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         if DNA_MODE:
@@ -444,7 +448,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_threads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         if DNA_MODE:
@@ -461,7 +465,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24567)
@@ -472,7 +476,7 @@ class TestQuery(TestingBase):
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa',
             num_theads=NUM_THREADS
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24779)
@@ -483,7 +487,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
@@ -493,7 +497,7 @@ class TestQuery(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 136959)
@@ -505,7 +509,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --query-coords \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa'
+                            --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -514,7 +518,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --query-coords \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa'
+                            --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -527,7 +531,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --query-coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa'
+                            --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -536,7 +540,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --query-coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa'
+                            --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -610,7 +614,7 @@ class TestQueryTinyLinear(TestingBase):
         query_command = f'{METAGRAPH} query --query-coords  --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.05 {self.fasta_graph}'
+                            --discovery-fraction 0.05 {self.fasta_graph}' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -661,7 +665,7 @@ class TestQuery1Column(TestingBase):
         if cls.with_bloom:
             convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
                                 --initialize-bloom --bloom-fpp 0.1 \
-                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}' + MMAP_FLAG
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -704,7 +708,7 @@ class TestQuery1Column(TestingBase):
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 1.0 \
-                            {TEST_DATA_DIR}/transcripts_1000.fa'
+                            {TEST_DATA_DIR}/transcripts_1000.fa' + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(hashlib.sha224(res.stdout).hexdigest(), '254d173abb255a81a4ab8a685201a73de8dbad4546c378e0a645d454')
@@ -713,7 +717,7 @@ class TestQuery1Column(TestingBase):
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 1.0 \
-                            {TEST_DATA_DIR}/transcripts_1000.fa'
+                            {TEST_DATA_DIR}/transcripts_1000.fa' + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(hashlib.sha224(res.stdout).hexdigest(), '1bd6c24373812064c3e17e73533de7b1e30baa3cca3a64b460e83cb4')
@@ -794,7 +798,7 @@ class TestQueryCounts(TestingBase):
         if cls.with_bloom:
             convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
                                 --initialize-bloom --bloom-fpp 0.1 \
-                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}' + MMAP_FLAG
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -870,7 +874,7 @@ class TestQueryCounts(TestingBase):
             query_command = f'{METAGRAPH} query --fast --count-kmers \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction {discovery_rate} {query_file}'
+                            --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
 
             res = subprocess.run(query_command.split(), stdout=PIPE)
             self.assertEqual(res.returncode, 0)
@@ -909,7 +913,7 @@ class TestQueryCounts(TestingBase):
             query_command = f'{METAGRAPH} query --fast --query-counts --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction {discovery_rate} {query_file}'
+                            --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
 
             res = subprocess.run(query_command.split(), stdout=PIPE)
             self.assertEqual(res.returncode, 0)
@@ -918,7 +922,7 @@ class TestQueryCounts(TestingBase):
         query_command = f'{METAGRAPH} query --fast --query-counts \
                         -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                         -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                        --discovery-fraction {discovery_rate} {query_file}'
+                        --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -961,7 +965,7 @@ class TestQueryCounts(TestingBase):
         query_command = f'{METAGRAPH} query --fast --count-quantiles <SET_BELOW> \
                         -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                         -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                        --discovery-fraction 0.0 {query_file}'
+                        --discovery-fraction 0.0 {query_file}' + MMAP_FLAG
 
         query_command = query_command.split()
         query_command[4] = ' '.join([str(p) for p in quantiles])
@@ -972,7 +976,7 @@ class TestQueryCounts(TestingBase):
         query_command = f'{METAGRAPH} query --fast --count-quantiles <SET_BELOW> \
                         -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                         -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                        --discovery-fraction 1.0 {query_file}'
+                        --discovery-fraction 1.0 {query_file}' + MMAP_FLAG
 
         query_command = query_command.split()
         query_command[4] = ' '.join([str(p) for p in quantiles])
@@ -1017,7 +1021,7 @@ class TestQueryCanonical(TestingBase):
         if cls.with_bloom:
             convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
                                 --initialize-bloom --bloom-fpp 0.1 \
-                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}' + MMAP_FLAG
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -1047,7 +1051,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
@@ -1057,7 +1061,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137093)
@@ -1068,7 +1072,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
@@ -1078,7 +1082,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12970)
@@ -1089,7 +1093,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
@@ -1099,7 +1103,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137093)
@@ -1110,7 +1114,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
@@ -1120,7 +1124,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12970)
@@ -1131,7 +1135,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
@@ -1141,7 +1145,7 @@ class TestQueryCanonical(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137093)
@@ -1184,7 +1188,7 @@ class TestQueryPrimary(TestingBase):
         if cls.with_bloom:
             convert_command = f'{METAGRAPH} transform -o {cls.tempdir.name}/graph \
                                 --initialize-bloom --bloom-fpp 0.1 \
-                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}'
+                                {cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}' + MMAP_FLAG
             res = subprocess.run([convert_command], shell=True)
             assert(res.returncode == 0)
 
@@ -1214,7 +1218,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
@@ -1224,7 +1228,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137093)
@@ -1235,7 +1239,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
@@ -1245,7 +1249,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12970)
@@ -1256,7 +1260,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
@@ -1266,7 +1270,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137093)
@@ -1277,7 +1281,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
@@ -1287,7 +1291,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_100_tail10_snp.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12970)
@@ -1298,7 +1302,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
@@ -1308,7 +1312,7 @@ class TestQueryPrimary(TestingBase):
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
             input=TEST_DATA_DIR + '/transcripts_1000.fa'
-        )
+        ) + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137093)

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1892,10 +1892,10 @@ load_coords(Annotator&& anno, const std::vector<std::string> &files) {
 
         auto coords_fname = utils::remove_suffix(files[i], ColumnCompressed<>::kExtension)
                                                         + ColumnCompressed<>::kCoordExtension;
-        std::ifstream in(coords_fname, std::ios::binary);
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(coords_fname, utils::with_mmap());
         size_t j = 0;
         try {
-            TupleCSC::load_tuples(in, label_encoder.size(), [&](auto&& delims, auto&& values) {
+            TupleCSC::load_tuples(*in, label_encoder.size(), [&](auto&& delims, auto&& values) {
                 size_t idx;
                 try {
                     idx = anno.get_label_encoder().encode(label_encoder.decode(j));

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1077,7 +1077,7 @@ void convert_to_row_disk(
 
 
 uint64_t get_num_rows_from_row_diff_anno(const std::string &fname) {
-    std::unique_ptr<std::ifstream> in = utils::open_ifstream(fname, utils::with_mmap());
+    std::unique_ptr<std::ifstream> in = utils::open_ifstream(fname);
     if (!in->good())
         throw std::ifstream::failure("can't open file");
 
@@ -1889,7 +1889,7 @@ load_coords(Annotator&& anno, const std::vector<std::string> &files) {
 
         auto coords_fname = utils::remove_suffix(files[i], ColumnCompressed<>::kExtension)
                                                         + ColumnCompressed<>::kCoordExtension;
-        std::unique_ptr<std::ifstream> in = utils::open_ifstream(coords_fname, utils::with_mmap());
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(coords_fname);
         size_t j = 0;
         try {
             TupleCSC::load_tuples(*in, label_encoder.size(), [&](auto&& delims, auto&& values) {

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -826,7 +826,7 @@ void convert_batch_to_row_disk(
         exit(1);
     }
 
-    std::ofstream out(outfname, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(outfname);
     if (!out.good())
         throw std::ofstream::failure("Can't write to " + outfname);
 
@@ -938,7 +938,7 @@ void merge_row_disk_annotations(const std::vector<std::string> &files,
         exit(1);
     }
 
-    std::ofstream out(outfname, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(outfname);
     if (!out.good())
         throw std::ofstream::failure("Can't write to " + outfname);
 
@@ -1178,7 +1178,7 @@ void convert_to_row_diff<IntRowDiffDiskAnnotator>(
             },
             num_threads);
 
-    std::ofstream out(outfname, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(outfname);
     if (!out.good())
         throw std::ofstream::failure("Can't write to " + outfname);
 
@@ -1296,7 +1296,7 @@ void convert_to_row_diff<RowDiffDiskCoordAnnotator>(
             },
             num_threads);
 
-    std::ofstream out(outfname, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(outfname);
     if (!out.good())
         throw std::ofstream::failure("Can't write to " + outfname);
 

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -1089,7 +1089,7 @@ uint64_t get_num_rows_from_row_diff_anno(const std::string &fname) {
         exit(1);
     }
 
-    return matrix.diffs().num_rows();
+    return matrix.num_rows();
 }
 
 template <>

--- a/metagraph/src/annotation/annotation_converters.cpp
+++ b/metagraph/src/annotation/annotation_converters.cpp
@@ -902,7 +902,7 @@ void merge_row_disk_annotations(const std::vector<std::string> &files,
         LEncoder le;
         matrices[j] = std::make_unique<RowDisk>();
 
-        utils::NamedIfstream in(files[j], std::ios::in);
+        sdsl::mmap_ifstream in(files[j], std::ios::binary);
         if (!le.load(in)) {
             logger->error("Can't load label encoder from {}", files[j]);
             exit(1);
@@ -1079,14 +1079,14 @@ void convert_to_row_disk(
 
 
 uint64_t get_num_rows_from_row_diff_anno(const std::string &fname) {
-    std::ifstream in(fname, std::ios::binary);
-    if (!in.good())
+    std::unique_ptr<std::ifstream> in = utils::open_ifstream(fname, utils::with_mmap());
+    if (!in->good())
         throw std::ifstream::failure("can't open file");
 
     LabelEncoder<std::string> label_encoder;
     binmat::RowDiff<binmat::ColumnMajor> matrix;
 
-    if (!label_encoder.load(in) || !matrix.load(in)) {
+    if (!label_encoder.load(*in) || !matrix.load(*in)) {
         logger->error("Can't load {}", fname);
         exit(1);
     }

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
@@ -244,7 +244,7 @@ BRWT BRWTBottomUpBuilder::build(
         get_node = [tmp_dir](uint64_t id) {
             BRWT node;
             auto filename = tmp_dir/std::to_string(id);
-            std::unique_ptr<std::ifstream> in = utils::open_ifstream(filename, utils::with_mmap());
+            std::unique_ptr<std::ifstream> in = utils::open_ifstream(filename);
             if (!node.load(*in)) {
                 logger->error("Can't load temp BRWT node {}", filename);
                 exit(1);

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt_builders.cpp
@@ -244,8 +244,8 @@ BRWT BRWTBottomUpBuilder::build(
         get_node = [tmp_dir](uint64_t id) {
             BRWT node;
             auto filename = tmp_dir/std::to_string(id);
-            std::ifstream in(filename, std::ios::binary);
-            if (!node.load(in)) {
+            std::unique_ptr<std::ifstream> in = utils::open_ifstream(filename, utils::with_mmap());
+            if (!node.load(*in)) {
                 logger->error("Can't load temp BRWT node {}", filename);
                 exit(1);
             }

--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
@@ -17,7 +17,7 @@ void IRowDiff::load_anchor(const std::string &filename) {
         common::logger->error("Can't read anchor file: {}", filename);
         std::exit(1);
     }
-    std::unique_ptr<std::ifstream> f = utils::open_ifstream(filename, utils::with_mmap());
+    std::unique_ptr<std::ifstream> f = utils::open_ifstream(filename);
     if (!f->good()) {
         common::logger->error("Could not open anchor file {}", filename);
         std::exit(1);
@@ -30,7 +30,7 @@ void IRowDiff::load_fork_succ(const std::string &filename) {
         common::logger->error("Can't read fork successor file: {}", filename);
         std::exit(1);
     }
-    std::unique_ptr<std::ifstream> f = utils::open_ifstream(filename, utils::with_mmap());
+    std::unique_ptr<std::ifstream> f = utils::open_ifstream(filename);
     if (!f->good()) {
         common::logger->error("Could not open fork successor file {}", filename);
         std::exit(1);

--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.cpp
@@ -6,6 +6,7 @@
 #include "annotation/binary_matrix/column_sparse/column_major.hpp"
 #include "annotation/binary_matrix/multi_brwt/brwt.hpp"
 #include "annotation/binary_matrix/row_sparse/row_sparse.hpp"
+#include "common/utils/file_utils.hpp"
 
 namespace mtg {
 namespace annot {
@@ -16,12 +17,12 @@ void IRowDiff::load_anchor(const std::string &filename) {
         common::logger->error("Can't read anchor file: {}", filename);
         std::exit(1);
     }
-    std::ifstream f(filename, ios::binary);
-    if (!f.good()) {
+    std::unique_ptr<std::ifstream> f = utils::open_ifstream(filename, utils::with_mmap());
+    if (!f->good()) {
         common::logger->error("Could not open anchor file {}", filename);
         std::exit(1);
     }
-    anchor_.load(f);
+    anchor_.load(*f);
 }
 
 void IRowDiff::load_fork_succ(const std::string &filename) {
@@ -29,12 +30,12 @@ void IRowDiff::load_fork_succ(const std::string &filename) {
         common::logger->error("Can't read fork successor file: {}", filename);
         std::exit(1);
     }
-    std::ifstream f(filename, ios::binary);
-    if (!f.good()) {
+    std::unique_ptr<std::ifstream> f = utils::open_ifstream(filename, utils::with_mmap());
+    if (!f->good()) {
         common::logger->error("Could not open fork successor file {}", filename);
         std::exit(1);
     }
-    fork_succ_.load(f);
+    fork_succ_.load(*f);
 }
 
 std::pair<std::vector<BinaryMatrix::Row>, std::vector<std::vector<size_t>>>

--- a/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
@@ -55,14 +55,14 @@ RowDisk::View::get_rows(const std::vector<Row> &row_ids) const {
 }
 
 bool RowDisk::load(std::istream &f) {
-    auto _f = dynamic_cast<utils::NamedIfstream *>(&f);
+    auto _f = dynamic_cast<sdsl::mmap_ifstream *>(&f);
     assert(_f);
     try {
         num_columns_ = load_number(f);
 
         auto boundary_start = load_number(f);
 
-        buffer_params_.filename = _f->get_name();
+        buffer_params_.filename = _f->get_filename();
         buffer_params_.offset = f.tellg();
 
         assert(boundary_start >= buffer_params_.offset);

--- a/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
@@ -140,7 +140,7 @@ CoordRowDisk::View::get_row_tuples(const std::vector<Row> &rows) const {
 
 
 bool CoordRowDisk::load(std::istream &f) {
-    auto _f = dynamic_cast<utils::NamedIfstream *>(&f);
+    auto _f = dynamic_cast<sdsl::mmap_ifstream *>(&f);
     assert(_f);
     try {
         num_columns_ = load_number(f);
@@ -151,7 +151,7 @@ bool CoordRowDisk::load(std::istream &f) {
         bits_for_number_of_vals_ = load_number(f);
         bits_for_single_value_ = load_number(f);
 
-        buffer_params_.filename = _f->get_name();
+        buffer_params_.filename = _f->get_filename();
         buffer_params_.offset = f.tellg();
 
         assert(boundary_start >= buffer_params_.offset);

--- a/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
@@ -93,7 +93,7 @@ IntRowDisk::View::get_row_values(const std::vector<Row> &row_ids) const {
 }
 
 bool IntRowDisk::load(std::istream &f) {
-    auto _f = dynamic_cast<utils::NamedIfstream *>(&f);
+    auto _f = dynamic_cast<sdsl::mmap_ifstream *>(&f);
     assert(_f);
     try {
         num_columns_ = load_number(f);
@@ -103,7 +103,7 @@ bool IntRowDisk::load(std::istream &f) {
         bits_for_col_id_ = load_number(f);
         bits_for_value_ = load_number(f);
 
-        buffer_params_.filename = _f->get_name();
+        buffer_params_.filename = _f->get_filename();
         buffer_params_.offset = f.tellg();
 
         assert(boundary_start >= buffer_params_.offset);

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -103,12 +103,8 @@ bool StaticBinRelAnnotator<BinaryMatrixType, Label>
 
     #pragma omp parallel for num_threads(num_threads)
     for (uint64_t i = 0; i < m; ++i) {
-        std::ofstream outstream(
-            remove_suffix(prefix, kExtension)
-                + "." + std::to_string(i)
-                + ".text.annodbg"
-        );
-
+        std::ofstream outstream(remove_suffix(prefix, kExtension)
+                                    + fmt::format(".{}.text.annodbg", i));
         if (!outstream.good()) {
             std::cerr << "ERROR: dumping column " << i << " failed" << std::endl;
             success = false;

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -126,6 +126,7 @@ StaticBinRelAnnotator<BinaryMatrixType, Label>
     label_encoder_ = label_encoder;
 }
 
+// TODO: make row-diff annotations .column.annodbg format and remove this function
 bool merge_load_row_diff(const std::vector<std::string> &filenames,
                          const ColumnCallback &callback,
                          size_t num_threads) {
@@ -145,6 +146,7 @@ bool merge_load_row_diff(const std::vector<std::string> &filenames,
             error_occurred = true;
         }
 
+        // TODO: use load_label_encoder
         LabelEncoder<std::string> label_encoder;
         if (!label_encoder.load(instream)) {
             common::logger->error("Can't load label encoder from {}", filenames[i]);

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -1,10 +1,12 @@
 #include "annotation_matrix.hpp"
 
+#include <filesystem>
+
 #include "common/threads/threading.hpp"
 #include "common/utils/string_utils.hpp"
+#include "common/utils/file_utils.hpp"
 #include "common/serialization.hpp"
 #include "static_annotators_def.hpp"
-#include "common/utils/file_utils.hpp"
 
 namespace mtg {
 namespace annot {
@@ -51,12 +53,12 @@ template <class BinaryMatrixType, typename Label>
 void
 StaticBinRelAnnotator<BinaryMatrixType, Label>
 ::serialize(const std::string &filename) const {
-    std::ofstream outstream(make_suffix(filename, kExtension), std::ios::binary);
-    if (!outstream.good()) {
-        throw std::ofstream::failure("Bad stream");
-    }
-    label_encoder_.serialize(outstream);
-    matrix_->serialize(outstream);
+    const auto &fname = make_suffix(filename, kExtension);
+    std::ofstream out = utils::open_new_ofstream(fname);
+    if (!out.good())
+        throw std::ofstream::failure("Can't write to " + fname);
+    label_encoder_.serialize(out);
+    matrix_->serialize(out);
 }
 
 template <class BinaryMatrixType, typename Label>

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -63,9 +63,10 @@ template <class BinaryMatrixType, typename Label>
 bool StaticBinRelAnnotator<BinaryMatrixType, Label>::load(const std::string &filename) {
     const auto &fname = make_suffix(filename, kExtension);
     std::unique_ptr<std::ifstream> in;
-    if (std::is_same_v<BinaryMatrixType, RowDiffDiskAnnotator>
-            || std::is_same_v<BinaryMatrixType, IntRowDiffDiskAnnotator>
-            || std::is_same_v<BinaryMatrixType, RowDiffDiskCoordAnnotator>) {
+    using T = StaticBinRelAnnotator<BinaryMatrixType, Label>;
+    if (std::is_same_v<T, RowDiffDiskAnnotator>
+            || std::is_same_v<T, IntRowDiffDiskAnnotator>
+            || std::is_same_v<T, RowDiffDiskCoordAnnotator>) {
         in.reset(new utils::NamedIfstream(fname, std::ios::binary));
     } else {
         in = utils::open_ifstream(fname, utils::with_mmap());

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -168,9 +168,9 @@ bool merge_load_row_diff(const std::vector<std::string> &filenames,
         try {
             common::logger->trace("Loading annotations from file {}", filenames[i]);
             LabelEncoder<std::string> label_encoder;
-            std::ifstream instream(filenames[i], std::ios::binary);
+            std::unique_ptr<std::ifstream> in = utils::open_ifstream(filenames[i], utils::with_mmap());
             binmat::RowDiff<binmat::ColumnMajor> matrix;
-            if (!label_encoder.load(instream) || !matrix.load(instream)) {
+            if (!label_encoder.load(*in) || !matrix.load(*in)) {
                 common::logger->error("Can't load {}", filenames[i]);
                 std::exit(1);
             }

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -166,7 +166,7 @@ bool merge_load_row_diff(const std::vector<std::string> &filenames,
         try {
             common::logger->trace("Loading annotations from file {}", filenames[i]);
             LabelEncoder<std::string> label_encoder;
-            std::unique_ptr<std::ifstream> in = utils::open_ifstream(filenames[i], utils::with_mmap());
+            std::unique_ptr<std::ifstream> in = utils::open_ifstream(filenames[i]);
             binmat::RowDiff<binmat::ColumnMajor> matrix;
             if (!label_encoder.load(*in) || !matrix.load(*in)) {
                 common::logger->error("Can't load {}", filenames[i]);

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -62,16 +62,11 @@ StaticBinRelAnnotator<BinaryMatrixType, Label>
 template <class BinaryMatrixType, typename Label>
 bool StaticBinRelAnnotator<BinaryMatrixType, Label>::load(const std::string &filename) {
     const auto &fname = make_suffix(filename, kExtension);
-    std::unique_ptr<std::ifstream> in;
     using T = StaticBinRelAnnotator<BinaryMatrixType, Label>;
-    if (std::is_same_v<T, RowDiffDiskAnnotator>
-            || std::is_same_v<T, IntRowDiffDiskAnnotator>
-            || std::is_same_v<T, RowDiffDiskCoordAnnotator>) {
-        in.reset(new utils::NamedIfstream(fname, std::ios::binary));
-    } else {
-        in = utils::open_ifstream(fname, utils::with_mmap());
-    }
-
+    bool use_mmap = std::is_same_v<T, RowDiffDiskAnnotator>
+                        || std::is_same_v<T, IntRowDiffDiskAnnotator>
+                        || std::is_same_v<T, RowDiffDiskCoordAnnotator>;
+    std::unique_ptr<std::ifstream> in = utils::open_ifstream(fname, use_mmap || utils::with_mmap());
     if (!in->good())
         return false;
 

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.hpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.hpp
@@ -34,6 +34,7 @@ class StaticBinRelAnnotator : public MultiLabelEncoded<Label> {
 
     void serialize(const std::string &filename) const override;
     bool load(const std::string &filename) override;
+    static LabelEncoder<Label> read_label_encoder(const std::string &filename);
     // Dump columns to separate files in human-readable format
     bool dump_columns(const std::string &prefix, uint64_t num_threads = 1) const;
 

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -216,7 +216,7 @@ template <typename Label>
 void ColumnCompressed<Label>::serialize(const std::string &filename) const {
     flush();
 
-    std::ofstream out(make_suffix(filename, kExtension), std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(make_suffix(filename, kExtension));
     if (!out) {
         logger->error("Could not open file for writing: {}",
                       make_suffix(filename, kExtension));
@@ -244,7 +244,7 @@ void ColumnCompressed<Label>::serialize(const std::string &filename) const {
 template <typename Label>
 void ColumnCompressed<Label>::serialize_counts(const std::string &filename) const {
     auto counts_fname = remove_suffix(filename, kExtension) + kCountExtension;
-    std::ofstream out(counts_fname, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(counts_fname);
     if (!out) {
         logger->error("Could not open file for writing: {}", counts_fname);
         throw std::ofstream::failure("Bad stream");
@@ -309,7 +309,7 @@ void ColumnCompressed<Label>::serialize_counts(const std::string &filename) cons
 template <typename Label>
 void ColumnCompressed<Label>::serialize_coordinates(const std::string &filename) const {
     auto coords_fname = remove_suffix(filename, kExtension) + kCoordExtension;
-    std::ofstream out(coords_fname, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(coords_fname);
     if (!out) {
         logger->error("Could not open file for writing: {}", coords_fname);
         throw std::ofstream::failure("Bad stream");

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -8,6 +8,7 @@
 #include <ips4o.hpp>
 
 #include "common/serialization.hpp"
+#include "common/utils/file_utils.hpp"
 #include "common/utils/string_utils.hpp"
 #include "common/logger.hpp"
 #include "common/unix_tools.hpp"
@@ -448,8 +449,9 @@ void ColumnCompressed<Label>::serialize_coordinates(const std::string &filename)
 
             {
                 sdsl::bit_vector delim_bv;
-                std::ifstream in(tmp_path/"delim", std::ios::binary);
-                delim_bv.load(in);
+                std::unique_ptr<std::ifstream> in
+                        = utils::open_ifstream(tmp_path/"delim", utils::with_mmap());
+                delim_bv.load(*in);
                 bit_vector_smart(std::move(delim_bv)).serialize(out);
             }
 
@@ -483,7 +485,8 @@ bool ColumnCompressed<Label>::load(const std::string &filename) {
     logger->trace("Loading annotations from file {}", f);
 
     try {
-        std::ifstream in(f, std::ios::binary);
+        std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(f, utils::with_mmap());
+        auto &in = *in_ptr;
         if (!in.good())
             throw std::ifstream::failure("can't open file");
 
@@ -623,7 +626,8 @@ bool ColumnCompressed<Label>::merge_load(const std::vector<std::string> &filenam
         const auto &filename = make_suffix(filenames[i], kExtension);
         logger->trace("Loading annotations from file {}", filename);
         try {
-            std::ifstream in(filename, std::ios::binary);
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename, utils::with_mmap());
+            auto &in = *in_ptr;
             if (!in.good())
                 throw std::ifstream::failure("can't open file");
 
@@ -705,7 +709,8 @@ void ColumnCompressed<Label>
             const auto &values_fname
                 = remove_suffix(filename, kExtension) + kCountExtension;
 
-            std::ifstream values_in(values_fname, std::ios::binary);
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(values_fname, utils::with_mmap());
+            auto &values_in = *in_ptr;
             if (!values_in)
                 throw std::ifstream::failure("can't open file " + values_fname);
 
@@ -769,7 +774,8 @@ void ColumnCompressed<Label>
         const auto &filename = make_suffix(filenames[i], kExtension);
         logger->trace("Loading columns from {}", filename);
         try {
-            std::ifstream in(filename, std::ios::binary);
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename, utils::with_mmap());
+            auto &in = *in_ptr;
             if (!in)
                 throw std::ifstream::failure("can't open file");
 
@@ -788,7 +794,9 @@ void ColumnCompressed<Label>
                 = utils::remove_suffix(filename, ColumnCompressed<>::kExtension)
                                                 + ColumnCompressed<>::kCountExtension;
 
-            std::ifstream values_in(values_fname, std::ios::binary);
+            std::unique_ptr<std::ifstream> values_in_ptr
+                    = utils::open_ifstream(values_fname, utils::with_mmap());
+            auto &values_in = *values_in_ptr;
             if (!values_in)
                 throw std::ifstream::failure("can't open file " + values_fname);
 
@@ -861,7 +869,8 @@ void ColumnCompressed<Label>::load_columns_delims_and_values(
         const auto &filename = make_suffix(filenames[i], kExtension);
         logger->trace("Loading columns from {}", filename);
         try {
-            std::ifstream in(filename, std::ios::binary);
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename, utils::with_mmap());
+            auto &in = *in_ptr;
             if (!in)
                 throw std::ifstream::failure("can't open file");
 
@@ -880,7 +889,9 @@ void ColumnCompressed<Label>::load_columns_delims_and_values(
                     = utils::remove_suffix(filename, ColumnCompressed<>::kExtension)
                     + ColumnCompressed<>::kCoordExtension;
 
-            std::ifstream coord_in(coords_fname, std::ios::binary);
+            std::unique_ptr<std::ifstream> coords_in_ptr
+                    = utils::open_ifstream(coords_fname, utils::with_mmap());
+            auto &coord_in = *coords_in_ptr;
             if (!coord_in)
                 throw std::ifstream::failure("can't open file " + coords_fname);
 

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -449,8 +449,7 @@ void ColumnCompressed<Label>::serialize_coordinates(const std::string &filename)
 
             {
                 sdsl::bit_vector delim_bv;
-                std::unique_ptr<std::ifstream> in
-                        = utils::open_ifstream(tmp_path/"delim", utils::with_mmap());
+                std::unique_ptr<std::ifstream> in = utils::open_ifstream(tmp_path/"delim");
                 delim_bv.load(*in);
                 bit_vector_smart(std::move(delim_bv)).serialize(out);
             }
@@ -485,7 +484,7 @@ bool ColumnCompressed<Label>::load(const std::string &filename) {
     logger->trace("Loading annotations from file {}", f);
 
     try {
-        std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(f, utils::with_mmap());
+        std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(f);
         auto &in = *in_ptr;
         if (!in.good())
             throw std::ifstream::failure("can't open file");
@@ -626,7 +625,7 @@ bool ColumnCompressed<Label>::merge_load(const std::vector<std::string> &filenam
         const auto &filename = make_suffix(filenames[i], kExtension);
         logger->trace("Loading annotations from file {}", filename);
         try {
-            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename, utils::with_mmap());
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename);
             auto &in = *in_ptr;
             if (!in.good())
                 throw std::ifstream::failure("can't open file");
@@ -709,7 +708,7 @@ void ColumnCompressed<Label>
             const auto &values_fname
                 = remove_suffix(filename, kExtension) + kCountExtension;
 
-            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(values_fname, utils::with_mmap());
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(values_fname);
             auto &values_in = *in_ptr;
             if (!values_in)
                 throw std::ifstream::failure("can't open file " + values_fname);
@@ -774,7 +773,7 @@ void ColumnCompressed<Label>
         const auto &filename = make_suffix(filenames[i], kExtension);
         logger->trace("Loading columns from {}", filename);
         try {
-            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename, utils::with_mmap());
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename);
             auto &in = *in_ptr;
             if (!in)
                 throw std::ifstream::failure("can't open file");
@@ -794,8 +793,7 @@ void ColumnCompressed<Label>
                 = utils::remove_suffix(filename, ColumnCompressed<>::kExtension)
                                                 + ColumnCompressed<>::kCountExtension;
 
-            std::unique_ptr<std::ifstream> values_in_ptr
-                    = utils::open_ifstream(values_fname, utils::with_mmap());
+            std::unique_ptr<std::ifstream> values_in_ptr = utils::open_ifstream(values_fname);
             auto &values_in = *values_in_ptr;
             if (!values_in)
                 throw std::ifstream::failure("can't open file " + values_fname);
@@ -869,7 +867,7 @@ void ColumnCompressed<Label>::load_columns_delims_and_values(
         const auto &filename = make_suffix(filenames[i], kExtension);
         logger->trace("Loading columns from {}", filename);
         try {
-            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename, utils::with_mmap());
+            std::unique_ptr<std::ifstream> in_ptr = utils::open_ifstream(filename);
             auto &in = *in_ptr;
             if (!in)
                 throw std::ifstream::failure("can't open file");
@@ -889,8 +887,7 @@ void ColumnCompressed<Label>::load_columns_delims_and_values(
                     = utils::remove_suffix(filename, ColumnCompressed<>::kExtension)
                     + ColumnCompressed<>::kCoordExtension;
 
-            std::unique_ptr<std::ifstream> coords_in_ptr
-                    = utils::open_ifstream(coords_fname, utils::with_mmap());
+            std::unique_ptr<std::ifstream> coords_in_ptr = utils::open_ifstream(coords_fname);
             auto &coord_in = *coords_in_ptr;
             if (!coord_in)
                 throw std::ifstream::failure("can't open file " + coords_fname);

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -579,12 +579,12 @@ bool ColumnCompressed<Label>::merge_load(const std::vector<std::string> &filenam
 
 template <typename Label>
 size_t ColumnCompressed<Label>::read_num_labels(const std::string &filename) {
-    return load_label_encoder(filename).size();
+    return read_label_encoder(filename).size();
 }
 
 template <typename Label>
 LabelEncoder<Label>
-ColumnCompressed<Label>::load_label_encoder(const std::string &filename) {
+ColumnCompressed<Label>::read_label_encoder(const std::string &filename) {
     auto fname = make_suffix(filename, kExtension);
     std::ifstream in(filename, std::ios::binary);
     std::ignore = load_number(in); // read num_rows
@@ -699,7 +699,7 @@ void ColumnCompressed<Label>
         const auto &filename = make_suffix(filenames[i], kExtension);
         logger->trace("Loading labels from {}", filename);
         try {
-            LabelEncoder<Label> label_encoder_load = load_label_encoder(filename);
+            LabelEncoder<Label> label_encoder_load = read_label_encoder(filename);
 
             if (!label_encoder_load.size()) {
                 logger->warn("No columns in {}", filename);

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
@@ -88,7 +88,7 @@ class ColumnCompressed : public MultiLabelEncoded<Label> {
                            const ColumnCallback &callback,
                            size_t num_threads = 1);
     static size_t read_num_labels(const std::string &filename);
-    static LabelEncoder<Label> load_label_encoder(const std::string &filename);
+    static LabelEncoder<Label> read_label_encoder(const std::string &filename);
 
     using ValuesCallback = std::function<void(uint64_t offset,
                                               const Label &,

--- a/metagraph/src/annotation/representation/row_compressed/annotate_row_compressed.cpp
+++ b/metagraph/src/annotation/representation/row_compressed/annotate_row_compressed.cpp
@@ -223,8 +223,7 @@ uint64_t RowCompressed<Label>::num_relations() const {
 }
 
 template <typename Label>
-std::unique_ptr<LabelEncoder<Label>>
-RowCompressed<Label>::load_label_encoder(const std::string &filebase) {
+LabelEncoder<Label> RowCompressed<Label>::read_label_encoder(const std::string &filebase) {
     auto filename = make_suffix(filebase, kExtension);
 
     std::ifstream instream(filename, std::ios::binary);
@@ -232,27 +231,26 @@ RowCompressed<Label>::load_label_encoder(const std::string &filebase) {
         throw std::ifstream::failure("Cannot read from file " + filename);
 
     try {
-        return load_label_encoder(instream);
+        return read_label_encoder(instream);
     } catch (...) {
         throw std::ifstream::failure("Cannot load label encoder from file " + filename);
     }
 }
 
 template <typename Label>
-std::unique_ptr<LabelEncoder<Label>>
-RowCompressed<Label>::load_label_encoder(std::istream &instream) {
+LabelEncoder<Label> RowCompressed<Label>::read_label_encoder(std::istream &instream) {
     if (!instream.good())
         throw std::istream::failure("Bad stream");
 
-    auto label_encoder = std::make_unique<LabelEncoder<Label>>();
-    if (!label_encoder->load(instream))
+    LabelEncoder<Label> label_encoder;
+    if (!label_encoder.load(instream))
         throw std::istream::failure("Cannot load label encoder");
 
     return label_encoder;
 }
 
 template <typename Label>
-void RowCompressed<Label>::load_shape(const std::string &filename,
+void RowCompressed<Label>::read_shape(const std::string &filename,
                                       uint64_t *num_objects_,
                                       uint64_t *num_relations_) {
     assert(num_objects_);
@@ -276,7 +274,7 @@ RowCompressed<Label>::get_row_streamer(const std::string &filebase) {
     std::string filename = make_suffix(filebase, kExtension);
     std::ifstream instream(filename, std::ios::binary);
     // skip header
-    load_label_encoder(instream);
+    read_label_encoder(instream);
     // rows
     return binmat::StreamRows<binmat::BinaryMatrix::SetBitPositions>(filename, instream.tellg());
 }

--- a/metagraph/src/annotation/representation/row_compressed/annotate_row_compressed.hpp
+++ b/metagraph/src/annotation/representation/row_compressed/annotate_row_compressed.hpp
@@ -48,12 +48,11 @@ class RowCompressed : public MultiLabelEncoded<Label> {
                           const LabelEncoder<Label> &label_encoder,
                           const std::function<void(binmat::BinaryMatrix::RowCallback)> &call_rows);
 
-    static void load_shape(const std::string &filename,
+    static void read_shape(const std::string &filename,
                            uint64_t *num_objects,
                            uint64_t *num_relations);
 
-    static std::unique_ptr<LabelEncoder<Label>>
-    load_label_encoder(const std::string &filename);
+    static LabelEncoder<Label> read_label_encoder(const std::string &filename);
 
     static binmat::StreamRows<binmat::BinaryMatrix::SetBitPositions>
     get_row_streamer(const std::string &filename);
@@ -71,8 +70,7 @@ class RowCompressed : public MultiLabelEncoded<Label> {
 
     std::unique_ptr<binmat::BinaryMatrixRowDynamic> matrix_;
 
-    static std::unique_ptr<LabelEncoder<Label>>
-    load_label_encoder(std::istream &instream);
+    static LabelEncoder<Label> read_label_encoder(std::istream &instream);
 };
 
 } // namespace annot

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -83,7 +83,7 @@ void load_coordinates(const std::vector<std::string> &source_files,
         const auto &coords_fname = utils::remove_suffix(source_files[i],
                                                         ColumnCompressed<>::kExtension)
                                         + ColumnCompressed<>::kCoordExtension;
-        std::unique_ptr<std::ifstream> in = utils::open_ifstream(coords_fname, utils::with_mmap());
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(coords_fname);
         if (!*in) {
             logger->error("Could not open file with coordinates {}", coords_fname);
             exit(1);
@@ -484,7 +484,7 @@ void assign_anchors(const std::string &graph_fname,
     {
         rd_succ_bv_type rd_succ;
         const std::string &rd_succ_fname = outfbase + kRowDiffForkSuccExt;
-        std::unique_ptr<std::ifstream> in = utils::open_ifstream(rd_succ_fname, utils::with_mmap());
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(rd_succ_fname);
         if (!rd_succ.load(*in)) {
             logger->error("Couldn't load row-diff successor bitmap from {}", rd_succ_fname);
             exit(1);
@@ -766,7 +766,7 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
             const auto &values_fname = utils::remove_suffix(source_files[i],
                                                             ColumnCompressed<>::kExtension)
                                             + ColumnCompressed<>::kCountExtension;
-            std::unique_ptr<std::ifstream> in = utils::open_ifstream(values_fname, utils::with_mmap());
+            std::unique_ptr<std::ifstream> in = utils::open_ifstream(values_fname);
             if (!*in) {
                 logger->error("Could not open file with column values {}", values_fname);
                 exit(1);
@@ -788,7 +788,7 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
     anchor_bv_type anchor;
     if (!compute_row_reduction) {
         const std::string anchors_fname = pred_succ_fprefix + kRowDiffAnchorExt;
-        std::unique_ptr<std::ifstream> in = utils::open_ifstream(anchors_fname, utils::with_mmap());
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(anchors_fname);
         if (!anchor.load(*in)) {
             logger->error("Can't load anchors from {}", anchors_fname);
             exit(1);
@@ -1254,7 +1254,7 @@ void convert_batch_to_row_diff_coord(const std::string &pred_succ_fprefix,
 
     anchor_bv_type anchor;
     const std::string anchors_fname = pred_succ_fprefix + kRowDiffAnchorExt;
-    std::unique_ptr<std::ifstream> in = utils::open_ifstream(anchors_fname, utils::with_mmap());
+    std::unique_ptr<std::ifstream> in = utils::open_ifstream(anchors_fname);
     if (!anchor.load(*in)) {
         logger->error("Can't load anchors from {}", anchors_fname);
         exit(1);

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -1047,9 +1047,9 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
                 logger->trace("Serialized {}", fpath);
 
                 fpath.replace_extension().replace_extension(ColumnCompressed<>::kCountExtension);
-                std::ofstream outstream(fpath, std::ios::binary);
+                std::ofstream out = utils::open_new_ofstream(fpath);
                 for (size_t j = 0; j < label_encoders[l_idx].size(); ++j) {
-                    values[l_idx][j].serialize(outstream);
+                    values[l_idx][j].serialize(out);
                 }
                 logger->trace("Serialized {}", fpath);
                 values[l_idx].clear();
@@ -1410,7 +1410,7 @@ void convert_batch_to_row_diff_coord(const std::string &pred_succ_fprefix,
 
         auto fpath_coord = col_out_dir/fs::path(source_files[l_idx]).filename();
         fpath_coord.replace_extension().replace_extension(ColumnCompressed<>::kCoordExtension);
-        std::ofstream out_coord(fpath_coord, std::ios::binary);
+        std::ofstream out_coord = utils::open_new_ofstream(fpath_coord);
 
         for (size_t j = 0; j < label_encoders[l_idx].size(); ++j) {
             // diff values may be negative, hence we need wider integers

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -83,8 +83,8 @@ void load_coordinates(const std::vector<std::string> &source_files,
         const auto &coords_fname = utils::remove_suffix(source_files[i],
                                                         ColumnCompressed<>::kExtension)
                                         + ColumnCompressed<>::kCoordExtension;
-        std::ifstream in(coords_fname, std::ios::binary);
-        if (!in) {
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(coords_fname, utils::with_mmap());
+        if (!*in) {
             logger->error("Could not open file with coordinates {}", coords_fname);
             exit(1);
         }
@@ -93,8 +93,8 @@ void load_coordinates(const std::vector<std::string> &source_files,
         bit_vector_smart delims;
         for (size_t j = 0; j < sources[i].num_labels(); ++j) {
             try {
-                delims.load(in);
-                coords.load(in);
+                delims.load(*in);
+                coords.load(*in);
             } catch (...) {
                 logger->error("Couldn't read coordinates from {}", coords_fname);
                 exit(1);
@@ -484,8 +484,8 @@ void assign_anchors(const std::string &graph_fname,
     {
         rd_succ_bv_type rd_succ;
         const std::string &rd_succ_fname = outfbase + kRowDiffForkSuccExt;
-        std::ifstream f(rd_succ_fname, ios::binary);
-        if (!rd_succ.load(f)) {
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(rd_succ_fname, utils::with_mmap());
+        if (!rd_succ.load(*in)) {
             logger->error("Couldn't load row-diff successor bitmap from {}", rd_succ_fname);
             exit(1);
         }
@@ -766,8 +766,8 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
             const auto &values_fname = utils::remove_suffix(source_files[i],
                                                             ColumnCompressed<>::kExtension)
                                             + ColumnCompressed<>::kCountExtension;
-            std::ifstream instream(values_fname, std::ios::binary);
-            if (!instream) {
+            std::unique_ptr<std::ifstream> in = utils::open_ifstream(values_fname, utils::with_mmap());
+            if (!*in) {
                 logger->error("Could not open file with column values {}", values_fname);
                 exit(1);
             }
@@ -775,7 +775,7 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
             values[i].resize(sources[i].num_labels());
             for (size_t j = 0; j < values[i].size(); ++j) {
                 try {
-                    values[i][j].load(instream);
+                    values[i][j].load(*in);
                 } catch (...) {
                     logger->error("Couldn't read column values from {}", values_fname);
                     exit(1);
@@ -788,8 +788,8 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
     anchor_bv_type anchor;
     if (!compute_row_reduction) {
         const std::string anchors_fname = pred_succ_fprefix + kRowDiffAnchorExt;
-        std::ifstream f(anchors_fname, std::ios::binary);
-        if (!anchor.load(f)) {
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(anchors_fname, utils::with_mmap());
+        if (!anchor.load(*in)) {
             logger->error("Can't load anchors from {}", anchors_fname);
             exit(1);
         }
@@ -1254,8 +1254,8 @@ void convert_batch_to_row_diff_coord(const std::string &pred_succ_fprefix,
 
     anchor_bv_type anchor;
     const std::string anchors_fname = pred_succ_fprefix + kRowDiffAnchorExt;
-    std::ifstream f(anchors_fname, std::ios::binary);
-    if (!anchor.load(f)) {
+    std::unique_ptr<std::ifstream> in = utils::open_ifstream(anchors_fname, utils::with_mmap());
+    if (!anchor.load(*in)) {
         logger->error("Can't load anchors from {}", anchors_fname);
         exit(1);
     }

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -115,6 +115,8 @@ Config::Config(int argc, char *argv[]) {
     for (int i = 2; i < argc; ++i) {
         if (!strcmp(argv[i], "-v") || !strcmp(argv[i], "--verbose")) {
             common::set_verbose(true);
+        } else if (!strcmp(argv[i], "--mmap")) {
+            utils::with_mmap(true);
         } else if (!strcmp(argv[i], "--print")) {
             print_graph = true;
         } else if (!strcmp(argv[i], "--advanced")) {
@@ -1380,6 +1382,7 @@ if (advanced) {
     }
 
     fprintf(stderr, "\nGeneral options:\n");
+    fprintf(stderr, "\t   --mmap \t\tuse memory mapping when loading to reduce RAM [off]\n");
     fprintf(stderr, "\t-v --verbose \t\tswitch on verbose output [off]\n");
     fprintf(stderr, "\t   --advanced \t\tshow other advanced and legacy options [off]\n");
     fprintf(stderr, "\t-h --help \t\tprint usage info\n");

--- a/metagraph/src/cli/stats.cpp
+++ b/metagraph/src/cli/stats.cpp
@@ -355,7 +355,7 @@ int print_stats(Config *config) {
             try {
                 std::ifstream instream(file, std::ios::binary);
 
-                // TODO: make this more reliable
+                // TODO: make this more reliable: add load_label_encoder to all annotators
                 if (parse_annotation_type(file) == Config::ColumnCompressed) {
                     // Column compressed dumps the number of rows first
                     // skipping it...

--- a/metagraph/src/cli/stats.cpp
+++ b/metagraph/src/cli/stats.cpp
@@ -355,7 +355,7 @@ int print_stats(Config *config) {
             try {
                 std::ifstream instream(file, std::ios::binary);
 
-                // TODO: make this more reliable: add load_label_encoder to all annotators
+                // TODO: make this more reliable
                 if (parse_annotation_type(file) == Config::ColumnCompressed) {
                     // Column compressed dumps the number of rows first
                     // skipping it...

--- a/metagraph/src/cli/transform_annotation.cpp
+++ b/metagraph/src/cli/transform_annotation.cpp
@@ -533,8 +533,8 @@ int transform_annotation(Config *config) {
         sdsl::util::bit_compress(sum);
 
         auto outfname = utils::remove_suffix(config->outfbase, ColumnCompressed<>::kExtension);
-        std::ofstream out_counts(outfname + ColumnCompressed<>::kCountExtension,
-                                 std::ios::binary);
+        std::ofstream out_counts
+                = utils::open_new_ofstream(outfname + ColumnCompressed<>::kCountExtension);
         sum.serialize(out_counts);
         sum = sdsl::int_vector<>();
 

--- a/metagraph/src/cli/transform_annotation.cpp
+++ b/metagraph/src/cli/transform_annotation.cpp
@@ -145,6 +145,7 @@ uint64_t get_num_columns(const std::vector<std::string> &files,
     #pragma omp parallel for num_threads(get_num_threads()) schedule(dynamic)
     for (size_t i = 0; i < files.size(); ++i) {
         std::string file = utils::make_suffix(files[i], extension);
+        // TODO: call load_label_encoder
         std::ifstream instream(file, std::ios::binary);
         if (!instream.good()) {
             logger->error("Can't read from {}", file);

--- a/metagraph/src/cli/transform_graph.cpp
+++ b/metagraph/src/cli/transform_graph.cpp
@@ -4,6 +4,7 @@
 
 #include "common/logger.hpp"
 #include "common/unix_tools.hpp"
+#include "common/utils/file_utils.hpp"
 #include "common/threads/threading.hpp"
 #include "graph/representation/succinct/dbg_succinct.hpp"
 #include "graph/graph_extensions/node_rc.hpp"
@@ -71,11 +72,11 @@ int transform_graph(Config *config) {
         assert(dbg_succ->get_bloom_filter());
 
         auto fname = utils::make_suffix(config->outfbase, dbg_succ->bloom_filter_file_extension());
-        std::ofstream bloom_outstream(fname, std::ios::binary);
-        if (!bloom_outstream)
+        std::ofstream bloom_out = utils::open_new_ofstream(fname);
+        if (!bloom_out)
             throw std::ios_base::failure("Can't write to file " + fname);
 
-        dbg_succ->get_bloom_filter()->serialize(bloom_outstream);
+        dbg_succ->get_bloom_filter()->serialize(bloom_out);
 
         return 0;
     }

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -28,7 +28,6 @@ static bool WITH_MMAP = false;
 
 bool with_mmap(bool set_bit) {
     if (set_bit) {
-        logger->trace("Memory mapping enabled");
         WITH_MMAP = true;
     }
     return WITH_MMAP;

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -12,6 +12,8 @@
 #include <stdio.h>
 #endif
 
+#include <sdsl/memory_management.hpp>
+
 #include "common/logger.hpp"
 
 namespace utils {
@@ -21,6 +23,27 @@ using mtg::common::logger;
 std::filesystem::path SWAP_PATH;
 std::vector<std::string> TMP_DIRS;
 std::mutex TMP_DIRS_MUTEX;
+
+static bool WITH_MMAP = false;
+
+bool with_mmap(bool set_bit) {
+    if (set_bit) {
+        logger->trace("Enabled memory mapping");
+        WITH_MMAP = true;
+    }
+    return WITH_MMAP;
+}
+
+std::unique_ptr<std::ifstream>
+open_ifstream(const std::string &filename, bool mmap_stream) {
+    std::unique_ptr<std::ifstream> in;
+    if (mmap_stream) {
+        in.reset(new sdsl::mmap_ifstream(filename, std::ios_base::binary));
+    } else {
+        in.reset(new std::ifstream(filename, std::ios_base::binary));
+    }
+    return in;
+}
 
 void set_swap_path(std::filesystem::path dir_path) {
     SWAP_PATH = dir_path;

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -34,8 +34,7 @@ bool with_mmap(bool set_bit) {
     return WITH_MMAP;
 }
 
-std::unique_ptr<std::ifstream>
-open_ifstream(const std::string &filename, bool mmap_stream) {
+std::unique_ptr<std::ifstream> open_ifstream(const std::string &filename, bool mmap_stream) {
     std::unique_ptr<std::ifstream> in;
     if (mmap_stream) {
         in.reset(new sdsl::mmap_ifstream(filename, std::ios_base::binary));

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -28,10 +28,7 @@ static bool WITH_MMAP = false;
 
 bool with_mmap(bool set_bit) {
     if (set_bit) {
-        // TODO: is there a good way to check this, like when opening outstreams?
-        // It could be logger->info() but that prints to stdout. Print info() to stderr?
-        logger->warn("Memory mapping enabled. Make sure all output files are"
-                     " different from the input to avoid errors.");
+        logger->trace("Memory mapping enabled");
         WITH_MMAP = true;
     }
     return WITH_MMAP;
@@ -46,6 +43,14 @@ open_ifstream(const std::string &filename, bool mmap_stream) {
         in.reset(new std::ifstream(filename, std::ios_base::binary));
     }
     return in;
+}
+
+std::ofstream open_new_ofstream(const std::string &filename) {
+    // If file already exists, remove it.
+    // This ensures that if that old file was open for reading (e.g., memory mapped),
+    // the readers can keep reading it and the new out stream points to a new inode.
+    std::filesystem::remove(filename);
+    return std::ofstream(filename, std::ios_base::binary);
 }
 
 void set_swap_path(std::filesystem::path dir_path) {

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -28,7 +28,9 @@ static bool WITH_MMAP = false;
 
 bool with_mmap(bool set_bit) {
     if (set_bit) {
-        logger->trace("Enabled memory mapping");
+        // TODO: is there a good way to check this, like when opening outstreams?
+        logger->info("Memory mapping enabled. Make sure all output files are"
+                     " different from the input to avoid errors.");
         WITH_MMAP = true;
     }
     return WITH_MMAP;

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -29,7 +29,8 @@ static bool WITH_MMAP = false;
 bool with_mmap(bool set_bit) {
     if (set_bit) {
         // TODO: is there a good way to check this, like when opening outstreams?
-        logger->info("Memory mapping enabled. Make sure all output files are"
+        // It could be logger->info() but that prints to stdout. Print info() to stderr?
+        logger->warn("Memory mapping enabled. Make sure all output files are"
                      " different from the input to avoid errors.");
         WITH_MMAP = true;
     }

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -28,6 +28,10 @@ bool with_mmap(bool set_bit = false);
 std::unique_ptr<std::ifstream>
 open_ifstream(const std::string &filename, bool mmap_stream = false);
 
+// Always create a new physical file to avoid overwriting the existing one if
+// such exists, so that all readers (including mmap) can keep reading from it.
+std::ofstream open_new_ofstream(const std::string &filename);
+
 class TempFile {
   public:
     // The state flow:

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -111,18 +111,6 @@ class BufferedAsyncWriter {
     std::ofstream *fos_;
 };
 
-
-class NamedIfstream : public std::ifstream {
-  public:
-    NamedIfstream(const std::string &fname, std::ios_base::openmode mode)
-        : std::ifstream(fname, mode), fname_(fname) {}
-
-    const std::string& get_name() const { return fname_; }
-
-  private:
-    std::string fname_;
-};
-
 } // namespace utils
 
 #endif // __FILE_UTILS_HPP__

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -22,6 +22,11 @@ void remove_temp_dir(std::filesystem::path dir_name);
 
 bool check_if_writable(const std::string &filename);
 
+// Call with_mmap() to check and with_mmap(true) to set. Off by default.
+bool with_mmap(bool set_bit = false);
+
+std::unique_ptr<std::ifstream>
+open_ifstream(const std::string &filename, bool mmap_stream = false);
 
 class TempFile {
   public:

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -26,7 +26,7 @@ bool check_if_writable(const std::string &filename);
 bool with_mmap(bool set_bit = false);
 
 std::unique_ptr<std::ifstream>
-open_ifstream(const std::string &filename, bool mmap_stream = false);
+open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
 
 // Always create a new physical file to avoid overwriting the existing one if
 // such exists, so that all readers (including mmap) can keep reading from it.

--- a/metagraph/src/common/vectors/vector_algorithm.hpp
+++ b/metagraph/src/common/vectors/vector_algorithm.hpp
@@ -833,6 +833,7 @@ aligned_int_vector(size_t size, uint64_t val, uint8_t width, size_t alignment) {
         typename sdsl::int_vector<t_width>::size_type m_size;
         uint64_t *m_data;
         typename sdsl::int_vector<t_width>::int_width_type m_width;
+        std::shared_ptr<sdsl::mmap_context> m_mmap_context;
     };
     static_assert(sizeof(sdsl::int_vector<t_width>) == sizeof(int_vector_access));
     assert(!t_width || t_width == width);

--- a/metagraph/src/graph/graph_extensions/node_rc.cpp
+++ b/metagraph/src/graph/graph_extensions/node_rc.cpp
@@ -7,6 +7,7 @@
 #include "graph/representation/succinct/dbg_succinct.hpp"
 #include "common/seq_tools/reverse_complement.hpp"
 #include "common/utils/template_utils.hpp"
+#include "common/utils/file_utils.hpp"
 
 namespace mtg {
 namespace graph {
@@ -217,12 +218,13 @@ void NodeRC::call_incoming_from_rc(node_index node,
 bool NodeRC::load(const std::string &filename_base) {
     const auto rc_filename = utils::make_suffix(filename_base, kRCExtension);
     try {
-        std::ifstream instream(rc_filename, std::ios::binary);
-        if (!instream.good())
+        std::unique_ptr<std::ifstream> in
+                = utils::open_ifstream(rc_filename, utils::with_mmap());
+        if (!in->good())
             return false;
 
-        rc_.load(instream);
-        mapping_.load(instream);
+        rc_.load(*in);
+        mapping_.load(*in);
         return true;
 
     } catch (...) {

--- a/metagraph/src/graph/graph_extensions/node_rc.cpp
+++ b/metagraph/src/graph/graph_extensions/node_rc.cpp
@@ -238,9 +238,9 @@ void NodeRC::serialize(const std::string &filename_base) const {
 
     const auto fname = utils::make_suffix(filename_base, kRCExtension);
 
-    std::ofstream outstream(fname, std::ios::binary);
-    rc_.serialize(outstream);
-    mapping_.serialize(outstream);
+    std::ofstream out = utils::open_new_ofstream(fname);
+    rc_.serialize(out);
+    mapping_.serialize(out);
 }
 
 bool NodeRC::is_compatible(const SequenceGraph &graph, bool) const {

--- a/metagraph/src/graph/graph_extensions/node_rc.cpp
+++ b/metagraph/src/graph/graph_extensions/node_rc.cpp
@@ -218,8 +218,7 @@ void NodeRC::call_incoming_from_rc(node_index node,
 bool NodeRC::load(const std::string &filename_base) {
     const auto rc_filename = utils::make_suffix(filename_base, kRCExtension);
     try {
-        std::unique_ptr<std::ifstream> in
-                = utils::open_ifstream(rc_filename, utils::with_mmap());
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(rc_filename);
         if (!in->good())
             return false;
 

--- a/metagraph/src/graph/graph_extensions/node_weights.cpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.cpp
@@ -37,8 +37,7 @@ bool NodeWeights::NodeWeights::load(const std::string &filename_base) {
     const auto weights_filename
             = utils::make_suffix(filename_base, kWeightsExtension);
     try {
-        std::unique_ptr<std::ifstream> in
-                = utils::open_ifstream(weights_filename, utils::with_mmap());
+        std::unique_ptr<std::ifstream> in = utils::open_ifstream(weights_filename);
         if (!in->good())
             return false;
 

--- a/metagraph/src/graph/graph_extensions/node_weights.cpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.cpp
@@ -3,7 +3,7 @@
 #include <filesystem>
 
 #include "common/algorithms.hpp"
-
+#include "common/utils/file_utils.hpp"
 
 namespace mtg {
 namespace graph {
@@ -37,11 +37,12 @@ bool NodeWeights::NodeWeights::load(const std::string &filename_base) {
     const auto weights_filename
             = utils::make_suffix(filename_base, kWeightsExtension);
     try {
-        std::ifstream instream(weights_filename, std::ios::binary);
-        if (!instream.good())
+        std::unique_ptr<std::ifstream> in
+                = utils::open_ifstream(weights_filename, utils::with_mmap());
+        if (!in->good())
             return false;
 
-        weights_.load(instream);
+        weights_.load(*in);
         max_weight_ = sdsl::bits::lo_set[weights_.width()];
         return true;
 

--- a/metagraph/src/graph/graph_extensions/node_weights.cpp
+++ b/metagraph/src/graph/graph_extensions/node_weights.cpp
@@ -56,8 +56,8 @@ bool NodeWeights::NodeWeights::load(const std::string &filename_base) {
 void NodeWeights::serialize(const std::string &filename_base) const {
     const auto fname = utils::make_suffix(filename_base, kWeightsExtension);
 
-    std::ofstream outstream(fname, std::ios::binary);
-    weights_.serialize(outstream);
+    std::ofstream out = utils::open_new_ofstream(fname);
+    weights_.serialize(out);
 }
 
 void NodeWeights::serialize(sdsl::int_vector_buffer<>&& weights,

--- a/metagraph/src/graph/representation/bitmap/dbg_bitmap.cpp
+++ b/metagraph/src/graph/representation/bitmap/dbg_bitmap.cpp
@@ -4,6 +4,7 @@
 #include <fstream>
 
 #include "common/serialization.hpp"
+#include "common/utils/file_utils.hpp"
 #include "dbg_bitmap_construct.hpp"
 
 
@@ -302,8 +303,9 @@ bool DBGBitmap::load(std::istream &in) {
 }
 
 bool DBGBitmap::load(const std::string &filename) {
-    std::ifstream in(utils::make_suffix(filename, kExtension), std::ios::binary);
-    return load(in);
+    std::unique_ptr<std::ifstream> in
+            = utils::open_ifstream(utils::make_suffix(filename, kExtension), utils::with_mmap());
+    return load(*in);
 }
 
 Vector<std::pair<DBGBitmap::Kmer, bool>>

--- a/metagraph/src/graph/representation/bitmap/dbg_bitmap.cpp
+++ b/metagraph/src/graph/representation/bitmap/dbg_bitmap.cpp
@@ -304,7 +304,7 @@ bool DBGBitmap::load(std::istream &in) {
 
 bool DBGBitmap::load(const std::string &filename) {
     std::unique_ptr<std::ifstream> in
-            = utils::open_ifstream(utils::make_suffix(filename, kExtension), utils::with_mmap());
+            = utils::open_ifstream(utils::make_suffix(filename, kExtension));
     return load(*in);
 }
 

--- a/metagraph/src/graph/representation/bitmap/dbg_bitmap.cpp
+++ b/metagraph/src/graph/representation/bitmap/dbg_bitmap.cpp
@@ -265,7 +265,7 @@ void DBGBitmap::serialize(std::ostream &out) const {
 }
 
 void DBGBitmap::serialize(const std::string &filename) const {
-    std::ofstream out(utils::make_suffix(filename, kExtension), std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(utils::make_suffix(filename, kExtension));
     serialize(out);
 }
 

--- a/metagraph/src/graph/representation/bitmap/dbg_bitmap_construct.cpp
+++ b/metagraph/src/graph/representation/bitmap/dbg_bitmap_construct.cpp
@@ -210,10 +210,7 @@ DBGBitmap* DBGBitmapConstructor
 
     size_t chunk_idx = 0;
 
-    //TODO configure stream for verbose output globally and refactor
-    std::ofstream null_ofstream;
-    ProgressBar progress_bar(chunk_filenames.size(), "Processing chunks",
-                             verbose ? std::cout : null_ofstream);
+    ProgressBar progress_bar(chunk_filenames.size(), "Processing chunks", std::cout, !verbose);
 
     return build_graph_from_chunks(
         size,

--- a/metagraph/src/graph/representation/bitmap/dbg_bitmap_construct.cpp
+++ b/metagraph/src/graph/representation/bitmap/dbg_bitmap_construct.cpp
@@ -190,8 +190,7 @@ DBGBitmap* DBGBitmapConstructor
         const auto &chunk_filename = chunk_filenames.at(i);
         DBGBitmap::Chunk chunk;
 
-        std::unique_ptr<std::ifstream> chunk_in
-                = utils::open_ifstream(chunk_filename, utils::with_mmap());
+        std::unique_ptr<std::ifstream> chunk_in = utils::open_ifstream(chunk_filename);
         chunk.load(*chunk_in);
 
         if (!i) {
@@ -222,8 +221,7 @@ DBGBitmap* DBGBitmapConstructor
             auto chunk_filename = utils::make_suffix(chunk_filenames.at(chunk_idx),
                                                      DBGBitmap::kChunkFileExtension);
 
-            std::unique_ptr<std::ifstream> chunk_in
-                    = utils::open_ifstream(chunk_filename, utils::with_mmap());
+            std::unique_ptr<std::ifstream> chunk_in = utils::open_ifstream(chunk_filename);
 
             if (!chunk_in->good()) {
                 logger->error("Input file {} corrupted", chunk_filename);

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -230,16 +230,6 @@ bool BOSS::operator==(const BOSS &other) const {
     return i == W_->size() && j == other.W_->size();
 }
 
-void BOSS::serialize(const std::string &filename) const {
-    const auto out_filename = utils::make_suffix(filename, kExtension);
-
-    std::ofstream outstream(out_filename, std::ios::binary);
-    if (!outstream.good())
-        throw std::ofstream::failure("Error: Can't write to file " + out_filename);
-
-    serialize(outstream);
-}
-
 void BOSS::serialize(std::ofstream &outstream) const {
     if (!outstream.good())
         throw std::ofstream::failure("Error: Can't write to file");
@@ -303,14 +293,6 @@ void BOSS::serialize(Chunk&& chunk, std::ofstream &out, State state) {
     }
 
     out.flush();
-}
-
-bool BOSS::load(const std::string &filename) {
-    auto file = utils::make_suffix(filename, kExtension);
-
-    std::ifstream instream(file, std::ios::binary);
-
-    return load(instream);
 }
 
 bool BOSS::load(std::ifstream &instream) {
@@ -383,7 +365,7 @@ bool BOSS::load_suffix_ranges(std::ifstream &instream) {
         indexed_suffix_length_ = load_number(instream);
         if (indexed_suffix_length_ > k_
                 || indexed_suffix_length_ * log2(alph_size - 1) > 63)
-            throw std::ifstream::failure("");
+            throw std::ifstream::failure("bad index of suffix ranges");
 
         indexed_suffix_ranges_.load(instream);
         indexed_suffix_ranges_rk1_ = decltype(indexed_suffix_ranges_rk1_)(&indexed_suffix_ranges_);
@@ -391,7 +373,7 @@ bool BOSS::load_suffix_ranges(std::ifstream &instream) {
         indexed_suffix_ranges_slct0_ = decltype(indexed_suffix_ranges_slct0_)(&indexed_suffix_ranges_);
 
         if (!instream.good())
-            throw std::ifstream::failure("");
+            throw std::ifstream::failure("couldn't read index of suffix ranges");
 
         return true;
 

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -68,9 +68,6 @@ class BOSS {
     uint64_t num_nodes() const;
     uint64_t num_edges() const;
 
-    bool load(const std::string &filename_base);
-    void serialize(const std::string &filename_base) const;
-
     bool load(std::ifstream &instream);
     void serialize(std::ofstream &outstream) const;
 
@@ -502,9 +499,6 @@ class BOSS {
     static constexpr size_t kSentinel = '$';
 
   private:
-    // file dump extension
-    static constexpr auto kExtension = ".dbg";
-
     const mtg::kmer::KmerExtractorBOSS kmer_extractor_;
     const size_t bits_per_char_W_;
 

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -671,7 +671,6 @@ bool DBGSuccinct::load(const std::string &filename) {
     auto prefix = utils::remove_suffix(filename, kExtension);
 
     std::unique_ptr<std::ifstream> in = utils::open_ifstream(prefix + kDummyMaskExtension);
-
     if (!in->good())
         return true;
 
@@ -708,7 +707,6 @@ bool DBGSuccinct::load(const std::string &filename) {
 
     if (std::filesystem::exists(prefix + kBloomFilterExtension)) {
         std::unique_ptr<std::ifstream> bloom_in = utils::open_ifstream(prefix + kBloomFilterExtension);
-
         if (!bloom_filter_)
             bloom_filter_ = std::make_unique<kmer::KmerBloomFilter<>>(get_k(), mode_ == CANONICAL);
 

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -750,7 +750,7 @@ void DBGSuccinct::serialize(const std::string &filename) const {
 
     {
         const std::string out_filename = prefix + kExtension;
-        std::ofstream out(out_filename, std::ios::binary);
+        std::ofstream out = utils::open_new_ofstream(out_filename);
         boss_graph_->serialize(out);
         serialize_number(out, static_cast<int>(mode_));
 
@@ -773,14 +773,14 @@ void DBGSuccinct::serialize(const std::string &filename) const {
                 && dynamic_cast<const bit_vector_small*>(valid_edges_.get())));
 
     const auto out_filename = prefix + kDummyMaskExtension;
-    std::ofstream out(out_filename, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(out_filename);
     if (!out.good())
         throw std::ios_base::failure("Can't write to file " + out_filename);
 
     valid_edges_->serialize(out);
 
     if (bloom_filter_) {
-        std::ofstream bloom_out(prefix + kBloomFilterExtension, std::ios::binary);
+        std::ofstream bloom_out = utils::open_new_ofstream(prefix + kBloomFilterExtension);
         if (!bloom_out.good())
             throw std::ios_base::failure("Can't write to file " + prefix + kBloomFilterExtension);
 
@@ -797,7 +797,7 @@ void DBGSuccinct::serialize(boss::BOSS::Chunk&& chunk,
     std::filesystem::remove(prefix + kDummyMaskExtension);
 
     const std::string &fname = prefix + kExtension;
-    std::ofstream out(fname, std::ios::binary);
+    std::ofstream out = utils::open_new_ofstream(fname);
     boss::BOSS::serialize(std::move(chunk), out, state);
     serialize_number(out, static_cast<int>(mode));
     serialize_number(out, 0); // suffix ranges are not indexed

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -650,7 +650,7 @@ bool DBGSuccinct::load_without_mask(const std::string &filename) {
 
     {
         std::unique_ptr<std::ifstream> in
-            = utils::open_ifstream(utils::make_suffix(filename, kExtension), utils::with_mmap());
+            = utils::open_ifstream(utils::make_suffix(filename, kExtension));
 
         if (!boss_graph_->load(*in))
             return false;
@@ -670,8 +670,7 @@ bool DBGSuccinct::load(const std::string &filename) {
 
     auto prefix = utils::remove_suffix(filename, kExtension);
 
-    std::unique_ptr<std::ifstream> in
-        = utils::open_ifstream(prefix + kDummyMaskExtension, utils::with_mmap());
+    std::unique_ptr<std::ifstream> in = utils::open_ifstream(prefix + kDummyMaskExtension);
 
     if (!in->good())
         return true;
@@ -708,8 +707,7 @@ bool DBGSuccinct::load(const std::string &filename) {
     }
 
     if (std::filesystem::exists(prefix + kBloomFilterExtension)) {
-        std::unique_ptr<std::ifstream> bloom_in
-            = utils::open_ifstream(prefix + kBloomFilterExtension, utils::with_mmap());
+        std::unique_ptr<std::ifstream> bloom_in = utils::open_ifstream(prefix + kBloomFilterExtension);
 
         if (!bloom_filter_)
             bloom_filter_ = std::make_unique<kmer::KmerBloomFilter<>>(get_k(), mode_ == CANONICAL);

--- a/metagraph/tests/annotation/test_annotation_row.cpp
+++ b/metagraph/tests/annotation/test_annotation_row.cpp
@@ -19,7 +19,7 @@ const std::string test_dump_basename_vec_bad = test_dump_basename + "_bad_filena
 const std::string test_dump_basename_vec_good = test_dump_basename + "_row_compressed";
 
 
-TEST(RowCompressed, load_label_encoder) {
+TEST(RowCompressed, read_label_encoder) {
     {
         RowCompressed<> annotation(5, false);
         annotation.set(0, { "Label0", "Label2", "Label8" });
@@ -29,13 +29,12 @@ TEST(RowCompressed, load_label_encoder) {
         annotation.serialize(test_dump_basename_vec_good);
     }
     {
-        auto label_encoder = RowCompressed<>::load_label_encoder(test_dump_basename_vec_good);
-        ASSERT_TRUE(label_encoder.get());
-        EXPECT_EQ(4u, label_encoder->size());
+        auto label_encoder = RowCompressed<>::read_label_encoder(test_dump_basename_vec_good);
+        EXPECT_EQ(4u, label_encoder.size());
     }
 }
 
-TEST(RowCompressed, load_shape) {
+TEST(RowCompressed, read_shape) {
     {
         RowCompressed<> annotation(5, false);
         annotation.set(0, { "Label0", "Label2", "Label8" });
@@ -46,14 +45,13 @@ TEST(RowCompressed, load_shape) {
     }
     {
         uint64_t num_rows, num_relations;
-        RowCompressed<>::load_shape(test_dump_basename_vec_good,
-                                              &num_rows, &num_relations);
+        RowCompressed<>::read_shape(test_dump_basename_vec_good, &num_rows, &num_relations);
         ASSERT_EQ(5u, num_rows);
         ASSERT_EQ(6u, num_relations);
     }
 }
 
-TEST(RowCompressed, load_label_encoder_and_load_shape) {
+TEST(RowCompressed, read_label_encoder_and_read_shape) {
     {
         RowCompressed<> annotation(5, false);
         annotation.set(0, { "Label0", "Label2", "Label8" });
@@ -64,19 +62,15 @@ TEST(RowCompressed, load_label_encoder_and_load_shape) {
     }
     {
         uint64_t num_rows, num_relations;
-        auto label_encoder = RowCompressed<>::load_label_encoder(
-            test_dump_basename_vec_good
-        );
-        RowCompressed<>::load_shape(test_dump_basename_vec_good,
-                                              &num_rows, &num_relations);
+        auto label_encoder = RowCompressed<>::read_label_encoder(test_dump_basename_vec_good);
+        RowCompressed<>::read_shape(test_dump_basename_vec_good, &num_rows, &num_relations);
         ASSERT_EQ(5u, num_rows);
         ASSERT_EQ(6u, num_relations);
-        ASSERT_TRUE(label_encoder.get());
-        EXPECT_EQ(4u, label_encoder->size());
+        EXPECT_EQ(4u, label_encoder.size());
     }
 }
 
-TEST(RowCompressed, load_shape_and_load_label_encoder) {
+TEST(RowCompressed, read_shape_and_read_label_encoder) {
     {
         RowCompressed<> annotation(5, false);
         annotation.set(0, { "Label0", "Label2", "Label8" });
@@ -87,15 +81,11 @@ TEST(RowCompressed, load_shape_and_load_label_encoder) {
     }
     {
         uint64_t num_rows, num_relations;
-        RowCompressed<>::load_shape(test_dump_basename_vec_good,
-                                              &num_rows, &num_relations);
-        auto label_encoder = RowCompressed<>::load_label_encoder(
-            test_dump_basename_vec_good
-        );
+        RowCompressed<>::read_shape(test_dump_basename_vec_good, &num_rows, &num_relations);
+        auto label_encoder = RowCompressed<>::read_label_encoder(test_dump_basename_vec_good);
         ASSERT_EQ(5u, num_rows);
         ASSERT_EQ(6u, num_relations);
-        ASSERT_TRUE(label_encoder.get());
-        EXPECT_EQ(4u, label_encoder->size());
+        EXPECT_EQ(4u, label_encoder.size());
     }
 }
 
@@ -106,15 +96,12 @@ TEST(RowCompressed, SerializationExtension) {
         annotation.set(2, { "Label1", "Label2" });
         annotation.set(4, { "Label8" });
 
-        annotation.serialize(test_dump_basename_vec_good
-                                        + annotation.file_extension());
+        annotation.serialize(test_dump_basename_vec_good + annotation.file_extension());
     }
     {
         RowCompressed<> annotation(5, false);
-        ASSERT_FALSE(annotation.load(test_dump_basename_vec_bad
-                                        + annotation.file_extension()));
-        ASSERT_TRUE(annotation.load(test_dump_basename_vec_good
-                                        + annotation.file_extension()));
+        ASSERT_FALSE(annotation.load(test_dump_basename_vec_bad + annotation.file_extension()));
+        ASSERT_TRUE(annotation.load(test_dump_basename_vec_good + annotation.file_extension()));
 
         EXPECT_EQ(convert_to_set({ "Label0", "Label2", "Label8" }),
                   convert_to_set(annotation.get(0)));

--- a/metagraph/tests/graph/succinct/test_boss.cpp
+++ b/metagraph/tests/graph/succinct/test_boss.cpp
@@ -233,10 +233,13 @@ TEST(BOSS, Serialization) {
 
     BOSS *graph = new BOSS(&constructor);
 
-    graph->serialize(test_dump_basename);
+    std::ofstream out(test_dump_basename + ".boss", std::ios::binary);
+    graph->serialize(out);
+    out.close();
 
     BOSS loaded_graph;
-    ASSERT_TRUE(loaded_graph.load(test_dump_basename)) << "Can't load the graph";
+    std::ifstream in(test_dump_basename + ".boss", std::ios::binary);
+    ASSERT_TRUE(loaded_graph.load(in)) << "Can't load the graph";
     EXPECT_EQ(*graph, loaded_graph) << "Loaded graph differs";
     EXPECT_FALSE(BOSS() == loaded_graph);
 


### PR DESCRIPTION
Added support for loading `sdsl::int_vector<*>` with memory mapping. So practically all bit/int-vectors and other data structures in metagraph become memory mapped, including the main graph representations as well as almost all annotation representations.

OFF by default. To turn on, add the `--mmap` flag.