### PR TITLE
Cleaner flags for setting query regime

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Requires `M*V/8 + Size(BRWT)` bytes of RAM, where `M` is the number of rows in t
 ```bash
 ./metagraph query -v -i <GRAPH_DIR>/graph.dbg \
                         -a <GRAPH_DIR>/annotation.column.annodbg \
-                        --discovery-fraction 0.8 --labels-delimiter ", " \
+                        --min-kmers-fraction-label 0.8 --labels-delimiter ", " \
                         query_seq.fa
 ```
 

--- a/metagraph/docs/source/conf.py
+++ b/metagraph/docs/source/conf.py
@@ -60,7 +60,7 @@ master_doc = 'index'
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -604,7 +604,7 @@ To query a MetaGraph index (graph + annotation) using the command line interface
 
     metagraph query -i graph.dbg \
                     -a annotation.column.annodbg \
-                    --discovery-fraction 0.1 \
+                    --min-kmers-fraction-label 0.1 \
                     transcripts_1000.fa
 
 For alignment, see ``metagraph align``.

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -457,6 +457,7 @@ compression performance and the complexity of the construction algorithm.
 In contrast, ``RowDiff<Multi-BRWT>`` typically achieves
 the best compression while still providing a good query performance, and thus, it is
 recommended for very large problem instances.
+Finally, ``RowDiff<RowSparse>`` provides a good trade-off between the query speed and compression performance.
 
 Convert annotation to Rainbowfish
 """""""""""""""""""""""""""""""""
@@ -537,6 +538,7 @@ The conversion to ``RowDiff<Multi-BRWT>`` is done in two steps.
 2.  Transform the diff-transformed columns ``*.row_diff.annodbg`` to ``Multi-BRWT``::
 
         find . -name "*.row_diff.annodbg" | metagraph transform_anno -v -p 18 \
+                                                        -i graph.dbg \
                                                         --anno-type row_diff_brwt \
                                                         --greedy ...
         metagraph relax_brwt -v -p 18 \
@@ -545,6 +547,19 @@ The conversion to ``RowDiff<Multi-BRWT>`` is done in two steps.
                              annotation.row_diff_brwt.annodbg
 
     Also see the above paragraph :ref:`to_multi_brwt` for other options.
+
+
+.. _to_row_diff_sparse:
+
+Convert annotation to RowDiff<RowSparse>
+"""""""""""""""""""""""""""""""""""""""""
+The conversion to ``RowDiff<RowSparse>`` is similar to :ref:`to_row_diff_brwt`. The first step is the same.
+In the second step, the diff-transformed columns ``*.row_diff.annodbg`` are converted to ``RowSparse``::
+
+        find . -name "*.row_diff.annodbg" | metagraph transform_anno -v -p 18 \
+                                                        -i graph.dbg \
+                                                        --anno-type row_diff_sparse
+
 
 .. _transform_count_annotations:
 

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -400,9 +400,9 @@ For more details, see section :ref:`transform_count_annotations`.
 
 Once the annotation is transformed, k-mer abundances can be queried with::
 
-    metagraph query --query-counts ...
+    metagraph query --query-mode counts ...
 
-Note that if flag ``--query-counts`` is not passed, the index will be queried in the default k-mer presence/absence regime.
+Note that if flag ``--query-mode counts`` is not passed, the index will be queried in the default k-mer presence/absence regime.
 
 
 .. _indexing coordinates:
@@ -438,10 +438,10 @@ Query k-mer coordinates
 Once a coordinate-aware annotation is constructed, it can be transformed into a more memory-efficient representation supporting
 querying (see :ref:`transform_coord_annotations` below) and then queried with::
 
-    metagraph query --query-coords ...
+    metagraph query --query-mode coords ...
 
-As the coordinate-aware annotations also contain the information about k-mer abundance, they can be queried to retrieve k-mer counts (simply pass ``--query-counts`` instead of ``--query-coords``).
-Note that if neither ``--query-coords`` nor ``--query-counts`` is passed, the index will be queried in the default k-mer presence/absence regime.
+As the coordinate-aware annotations also contain the information about k-mer abundance, they can be queried to retrieve k-mer counts (simply pass ``--query-mode counts`` instead of ``--query-mode coords``).
+Note that if neither ``--query-mode coords`` nor ``--query-mode counts`` is passed, the index will be queried in the default k-mer presence/absence regime.
 
 .. _transform annotation:
 
@@ -589,7 +589,6 @@ To query a MetaGraph index (graph + annotation) using the command line interface
 
     metagraph query -i graph.dbg \
                     -a annotation.column.annodbg \
-                    --count-kmers \
                     --discovery-fraction 0.1 \
                     transcripts_1000.fa
 

--- a/metagraph/docs/source/sequence_search.rst
+++ b/metagraph/docs/source/sequence_search.rst
@@ -33,7 +33,7 @@ column being the corresponding node in the graph (or :code:`0` if not present).
 For less verbose output, the additional :code:`--query-presence` and :code:`--count-kmers`
 flags are available.
 
-- :code:`--query-presence` outputs one line per sequence indicating whether the sequence is present (:code:`1`) or absent (:code:`0`). A sequence is considered to be present if its fraction of present k-mers is at least :code:`d`, as set by the :code:`--discovery-fraction` flag.
+- :code:`--query-presence` outputs one line per sequence indicating whether the sequence is present (:code:`1`) or absent (:code:`0`). A sequence is considered to be present if its fraction of present k-mers is at least :code:`d`, as set by the :code:`--min-kmers-fraction-label` flag.
 - :code:`--count-kmers` outputs one line per sequence in TSV format. The first column is the sequence header, while the second column is of the form :code:`a/b/c`, where :code:`a` is the number of matching k-mers, :code:`b` is the total number of k-mers, and :code:`c` is the total number of unique matching k-mers (where reverse complements are considered to be matching).
 
 Sequence-to-graph alignment

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -135,7 +135,7 @@ class TestQuery(TestingBase):
         assert(f'representation: {cls.anno_repr}' == out[3])
 
     def test_query(self):
-        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -145,7 +145,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -158,7 +158,7 @@ class TestQuery(TestingBase):
     @unittest.skipIf(PROTEIN_MODE, "Reverse sequences for Protein alphabets are not defined")
     def test_query_both(self):
         """query graph (fwd and reverse)"""
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -168,7 +168,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -180,7 +180,7 @@ class TestQuery(TestingBase):
 
     def test_query_parallel(self):
         """query graph (multi-threaded)"""
-        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -191,7 +191,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -205,7 +205,7 @@ class TestQuery(TestingBase):
     @unittest.skipIf(PROTEIN_MODE, "Reverse sequences for Protein alphabets are not defined")
     def test_query_both_parallel(self):
         """query graph (fwd and reverse, multi-threaded)"""
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -216,7 +216,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -228,7 +228,7 @@ class TestQuery(TestingBase):
         self.assertEqual(len(res.stdout), 260215)
 
     def test_query_with_align(self):
-        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -241,7 +241,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -255,7 +255,7 @@ class TestQuery(TestingBase):
             self.assertEqual(len(res.stdout), 12350)
 
         # align to graph (multi-threaded)
