### PR TITLE
Update htslib

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -75,7 +75,7 @@ jobs:
             sudo apt-get install ${{ matrix.compiler }}
         fi
 
-        sudo apt-get install libbz2-dev libjemalloc-dev libboost-all-dev
+        sudo apt-get install libbz2-dev libjemalloc-dev libboost-all-dev libdeflate-dev
 
         if [ "${{ matrix.build_static }}" = "ON" ]; then
           # for static builds, compile curl ourselves

--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -402,7 +402,7 @@ set_target_properties(metagraph PROPERTIES OUTPUT_NAME "metagraph_${CMAKE_DBG_AL
 
 set(METALIBS ${METALIBS}
   -lKMC
-  -lhts zlib
+  -lhts zlib deflate
   -lsdsl
   jsoncpp_lib
   progress_bar


### PR DESCRIPTION
Workflows create some linking errors due to libdeflate from htslib. Trying to update submodule and see if it fixes the issue.