### PR TITLE
Fix CI failures for MacOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -167,7 +167,7 @@ jobs:
       run: brew install bzip2 libomp boost jemalloc autoconf automake libtool
 
     - name: install dependencies for integration tests
-      run: pip3 install parameterized
+      run: pip3 install parameterized --break-system-packages --user
 
     - name: install sdsl-lite
       run: |

--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -269,7 +269,6 @@ include_directories(
   external-libraries/spdlog/include
   external-libraries/zlib
   external-libraries/sdust
-  external-libraries/simde-no-tests
   ${PROJECT_SOURCE_DIR}/src
 )
 
@@ -277,6 +276,7 @@ include_directories(
 include_directories(
   PUBLIC SYSTEM
   external-libraries/asio/asio/include
+  external-libraries/simde-no-tests
 )
 
 add_library(ips4o INTERFACE)

--- a/metagraph/src/common/utils/simd_utils.hpp
+++ b/metagraph/src/common/utils/simd_utils.hpp
@@ -87,13 +87,13 @@ inline uint64_t restrict_to(uint64_t h, size_t size) {
 
 SIMDE_FUNCTION_ATTRIBUTES simde__m256i restrict_to_mask_epi64(const uint64_t *hashes, size_t size, simde__m256i mask) {
     // TODO: is there a vectorized way of doing this?
-    return simde_mm256_and_si256(
-        simde_mm256_setr_epi64x(restrict_to(hashes[0], size),
-                                restrict_to(hashes[1], size),
-                                restrict_to(hashes[2], size),
-                                restrict_to(hashes[3], size)),
-        mask
-    );
+    uint64_t mask_words[4] __attribute__ ((aligned (32)));
+    simde_mm256_store_si256((simde__m256i*)mask_words, mask);
+    mask_words[0] &= restrict_to(hashes[0], size);
+    mask_words[1] &= restrict_to(hashes[1], size);
+    mask_words[2] &= restrict_to(hashes[2], size);
+    mask_words[3] &= restrict_to(hashes[3], size);
+    return simde_mm256_load_si256((const simde__m256i*)mask_words);
 }
 
 


### PR DESCRIPTION
MacOS workflows currently produce the following error. The PR is a quick dirty fix to it.

```sh
Run pip3 install parameterized
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try brew install
    xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a Python library that isn't in Homebrew,
    use a virtual environment:
    
    python3 -m venv path/to/venv
    source path/to/venv/bin/activate
    python3 -m pip install xyz
    
    If you wish to install a Python application that isn't in Homebrew,
    it may be easiest to use 'pipx install xyz', which will manage a
    virtual environment for you. You can install pipx with
    
    brew install pipx
    
    You may restore the old behavior of pip by passing
    the '--break-system-packages' flag to pip, or by adding
    'break-system-packages = true' to your pip.conf file. The latter
    will permanently disable this error.
    
    If you disable this error, we STRONGLY recommend that you additionally
    pass the '--user' flag to pip, or set 'user = true' in your pip.conf
    file. Failure to do this can result in a broken Homebrew installation.
    
    Read more about this behavior here: <https://peps.python.org/pep-0668/>
```