-        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -269,7 +269,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -286,7 +286,7 @@ class TestQuery(TestingBase):
     @unittest.skipIf(PROTEIN_MODE, "Reverse sequences for Protein alphabets are not defined")
     def test_query_with_align_both(self):
         """align to graph (fwd and reverse multi-threaded)"""
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --align -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --align -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -297,7 +297,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24567)
 
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -309,7 +309,7 @@ class TestQuery(TestingBase):
         self.assertEqual(len(res.stdout), 24779)
 
     def test_batch_query(self):
-        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -319,7 +319,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -332,7 +332,7 @@ class TestQuery(TestingBase):
     @unittest.skipIf(PROTEIN_MODE, "Reverse sequences for Protein alphabets are not defined")
     def test_batch_query_both(self):
         """query graph (fwd and reverse)"""
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -342,7 +342,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -354,7 +354,7 @@ class TestQuery(TestingBase):
 
     def test_batch_query_parallel(self):
         """query graph (multi-threaded)"""
-        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} -p {num_threads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -365,7 +365,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} -p {num_threads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -379,7 +379,7 @@ class TestQuery(TestingBase):
     @unittest.skipIf(PROTEIN_MODE, "Reverse sequences for Protein alphabets are not defined")
     def test_batch_query_both_parallel(self):
         """query graph (fwd and reverse, multi-threaded)"""
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -390,7 +390,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -402,7 +402,7 @@ class TestQuery(TestingBase):
         self.assertEqual(len(res.stdout), 260215)
 
     def test_batch_query_with_align(self):
-        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -415,7 +415,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -429,7 +429,7 @@ class TestQuery(TestingBase):
             self.assertEqual(len(res.stdout), 12350)
 
         # align to graph (multi-threaded)
-        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} -p {num_threads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -443,7 +443,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} -p {num_threads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -460,7 +460,7 @@ class TestQuery(TestingBase):
     @unittest.skipIf(PROTEIN_MODE, "Reverse sequences for Protein alphabets are not defined")
     def test_batch_query_with_align_both(self):
         """align to graph (fwd and reverse multi-threaded)"""
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --align -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --align -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -471,7 +471,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24567)
 
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -483,7 +483,7 @@ class TestQuery(TestingBase):
         self.assertEqual(len(res.stdout), 24779)
 
     def test_batch_query_with_tiny_batch(self):
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -493,7 +493,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -510,7 +510,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
+                            --min-kmers-fraction-label 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -519,7 +519,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
+                            --min-kmers-fraction-label 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -532,7 +532,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
+                            --min-kmers-fraction-label 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -541,7 +541,7 @@ class TestQuery(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
+                            --min-kmers-fraction-label 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -615,7 +615,7 @@ class TestQueryTinyLinear(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords  --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 0.05 {self.fasta_graph}' + MMAP_FLAG
+                            --min-kmers-fraction-label 0.05 {self.fasta_graph}' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -708,7 +708,7 @@ class TestQuery1Column(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 0 \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 1.0 \
+                            --min-kmers-fraction-label 1.0 \
                             {TEST_DATA_DIR}/transcripts_1000.fa' + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -717,7 +717,7 @@ class TestQuery1Column(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 0 --query-mode matches \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction 1.0 \
+                            --min-kmers-fraction-label 1.0 \
                             {TEST_DATA_DIR}/transcripts_1000.fa' + MMAP_FLAG
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -875,7 +875,7 @@ class TestQueryCounts(TestingBase):
             query_command = f'{METAGRAPH} query --batch-size 100000000 --query-mode counts-sum \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
+                            --min-kmers-fraction-label {discovery_rate} {query_file}' + MMAP_FLAG
 
             res = subprocess.run(query_command.split(), stdout=PIPE)
             self.assertEqual(res.returncode, 0)
@@ -914,7 +914,7 @@ class TestQueryCounts(TestingBase):
             query_command = f'{METAGRAPH} query --batch-size 100000000 --query-mode counts --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                            --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
+                            --min-kmers-fraction-label {discovery_rate} {query_file}' + MMAP_FLAG
 
             res = subprocess.run(query_command.split(), stdout=PIPE)
             self.assertEqual(res.returncode, 0)
@@ -923,7 +923,7 @@ class TestQueryCounts(TestingBase):
         query_command = f'{METAGRAPH} query --batch-size 100000000 --query-mode counts \
                         -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                         -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
-                        --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
+                        --min-kmers-fraction-label {discovery_rate} {query_file}' + MMAP_FLAG
 
         res = subprocess.run(query_command.split(), stdout=PIPE)
         self.assertEqual(res.returncode, 0)
@@ -1004,7 +1004,7 @@ class TestQueryCanonical(TestingBase):
         assert('representation: ' + cls.anno_repr == out[3])
 
     def test_query(self):
-        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1014,7 +1014,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1025,7 +1025,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(len(res.stdout), 137093)
 
     def test_query_with_align(self):
-        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1035,7 +1035,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1046,7 +1046,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(len(res.stdout), 12970)
 
     def test_batch_query(self):
-        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1056,7 +1056,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1067,7 +1067,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(len(res.stdout), 137093)
 
     def test_batch_query_with_align(self):
-        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1077,7 +1077,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1088,7 +1088,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(len(res.stdout), 12970)
 
     def test_batch_query_with_tiny_batch(self):
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1098,7 +1098,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1171,7 +1171,7 @@ class TestQueryPrimary(TestingBase):
         assert('representation: ' + cls.anno_repr == out[3])
 
     def test_query(self):
-        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1181,7 +1181,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1192,7 +1192,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(len(res.stdout), 137093)
 
     def test_query_with_align(self):
-        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1202,7 +1202,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1213,7 +1213,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(len(res.stdout), 12970)
 
     def test_batch_query(self):
-        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1223,7 +1223,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1234,7 +1234,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(len(res.stdout), 137093)
 
     def test_batch_query_with_align(self):
-        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1244,7 +1244,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1255,7 +1255,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(len(res.stdout), 12970)
 
     def test_batch_query_with_tiny_batch(self):
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1265,7 +1265,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --min-kmers-fraction-label 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -145,7 +145,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 0 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -168,7 +168,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -191,7 +191,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 0 --count-labels -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -216,7 +216,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --count-labels -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -241,7 +241,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 0 --align --count-labels -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -269,7 +269,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 0 --align --count-labels -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -297,7 +297,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24567)
 
-        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --align --count-labels -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --fwd-and-reverse --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -319,7 +319,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 100000000 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -342,7 +342,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -365,7 +365,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 100000000 --count-labels -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -390,7 +390,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 261390)
 
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --count-labels -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -415,7 +415,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 100000000 --align --count-labels -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -443,7 +443,7 @@ class TestQuery(TestingBase):
         else:
             self.assertEqual(len(res.stdout), 12244)
 
-        query_command = '{exe} query --batch-size 100000000 --align --count-labels -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} -p {num_threads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -471,7 +471,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 24567)
 
-        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --align --count-labels -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --fwd-and-reverse --align --query-mode matches -i {graph} -a {annotation} -p {num_theads} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -493,7 +493,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137140)
 
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -507,7 +507,7 @@ class TestQuery(TestingBase):
         if not self.anno_repr.endswith('_coord'):
             self.skipTest('annotation does not support coordinates')
 
-        query_command = f'{METAGRAPH} query --batch-size 0 --query-coords \
+        query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
@@ -516,7 +516,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 139268)
 
