### PR TITLE
Add missing headers to `binary_matrix.hpp`

### DIFF
--- a/metagraph/src/annotation/binary_matrix/base/binary_matrix.hpp
+++ b/metagraph/src/annotation/binary_matrix/base/binary_matrix.hpp
@@ -3,6 +3,8 @@
 
 #include <vector>
 #include <functional>
+#include <istream>
+#include <ostream>
 
 #include "common/vector.hpp"
 


### PR DESCRIPTION
Add required `<istream>` and `<ostream>` headers.  

The stream types are referenced within the class and, at least under `g++11`, didn't seem to make their way into scope via another path within this file.  Adding them here allowed the code to compile successfully.