-        query_command = f'{METAGRAPH} query --batch-size 0 --query-coords \
+        query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
@@ -529,7 +529,7 @@ class TestQuery(TestingBase):
         if not self.anno_repr.endswith('_coord'):
             self.skipTest('annotation does not support coordinates')
 
-        query_command = f'{METAGRAPH} query --batch-size 0 --query-coords --verbose-output \
+        query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.05 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
@@ -538,7 +538,7 @@ class TestQuery(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 1619883)
 
-        query_command = f'{METAGRAPH} query --batch-size 0 --query-coords --verbose-output \
+        query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.95 {TEST_DATA_DIR}/transcripts_100.fa' + MMAP_FLAG
@@ -612,7 +612,7 @@ class TestQueryTinyLinear(TestingBase):
         if not self.anno_repr.endswith('_coord'):
             self.skipTest('annotation does not support coordinates')
 
-        query_command = f'{METAGRAPH} query --batch-size 0 --query-coords  --verbose-output \
+        query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords  --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 0.05 {self.fasta_graph}' + MMAP_FLAG
@@ -714,7 +714,7 @@ class TestQuery1Column(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(hashlib.sha224(res.stdout).hexdigest(), '254d173abb255a81a4ab8a685201a73de8dbad4546c378e0a645d454')
 
-        query_command = f'{METAGRAPH} query --batch-size 0 --count-labels \
+        query_command = f'{METAGRAPH} query --batch-size 0 --query-mode matches \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction 1.0 \
@@ -872,7 +872,7 @@ class TestQueryCounts(TestingBase):
 
                     expected_output += '\n'
 
-            query_command = f'{METAGRAPH} query --batch-size 100000000 --count-kmers \
+            query_command = f'{METAGRAPH} query --batch-size 100000000 --query-mode counts-sum \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
@@ -911,7 +911,7 @@ class TestQueryCounts(TestingBase):
 
                     expected_output += '\n'
 
-            query_command = f'{METAGRAPH} query --batch-size 100000000 --query-counts --verbose-output \
+            query_command = f'{METAGRAPH} query --batch-size 100000000 --query-mode counts --verbose-output \
                             -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                             -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                             --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
@@ -920,7 +920,7 @@ class TestQueryCounts(TestingBase):
             self.assertEqual(res.returncode, 0)
             self._compare_unsorted_results(res.stdout.decode(), expected_output)
 
-        query_command = f'{METAGRAPH} query --batch-size 100000000 --query-counts \
+        query_command = f'{METAGRAPH} query --batch-size 100000000 --query-mode counts \
                         -i {self.tempdir.name}/graph{graph_file_extension[self.graph_repr]} \
                         -a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} \
                         --discovery-fraction {discovery_rate} {query_file}' + MMAP_FLAG
@@ -1057,7 +1057,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 0 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1078,7 +1078,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 0 --align --count-labels -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1099,7 +1099,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1120,7 +1120,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 100000000 --align --count-labels -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1141,7 +1141,7 @@ class TestQueryCanonical(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1224,7 +1224,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 0 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1245,7 +1245,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 0 --align --count-labels -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 0 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1266,7 +1266,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1287,7 +1287,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 12840)
 
-        query_command = '{exe} query --batch-size 100000000 --align --count-labels -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --align --query-mode matches -i {graph} -a {annotation} --discovery-fraction 0.0 --align-min-exact-match 0.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],
@@ -1308,7 +1308,7 @@ class TestQueryPrimary(TestingBase):
         self.assertEqual(res.returncode, 0)
         self.assertEqual(len(res.stdout), 137269)
 
-        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --count-labels -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
+        query_command = '{exe} query --batch-size 100000000 --batch-size 100 --query-mode matches -i {graph} -a {annotation} --discovery-fraction 1.0 {input}'.format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr],
             annotation=self.tempdir.name + '/annotation' + anno_file_extension[self.anno_repr],

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -278,7 +278,7 @@ std::string format_alignment(const std::string &header,
         }
 
         if (paths.empty()) {
-            Json::Value json_line = Alignment().to_json(graph.get_k(), secondary, header);
+            Json::Value json_line = graph::align::Alignment().to_json(graph.get_k(), secondary, header);
             sout += fmt::format("{}\n", Json::writeString(builder, json_line));
         }
     }

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -524,6 +524,9 @@ Config::Config(int argc, char *argv[]) {
                           && alignment_num_alternative_paths != 1)
         print_usage_and_exit = true;
 
+    if (identity == QUERY && count_quantiles.size())
+        query_mode = COUNTS;
+
     if (identity == ALIGN && infbase.empty())
         print_usage_and_exit = true;
 

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -216,11 +216,11 @@ Config::Config(int argc, char *argv[]) {
             memory_available = atof(get_value(i++));
         } else if (!strcmp(argv[i], "--dump-text-anno")) {
             dump_text_anno = true;
-        } else if (!strcmp(argv[i], "--discovery-fraction")) {
+        } else if (!strcmp(argv[i], "--min-kmers-fraction-label")) {
             discovery_fraction = std::stof(get_value(i++));
         } else if (!strcmp(argv[i], "--align-rel-score-cutoff")) {
             alignment_rel_score_cutoff = std::stof(get_value(i++));
-        } else if (!strcmp(argv[i], "--presence-fraction")) {
+        } else if (!strcmp(argv[i], "--min-kmers-fraction-graph")) {
             presence_fraction = std::stof(get_value(i++));
         } else if (!strcmp(argv[i], "--query-presence")) {
             query_presence = true;
@@ -1316,9 +1316,9 @@ if (advanced) {
 if (advanced) {
             fprintf(stderr, "\t   --verbose-output \t\tdo not collapse continuous coord or count ranges (for query coords and counts) [off]\n");
 }
-            fprintf(stderr, "\t   --num-top-labels [INT] \tmaximum number of top labels to output [inf]\n");
-            fprintf(stderr, "\t   --discovery-fraction [FLOAT] min fraction of k-mers from the query required to be present in a label [0.7]\n");
-            fprintf(stderr, "\t   --presence-fraction [FLOAT] \tmin fraction of k-mers from the query required to be present in the graph [0.0]\n");
+            fprintf(stderr, "\t   --num-top-labels [INT] \t\tmaximum number of top labels to output [inf]\n");
+            fprintf(stderr, "\t   --min-kmers-fraction-label [FLOAT] \tmin fraction of k-mers from the query required to be present in a label [0.7]\n");
+            fprintf(stderr, "\t   --min-kmers-fraction-graph [FLOAT] \tmin fraction of k-mers from the query required to be present in the graph [0.0]\n");
 if (advanced) {
             fprintf(stderr, "\t   --labels-delimiter [STR]\tdelimiter for annotation labels [\":\"]\n");
             fprintf(stderr, "\t   --suppress-unlabeled \tdo not show results for sequences missing in graph [off]\n");

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -524,9 +524,6 @@ Config::Config(int argc, char *argv[]) {
                           && alignment_num_alternative_paths != 1)
         print_usage_and_exit = true;
 
-    if (identity == QUERY && count_quantiles.size())
-        query_mode = COUNTS;
-
     if (identity == ALIGN && infbase.empty())
         print_usage_and_exit = true;
 
@@ -1316,9 +1313,6 @@ if (advanced) {
             fprintf(stderr, "\t                \t\t\t\tOutput format: '<pos in query>-<pos in sample>' (single k-mer match)\n"
                             "\t                \t\t\t\t    or '<start pos in query>-<first pos in sample>-<last pos in sample>' (segment match)\n"
                             "\t                \t\t\t\tAll positions start with 0\n");
-            fprintf(stderr, "\t   --count-quantiles ['FLOAT ...'] \tin the '%s' query mode, aggregate the counts and compute their quantiles [off]\n", querymode_to_string(COUNTS).c_str());
-            fprintf(stderr, "\t                                 \t\tExample: --query-mode %s --count-quantiles '0 0.33 0.5 0.66 1'\n", querymode_to_string(COUNTS).c_str());
-            fprintf(stderr, "\t                                 \t\t(0 corresponds to MIN, 1 corresponds to MAX)\n");
 if (advanced) {
             fprintf(stderr, "\t   --verbose-output \t\tdo not collapse continuous coord or count ranges (for query coords and counts) [off]\n");
 }

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -8,6 +8,7 @@
 #include "kmer/kmer_collector_config.hpp"
 #include "graph/representation/succinct/boss.hpp"
 #include "graph/representation/base/sequence_graph.hpp"
+#include "cli/query.hpp"
 
 
 namespace mtg {
@@ -39,17 +40,13 @@ class Config {
     bool kmers_in_single_form = false;
     bool initialize_bloom = false;
     bool count_kmers = false;
-    bool print_signature = false;
     bool query_presence = false;
-    bool query_counts = false;
-    bool query_coords = false;
     bool verbose_output = false;
     bool filter_present = false;
     bool dump_text_anno = false;
     bool sparse = false;
     bool subsample_rows = false;
     bool batch_align = false;
-    bool count_labels = false;
     bool suppress_unlabeled = false;
     bool inplace = false;
     bool clear_dummy = false;
@@ -241,6 +238,10 @@ class Config {
     graph::DeBruijnGraph::Mode graph_mode = graph::DeBruijnGraph::BASIC;
     static std::string graphmode_to_string(graph::DeBruijnGraph::Mode mode);
     static graph::DeBruijnGraph::Mode string_to_graphmode(const std::string &string);
+
+    QueryMode query_mode = LABELS;
+    static std::string querymode_to_string(QueryMode mode);
+    static QueryMode string_to_querymode(const std::string &string);
 
     void print_usage(const std::string &prog_name,
                      IdentityType identity = NO_IDENTITY);

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -364,8 +364,7 @@ SeqSearchResult QueryExecutor::execute_query(QuerySequence&& sequence,
                                              size_t num_top_labels,
                                              double discovery_fraction,
                                              double presence_fraction,
-                                             const graph::AnnotatedDBG &anno_graph,
-                                             const std::vector<double> &count_quantiles) {
+                                             const graph::AnnotatedDBG &anno_graph) {
     // Perform a different action depending on the type (specified by config flags)
     SeqSearchResult::result_type result;
 
@@ -387,20 +386,11 @@ SeqSearchResult QueryExecutor::execute_query(QuerySequence&& sequence,
             break;
         }
         case COUNTS: {
-            if (count_quantiles.size()) {
-                // Get labels with count quantiles
-                result = anno_graph.get_label_count_quantiles(sequence.sequence,
-                                                              num_top_labels,
-                                                              discovery_fraction,
-                                                              presence_fraction,
-                                                              count_quantiles);
-            } else {
-                // Get labels with k-mer counts
-                result = anno_graph.get_kmer_counts(sequence.sequence,
-                                                    num_top_labels,
-                                                    discovery_fraction,
-                                                    presence_fraction);
-            }
+            // Get labels with k-mer counts
+            result = anno_graph.get_kmer_counts(sequence.sequence,
+                                                num_top_labels,
+                                                discovery_fraction,
+                                                presence_fraction);
             break;
         }
         case MATCHES: {
@@ -1277,8 +1267,7 @@ SeqSearchResult query_sequence(QuerySequence&& sequence,
     SeqSearchResult result = QueryExecutor::execute_query(std::move(sequence),
             config.query_mode,
             config.num_top_labels, config.discovery_fraction,
-            config.presence_fraction, anno_graph,
-            config.count_quantiles);
+            config.presence_fraction, anno_graph);
 
     if (aligner_config)
         result.get_alignment() = alignment;

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -360,56 +360,74 @@ std::string SeqSearchResult::to_string(const std::string delimiter,
 
 
 SeqSearchResult QueryExecutor::execute_query(QuerySequence&& sequence,
-                                             bool count_labels,
-                                             bool print_signature,
+                                             QueryMode query_mode,
                                              size_t num_top_labels,
                                              double discovery_fraction,
                                              double presence_fraction,
                                              const graph::AnnotatedDBG &anno_graph,
-                                             bool with_kmer_counts,
-                                             const std::vector<double> &count_quantiles,
-                                             bool query_counts,
-                                             bool query_coords) {
+                                             const std::vector<double> &count_quantiles) {
     // Perform a different action depending on the type (specified by config flags)
     SeqSearchResult::result_type result;
 
-    if (print_signature) {
-        // Get labels with presence/absence signatures
-        result = anno_graph.get_top_label_signatures(sequence.sequence,
+    switch (query_mode) {
+        case SIGNATURE: {
+            // Get labels with presence/absence signatures
+            result = anno_graph.get_top_label_signatures(sequence.sequence,
+                                                         num_top_labels,
+                                                         discovery_fraction,
+                                                         presence_fraction);
+            break;
+        }
+        case COORDS: {
+            // Get labels with k-mer coordinates
+            result = anno_graph.get_kmer_coordinates(sequence.sequence,
                                                      num_top_labels,
                                                      discovery_fraction,
                                                      presence_fraction);
-    } else if (query_coords) {
-        // Get labels with k-mer coordinates
-        result = anno_graph.get_kmer_coordinates(sequence.sequence,
-                                                 num_top_labels,
-                                                 discovery_fraction,
-                                                 presence_fraction);
-    } else if (query_counts) {
-        // Get labels with k-mer counts
-        result = anno_graph.get_kmer_counts(sequence.sequence,
-                                            num_top_labels,
-                                            discovery_fraction,
-                                            presence_fraction);
-    } else if (count_quantiles.size()) {
-        // Get labels with count quantiles
-        result = anno_graph.get_label_count_quantiles(sequence.sequence,
-                                                      num_top_labels,
-                                                      discovery_fraction,
-                                                      presence_fraction,
-                                                      count_quantiles);
-    } else if (count_labels || with_kmer_counts) {
-        // Get labels with label counts / kmer counts
-        result = anno_graph.get_top_labels(sequence.sequence,
-                                           num_top_labels,
+            break;
+        }
+        case COUNTS: {
+            if (count_quantiles.size()) {
+                // Get labels with count quantiles
+                result = anno_graph.get_label_count_quantiles(sequence.sequence,
+                                                              num_top_labels,
+                                                              discovery_fraction,
+                                                              presence_fraction,
+                                                              count_quantiles);
+            } else {
+                // Get labels with k-mer counts
+                result = anno_graph.get_kmer_counts(sequence.sequence,
+                                                    num_top_labels,
+                                                    discovery_fraction,
+                                                    presence_fraction);
+            }
+            break;
+        }
+        case MATCHES: {
+            // Get labels with label counts
+            result = anno_graph.get_top_labels(sequence.sequence,
+                                               num_top_labels,
+                                               discovery_fraction,
+                                               presence_fraction,
+                                               false);
+            break;
+        }
+        case COUNTS_SUM: {
+            // Get labels with label counts / kmer counts
+            result = anno_graph.get_top_labels(sequence.sequence,
+                                               num_top_labels,
+                                               discovery_fraction,
+                                               presence_fraction,
+                                               true);
+            break;
+        }
+        case LABELS: {
+            // Default, just get labels
+            result = anno_graph.get_labels(sequence.sequence,
                                            discovery_fraction,
-                                           presence_fraction,
-                                           with_kmer_counts);
-    } else {
-        // Default, just get labels
-        result = anno_graph.get_labels(sequence.sequence,
-                                       discovery_fraction,
-                                       presence_fraction);
+                                           presence_fraction);
+            break;
+        }
     }
 
     // Create seq search instance and move sequence into it
@@ -1188,14 +1206,14 @@ int query_graph(Config *config) {
             if (config->output_json) {
                 std::ostringstream ss;
                 ss << result.to_json(config->verbose_output
-                                         || !(config->query_counts || config->query_coords),
+                                         || !(config->query_mode == COUNTS || config->query_mode == COORDS),
                                      anno_graph) << "\n";
                 std::cout << ss.str();
             } else {
                 std::cout << result.to_string(config->anno_labels_delimiter,
                                               config->suppress_unlabeled,
                                               config->verbose_output
-                                                || !(config->query_counts || config->query_coords),
+                                                || !(config->query_mode == COUNTS || config->query_mode == COORDS),
                                               anno_graph) + "\n";
             }
         });
@@ -1257,11 +1275,10 @@ SeqSearchResult query_sequence(QuerySequence&& sequence,
 
     // Get sequence search result by executing query
     SeqSearchResult result = QueryExecutor::execute_query(std::move(sequence),
-            config.count_labels, config.print_signature,
+            config.query_mode,
             config.num_top_labels, config.discovery_fraction,
             config.presence_fraction, anno_graph,
-            config.count_kmers, config.count_quantiles,
-            config.query_counts, config.query_coords);
+            config.count_quantiles);
 
     if (aligner_config)
         result.get_alignment() = alignment;
@@ -1277,8 +1294,9 @@ void QueryExecutor::query_fasta(const string &file,
     seq_io::FastaParser fasta_parser(file, config_.forward_and_reverse);
 
     // Only query_coords/count_kmers if using coord/count aware index.
-    if (this->config_.query_coords && !(dynamic_cast<const annot::matrix::MultiIntMatrix *>(
-            &this->anno_graph_.get_annotator().get_matrix()))) {
+    if (config_.query_mode == COORDS
+            && !dynamic_cast<const annot::matrix::MultiIntMatrix *>(
+                    &this->anno_graph_.get_annotator().get_matrix())) {
         logger->error("Annotation does not support k-mer coordinate queries. "
                       "First transform this annotation to include coordinate data "
                       "(e.g., {}, {}, {}, {}, {}).",
@@ -1290,8 +1308,9 @@ void QueryExecutor::query_fasta(const string &file,
         exit(1);
     }
 
-    if (this->config_.count_kmers && !(dynamic_cast<const annot::matrix::IntMatrix *>(
-            &this->anno_graph_.get_annotator().get_matrix()))) {
+    if ((config_.query_mode == COUNTS || config_.query_mode == COUNTS_SUM)
+            && !dynamic_cast<const annot::matrix::IntMatrix *>(
+                    &this->anno_graph_.get_annotator().get_matrix())) {
         logger->error("Annotation does not support k-mer count queries. "
                       "First transform this annotation to include count data "
                       "(e.g., {}, {}, {}).",
@@ -1302,7 +1321,7 @@ void QueryExecutor::query_fasta(const string &file,
     }
 
     if (config_.query_batch_size) {
-        if (!config_.query_coords) {
+        if (config_.query_mode != COORDS) {
             // Construct a query graph and query against it
             batched_query_fasta(fasta_parser, callback);
             return;

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -209,8 +209,7 @@ class QueryExecutor {
                                          size_t num_top_labels,
                                          double discovery_fraction,
                                          double presence_fraction,
-                                         const graph::AnnotatedDBG &anno_graph,
-                                         const std::vector<double> &count_quantiles = {});
+                                         const graph::AnnotatedDBG &anno_graph);
 
   private:
     const Config &config_;

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -173,6 +173,15 @@ class SeqSearchResult {
 };
 
 
+enum QueryMode {
+    LABELS = 0,
+    MATCHES,
+    COUNTS_SUM,
+    COUNTS,
+    COORDS,
+    SIGNATURE
+};
+
 class QueryExecutor {
   public:
     QueryExecutor(const Config &config,
@@ -196,16 +205,12 @@ class QueryExecutor {
                      const std::function<void(const SeqSearchResult &)> &callback);
 
     static SeqSearchResult execute_query(QuerySequence&& sequence,
-                                         bool count_labels,
-                                         bool print_signature,
+                                         QueryMode query_mode,
                                          size_t num_top_labels,
                                          double discovery_fraction,
                                          double presence_fraction,
                                          const graph::AnnotatedDBG &anno_graph,
-                                         bool with_kmer_counts = false,
-                                         const std::vector<double> &count_quantiles = {},
-                                         bool query_counts = false,
-                                         bool query_coords = false);
+                                         const std::vector<double> &count_quantiles = {});
 
   private:
     const Config &config_;

--- a/projects/BIGSI/README.md
+++ b/projects/BIGSI/README.md
@@ -529,7 +529,7 @@ for QUERY in ~/metagenome/data/BIGSI/subsets/query/samples/haib18CEM5453_HMCMJCC
     mkdir -p $OUTDIR
 
     for num_columns in $(seq 750 3000 24750); do
-        run="$METAGRAPH query -v --discovery-fraction 0.0 --query-mode matches \
+        run="$METAGRAPH query -v --min-kmers-fraction-label 0.0 --query-mode matches \
                 -i \${TMPDIR}/graph.dbg \
                 -a \${TMPDIR}/graph.row_diff_brwt.annodbg \
                 $QUERY"
@@ -639,7 +639,7 @@ done
 #QUERY=~/metagenome/data/BIGSI/subsets/query/samples/haib18CEM5453_HMCMJCCXY_SL336225.fasta
 QUERY=~/metagenome/data/BIGSI/subsets/query/samples/nucleotide_fasta_protein_homolog_model.fasta
 #QUERY=~/metagenome/data/BIGSI/subsets/query/samples/DRR067889.fasta
-./metagraph query -v --discovery-fraction 0.0 --query-mode matches \
+./metagraph query -v --min-kmers-fraction-label 0.0 --query-mode matches \
     -i ~/metagenome/data/BIGSI/subsets/graph_subset_24750.dbg \
     -a ~/metagenome/data/BIGSI/subsets/annotation/annotation_subset_24750.rb_brwt.annodbg \
     $QUERY \

--- a/projects/BIGSI/README.md
+++ b/projects/BIGSI/README.md
@@ -529,7 +529,7 @@ for QUERY in ~/metagenome/data/BIGSI/subsets/query/samples/haib18CEM5453_HMCMJCC
     mkdir -p $OUTDIR
 
     for num_columns in $(seq 750 3000 24750); do
-        run="$METAGRAPH query -v --discovery-fraction 0.0 --count-labels \
+        run="$METAGRAPH query -v --discovery-fraction 0.0 --query-mode matches \
                 -i \${TMPDIR}/graph.dbg \
                 -a \${TMPDIR}/graph.row_diff_brwt.annodbg \
                 $QUERY"
@@ -639,7 +639,7 @@ done
 #QUERY=~/metagenome/data/BIGSI/subsets/query/samples/haib18CEM5453_HMCMJCCXY_SL336225.fasta
 QUERY=~/metagenome/data/BIGSI/subsets/query/samples/nucleotide_fasta_protein_homolog_model.fasta
 #QUERY=~/metagenome/data/BIGSI/subsets/query/samples/DRR067889.fasta
-./metagraph query -v --discovery-fraction 0.0 --count-labels \
+./metagraph query -v --discovery-fraction 0.0 --query-mode matches \
     -i ~/metagenome/data/BIGSI/subsets/graph_subset_24750.dbg \
     -a ~/metagenome/data/BIGSI/subsets/annotation/annotation_subset_24750.rb_brwt.annodbg \
     $QUERY \

--- a/projects/GTEx/query/first_exons/query_first_exons.sh
+++ b/projects/GTEx/query/first_exons/query_first_exons.sh
@@ -15,4 +15,4 @@ graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/gencode.v30.first_exons.fa
 
-$metagraph query -p ${threads} --discovery-fraction 0.0 --count-labels -i ${graph} -a ${annotation} ${query} > ${query_dir}/gencode.v30.first_exons.result.txt
+$metagraph query -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} > ${query_dir}/gencode.v30.first_exons.result.txt

--- a/projects/GTEx/query/first_exons/query_first_exons.sh
+++ b/projects/GTEx/query/first_exons/query_first_exons.sh
@@ -15,4 +15,4 @@ graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/gencode.v30.first_exons.fa
 
-$metagraph query -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} > ${query_dir}/gencode.v30.first_exons.result.txt
+$metagraph query -p ${threads} --min-kmers-fraction-label 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} > ${query_dir}/gencode.v30.first_exons.result.txt

--- a/projects/GTEx/query/first_exons/query_first_exons_non_ovlp.sh
+++ b/projects/GTEx/query/first_exons/query_first_exons_non_ovlp.sh
@@ -15,4 +15,4 @@ graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merg
 annotation=${basedir}/gtex/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/gencode.v30.first_exons_non_ovlp.fa
 
-$metagraph query -v -p ${threads} --discovery-fraction 0.0 --count-labels -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/gencode.v30.first_exons_non_ovlp.result.txt
+$metagraph query -v -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/gencode.v30.first_exons_non_ovlp.result.txt

--- a/projects/GTEx/query/first_exons/query_first_exons_non_ovlp.sh
+++ b/projects/GTEx/query/first_exons/query_first_exons_non_ovlp.sh
@@ -15,4 +15,4 @@ graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merg
 annotation=${basedir}/gtex/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/gencode.v30.first_exons_non_ovlp.fa
 
-$metagraph query -v -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/gencode.v30.first_exons_non_ovlp.result.txt
+$metagraph query -v -p ${threads} --min-kmers-fraction-label 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/gencode.v30.first_exons_non_ovlp.result.txt

--- a/projects/GTEx/query/junctions/query_junctions.sh
+++ b/projects/GTEx/query/junctions/query_junctions.sh
@@ -14,4 +14,4 @@ query_dir=${basedir}/gtex/queries
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/junctions/gencode.v30.all_junctions.fa
-$metagraph query -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | gzip > ${query_dir}/junctions/gencode.v30.all_junctions.result.txt.gz
+$metagraph query -p ${threads} --min-kmers-fraction-label 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | gzip > ${query_dir}/junctions/gencode.v30.all_junctions.result.txt.gz

--- a/projects/GTEx/query/junctions/query_junctions.sh
+++ b/projects/GTEx/query/junctions/query_junctions.sh
@@ -14,4 +14,4 @@ query_dir=${basedir}/gtex/queries
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/junctions/gencode.v30.all_junctions.fa
-$metagraph query -p ${threads} --discovery-fraction 0.0 --count-labels -i ${graph} -a ${annotation} ${query} | gzip > ${query_dir}/junctions/gencode.v30.all_junctions.result.txt.gz
+$metagraph query -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | gzip > ${query_dir}/junctions/gencode.v30.all_junctions.result.txt.gz

--- a/projects/GTEx/query/trans_exons/query_trans_exons_all_hits_samples.sh
+++ b/projects/GTEx/query/trans_exons/query_trans_exons_all_hits_samples.sh
@@ -16,5 +16,5 @@ mkdir -p $result_dir
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.samples.brwt.annodbg
 query=${query_dir}/trans_exons/gencode.v30.trans_exons_all.result.hits.fa
-$metagraph query -v -p ${threads} --discovery-fraction 0.8 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_all_hits.result_samples.txt
+$metagraph query -v -p ${threads} --min-kmers-fraction-label 0.8 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_all_hits.result_samples.txt
 

--- a/projects/GTEx/query/trans_exons/query_trans_exons_all_hits_samples.sh
+++ b/projects/GTEx/query/trans_exons/query_trans_exons_all_hits_samples.sh
@@ -16,5 +16,5 @@ mkdir -p $result_dir
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.samples.brwt.annodbg
 query=${query_dir}/trans_exons/gencode.v30.trans_exons_all.result.hits.fa
-$metagraph query -v -p ${threads} --discovery-fraction 0.8 --count-labels -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_all_hits.result_samples.txt
+$metagraph query -v -p ${threads} --discovery-fraction 0.8 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_all_hits.result_samples.txt
 

--- a/projects/GTEx/query/trans_exons/query_trans_exons_hits_abundance.sh
+++ b/projects/GTEx/query/trans_exons/query_trans_exons_hits_abundance.sh
@@ -14,5 +14,5 @@ query_dir=${basedir}/gtex/queries
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/trans_exons/gencode.v30.trans_exons.result.hits.fa
-$metagraph query -v -p ${threads} --discovery-fraction 0.0 --count-labels -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_abundance.txt
+$metagraph query -v -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_abundance.txt
 

--- a/projects/GTEx/query/trans_exons/query_trans_exons_hits_abundance.sh
+++ b/projects/GTEx/query/trans_exons/query_trans_exons_hits_abundance.sh
@@ -14,5 +14,5 @@ query_dir=${basedir}/gtex/queries
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.abundance.brwt.annodbg
 query=${query_dir}/trans_exons/gencode.v30.trans_exons.result.hits.fa
-$metagraph query -v -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_abundance.txt
+$metagraph query -v -p ${threads} --min-kmers-fraction-label 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_abundance.txt
 

--- a/projects/GTEx/query/trans_exons/query_trans_exons_hits_samples.sh
+++ b/projects/GTEx/query/trans_exons/query_trans_exons_hits_samples.sh
@@ -14,5 +14,5 @@ query_dir=${basedir}/gtex/queries
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.samples.brwt.annodbg
 query=${query_dir}/trans_exons/gencode.v30.trans_exons.result.hits.fa
-$metagraph query -v -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_samples.txt
+$metagraph query -v -p ${threads} --min-kmers-fraction-label 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_samples.txt
 

--- a/projects/GTEx/query/trans_exons/query_trans_exons_hits_samples.sh
+++ b/projects/GTEx/query/trans_exons/query_trans_exons_hits_samples.sh
@@ -14,5 +14,5 @@ query_dir=${basedir}/gtex/queries
 graph=${basedir}/gtex/graphs/output_k${K}_trimmed_clean_graph_chunked/graph_merged_k${K}.dbg
 annotation=${basedir}/gtex/graphs/output_k${K}_trimmed_clean.samples.brwt.annodbg
 query=${query_dir}/trans_exons/gencode.v30.trans_exons.result.hits.fa
-$metagraph query -v -p ${threads} --discovery-fraction 0.0 --count-labels -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_samples.txt
+$metagraph query -v -p ${threads} --discovery-fraction 0.0 --query-mode matches -i ${graph} -a ${annotation} ${query} | tee ${query_dir}/trans_exons/gencode.v30.trans_exons_hits.result_samples.txt
 

--- a/projects/GTEx/query/unaligned/query_unaligned.sh
+++ b/projects/GTEx/query/unaligned/query_unaligned.sh
@@ -21,6 +21,6 @@ do
     then
         graph=${basedir}/gtex/graphs/output_k${K}_merged/all_merged_k${K}.dbg
         annotation=${basedir}/gtex/graphs/output_k${K}_merged.anno.brwt.annodbg
-        $metagraph query -p ${threads} --discovery-fraction 1.0 -i ${graph} -a ${annotation} ${fname} > $outfile
+        $metagraph query -p ${threads} --min-kmers-fraction-label 1.0 -i ${graph} -a ${annotation} ${fname} > $outfile
     fi
 done

--- a/projects/GTEx/query_extended/align_samples_back_fast.sh
+++ b/projects/GTEx/query_extended/align_samples_back_fast.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --align-min-seed-length 19 --align --discovery-fraction 0.0 --count-labels -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --align-min-seed-length 19 --align --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/align_samples_back_fast.sh
+++ b/projects/GTEx/query_extended/align_samples_back_fast.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --align-min-seed-length 19 --align --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --align-min-seed-length 19 --align --min-kmers-fraction-label 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/align_unaligned.sh
+++ b/projects/GTEx/query_extended/align_unaligned.sh
@@ -20,6 +20,6 @@ do
     logfile=${query_dir}/align_unaligned.${sample}.lsf.log
     if [ ! -f ${outfile} ]
     then
-        echo "/usr/bin/time -v $metagraph query --align --discovery-fraction 0.0 --query-mode matches -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
+        echo "/usr/bin/time -v $metagraph query --align --min-kmers-fraction-label 0.0 --query-mode matches -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
     fi
 done

--- a/projects/GTEx/query_extended/align_unaligned.sh
+++ b/projects/GTEx/query_extended/align_unaligned.sh
@@ -20,6 +20,6 @@ do
     logfile=${query_dir}/align_unaligned.${sample}.lsf.log
     if [ ! -f ${outfile} ]
     then
-        echo "/usr/bin/time -v $metagraph query --align --discovery-fraction 0.0 --count-labels -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
+        echo "/usr/bin/time -v $metagraph query --align --discovery-fraction 0.0 --query-mode matches -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
     fi
 done

--- a/projects/GTEx/query_extended/map_samples_back.sh
+++ b/projects/GTEx/query_extended/map_samples_back.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --count-labels -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/map_samples_back.sh
+++ b/projects/GTEx/query_extended/map_samples_back.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --min-kmers-fraction-label 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/map_samples_back_fast.sh
+++ b/projects/GTEx/query_extended/map_samples_back_fast.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --count-labels -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/map_samples_back_fast.sh
+++ b/projects/GTEx/query_extended/map_samples_back_fast.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --min-kmers-fraction-label 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/map_samples_back_fast_split.sh
+++ b/projects/GTEx/query_extended/map_samples_back_fast_split.sh
@@ -80,7 +80,7 @@ do
             echo "$fbase already done"
             continue
         fi
-        echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --count-labels -v -i $graph -a $anno -p $threads $fname | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+        echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fname | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
     done
     exit
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/map_samples_back_fast_split.sh
+++ b/projects/GTEx/query_extended/map_samples_back_fast_split.sh
@@ -80,7 +80,7 @@ do
             echo "$fbase already done"
             continue
         fi
-        echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fname | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+        echo "(/usr/bin/time -v $metagraph query --min-kmers-fraction-label 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fname | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
     done
     exit
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/GTEx/query_extended/map_unaligned.sh
+++ b/projects/GTEx/query_extended/map_unaligned.sh
@@ -20,6 +20,6 @@ do
     logfile=${query_dir}/map_unaligned.${sample}.lsf.log
     if [ ! -f ${outfile} ]
     then
-        echo "/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --count-labels -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
+        echo "/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
     fi
 done

--- a/projects/GTEx/query_extended/map_unaligned.sh
+++ b/projects/GTEx/query_extended/map_unaligned.sh
@@ -20,6 +20,6 @@ do
     logfile=${query_dir}/map_unaligned.${sample}.lsf.log
     if [ ! -f ${outfile} ]
     then
-        echo "/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
+        echo "/usr/bin/time -v $metagraph query --min-kmers-fraction-label 0.0 --query-mode matches -v -p ${threads} -i ${basedir}/output_k${K}_trimmed_clean_graph_extended_chunked/graph_k${K}.dbg -a ${basedir}/output_k${K}_trimmed_extended.samples.brwt.annodbg ${fname} | gzip > $outfile" | bsub -M $mem -We 24:00 -n ${threads} -R "rusage[mem=${pmem}]" -R "span[hosts=1]" -J aln_gtex -oo $logfile
     fi
 done

--- a/projects/kingsford/README.md
+++ b/projects/kingsford/README.md
@@ -249,7 +249,7 @@ bsub -J "kingsford_query_old" \
      -oo ${DIR}/logs/query_rd_brwt_relax_old.lsf \
      -W 4:00 \
      -n 1 -R "rusage[mem=30000] span[hosts=1]" \
-    "/usr/bin/time -v $METAGRAPH query --count-labels -v \
+    "/usr/bin/time -v $METAGRAPH query --query-mode matches -v \
             -i ${DIR}/kingsford_small.dbg \
             -a ${DIR}/annotation_old.relaxed.row_diff_brwt.annodbg \
             ~/projects/projects2014-metagenome/metagraph/tests/data/transcripts_100.fa \
@@ -258,7 +258,7 @@ bsub -J "kingsford_query" \
      -oo ${DIR}/logs/query_rd_brwt_relax.lsf \
      -W 4:00 \
      -n 1 -R "rusage[mem=30000] span[hosts=1]" \
-    "/usr/bin/time -v $METAGRAPH query --count-labels -v \
+    "/usr/bin/time -v $METAGRAPH query --query-mode matches -v \
             -i ${DIR}/kingsford_small.dbg \
             -a ${DIR}/annotation.relaxed.row_diff_brwt.annodbg \
             ~/projects/projects2014-metagenome/metagraph/tests/data/transcripts_100.fa \
@@ -274,7 +274,7 @@ bsub -J "kingsford_count_query" \
      -oo ${DIR}/logs/query_count_rd_brwt_relax.lsf \
      -W 4:00 \
      -n 1 -R "rusage[mem=30000] span[hosts=1]" \
-    "/usr/bin/time -v $METAGRAPH query --count-labels --count-kmers -v \
+    "/usr/bin/time -v $METAGRAPH query --query-mode counts-sum -v \
             -i ${DIR}/../kingsford_small.dbg \
             -a ${DIR}/annotation.relaxed.row_diff_int_brwt.annodbg \
             ~/projects/projects2014-metagenome/metagraph/tests/data/transcripts_100.fa \

--- a/projects/kingsford/query_transcripts.sh
+++ b/projects/kingsford/query_transcripts.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/bash
 
-./metagraph query -v -i ~/big_graph/graph_SRR_k20_2/graph_SRR_2.dbg -a ~/big_graph/graph_SRR_k20_2/merged_annotation.column.annodbg --discovery-fraction 0.8 --labels-delimiter ", " ~/transcripts_1000.fa
+./metagraph query -v -i ~/big_graph/graph_SRR_k20_2/graph_SRR_2.dbg -a ~/big_graph/graph_SRR_k20_2/merged_annotation.column.annodbg --min-kmers-fraction-label 0.8 --labels-delimiter ", " ~/transcripts_1000.fa

--- a/projects/metasub/query/map_gtex_samples.sh
+++ b/projects/metasub/query/map_gtex_samples.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --count-labels -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/metasub/query/map_gtex_samples.sh
+++ b/projects/metasub/query/map_gtex_samples.sh
@@ -51,5 +51,5 @@ do
         echo No fastq file for $uuid
         continue
     fi
-    echo "(/usr/bin/time -v $metagraph query --discovery-fraction 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
+    echo "(/usr/bin/time -v $metagraph query --min-kmers-fraction-label 0.0 --query-mode matches -v -i $graph -a $anno -p $threads $fq1 $fq2 | gzip > $outfile) && touch $donefile" | bsub -M $mem -n $threads -R "rusage[mem=${pmem}]" -We 48:00 -n 1 -J map_gtex -oo $logfile  #-R "select[model==XeonGold_6150]"
 done < <(shuf -n 10 --random-source $metadata $metadata | tr $'\t' ',')

--- a/projects/metasub/query/query_AMR_alignment_fast_CARD.sh
+++ b/projects/metasub/query/query_AMR_alignment_fast_CARD.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.fast.log
 out=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.fast.tsv
-echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --count-labels --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_fast_CARD.sh
+++ b/projects/metasub/query/query_AMR_alignment_fast_CARD.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.fast.log
 out=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.fast.tsv
-echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --min-kmers-fraction-label 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_fast_mustard.sh
+++ b/projects/metasub/query/query_AMR_alignment_fast_mustard.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/amr_mustard_all_ard_k${K}.fast.log
 out=${outdir}/amr_mustard_all_ard_k${K}.fast.tsv
-echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --count-labels --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_fast_mustard.sh
+++ b/projects/metasub/query/query_AMR_alignment_fast_mustard.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/amr_mustard_all_ard_k${K}.fast.log
 out=${outdir}/amr_mustard_all_ard_k${K}.fast.tsv
-echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --min-kmers-fraction-label 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_fast_plasmids_db.sh
+++ b/projects/metasub/query/query_AMR_alignment_fast_plasmids_db.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/plasmids_db_v2_k${K}.fast.log
 out=${outdir}/plasmids_db_v2_k${K}.fast.tsv
-echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_plsm${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --min-kmers-fraction-label 0.1 ${query} > $out" | bsub -J ms_q_plsm${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_fast_plasmids_db.sh
+++ b/projects/metasub/query/query_AMR_alignment_fast_plasmids_db.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/plasmids_db_v2_k${K}.fast.log
 out=${outdir}/plasmids_db_v2_k${K}.fast.tsv
-echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --count-labels --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_plsm${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query --align --suppress-unlabeled -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_plsm${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_step2_CARD.sh
+++ b/projects/metasub/query/query_AMR_alignment_step2_CARD.sh
@@ -28,4 +28,4 @@ if [ ! -f ${query} ]
 then
     python tsv2fasta.py ${query%fa}tsv > $query
 fi
-echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --count-labels --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_step2_CARD.sh
+++ b/projects/metasub/query/query_AMR_alignment_step2_CARD.sh
@@ -28,4 +28,4 @@ if [ ! -f ${query} ]
 then
     python tsv2fasta.py ${query%fa}tsv > $query
 fi
-echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --query-mode matches --min-kmers-fraction-label 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_step2_mustard.sh
+++ b/projects/metasub/query/query_AMR_alignment_step2_mustard.sh
@@ -28,4 +28,4 @@ if [ ! -f ${query} ]
 then
     python tsv2fasta.py ${query%fa}tsv > $query
 fi
-echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --count-labels --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_alignment_step2_mustard.sh
+++ b/projects/metasub/query/query_AMR_alignment_step2_mustard.sh
@@ -28,4 +28,4 @@ if [ ! -f ${query} ]
 then
     python tsv2fasta.py ${query%fa}tsv > $query
 fi
-echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --query-mode matches --discovery-fraction 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} -p ${threads} --query-mode matches --min-kmers-fraction-label 0.1 ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_kmer.sh
+++ b/projects/metasub/query/query_AMR_kmer.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.kmer_based.log
 out=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.kmer_based.tsv
-echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} --query-mode matches --discovery-fraction 0.1 -p ${threads} ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} --query-mode matches --min-kmers-fraction-label 0.1 -p ${threads} ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/projects/metasub/query/query_AMR_kmer.sh
+++ b/projects/metasub/query/query_AMR_kmer.sh
@@ -24,4 +24,4 @@ pmem=$((${mem} / ${threads}))
 
 log=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.kmer_based.log
 out=${outdir}/amr_CARD_nucleotide_fasta_protein_homolog_model_k${K}.kmer_based.tsv
-echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} --count-labels --discovery-fraction 0.1 -p ${threads} ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"
+echo "/usr/bin/time -v $metagraph query -i $graph -a ${annotation} --query-mode matches --discovery-fraction 0.1 -p ${threads} ${query} > $out" | bsub -J ms_q_amr${K} -oo ${log} -We 24:00 -n $threads -M ${mem} -R "rusage[mem=${pmem}]" -R "span[hosts=1]"

--- a/visualization/geolocation/README.md
+++ b/visualization/geolocation/README.md
@@ -24,7 +24,7 @@ open world_data.html
 
 1. Run server
 ```
-../../metagraph/build/metagraph server_query -i data/test_graph -a data/test_annotation.column.annodbg --count-labels
+../../metagraph/build/metagraph server_query -i data/test_graph -a data/test_annotation.column.annodbg
 ```
 2. Run client
 ```

--- a/visualization/geolocation/sequence_annotator.py
+++ b/visualization/geolocation/sequence_annotator.py
@@ -28,7 +28,7 @@ class SequenceAnnotator():
                     self.executable, 'query',
                     '-i', self.graph,
                     '-a', self.annotation,
-                    '--count-labels',
+                    *('--query-mode matches'.split()),
                     f_in.name
                 ],
                 stderr=subprocess.STDOUT


### PR DESCRIPTION
* Query modes (labels, num. matches, counts, coords, ...) to make the priorities clear
* Removed the support for quantile computation -- can always be done in postprocessing