### PR TITLE
Option to annotate a representative node from each monochromatic contig

### DIFF
--- a/metagraph/src/cli/build.cpp
+++ b/metagraph/src/cli/build.cpp
@@ -251,12 +251,16 @@ int build_graph(Config *config) {
         }
 
     } else if (config->graph_type == Config::GraphType::SSHASH && !config->dynamic) {
-        graph.reset(new DBGSSHash(files.at(0), config->k, config->graph_mode, config->num_chars));
         if (files.size() > 1) {
             logger->error("DBGSSHash does not support multiple input files.");
             exit(1);
         }
 
+        graph.reset(new DBGSSHash(files.at(0),
+                                  config->k,
+                                  config->graph_mode,
+                                  config->num_chars,
+                                  config->is_monochromatic));
     } else {
         //slower method
         switch (config->graph_type) {

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -151,6 +151,8 @@ Config::Config(int argc, char *argv[]) {
             dynamic = true;
         } else if (!strcmp(argv[i], "--mask-dummy")) {
             mark_dummy_kmers = true;
+        } else if (!strcmp(argv[i], "--is-monochromatic")) {
+            is_monochromatic = true;
         } else if (!strcmp(argv[i], "--anno-filename")) {
             filename_anno = true;
         } else if (!strcmp(argv[i], "--anno-header")) {
@@ -972,6 +974,7 @@ if (advanced) {
             fprintf(stderr, "\t   --mode \t\tk-mer indexing mode: basic / canonical / primary [basic]\n");
 #endif
             fprintf(stderr, "\t   --complete \t\tconstruct a complete graph (only for Bitmap graph) [off]\n");
+            fprintf(stderr, "\t   --is-monochromatic \t\tindicate that the input sequences are monochromatic (i.e., their colouring is constant) [off]\n");
             fprintf(stderr, "\t   --mem-cap-gb [INT] \tpreallocated buffer size in GB [1]\n");
 if (advanced) {
             fprintf(stderr, "\t   --dynamic \t\tuse dynamic build method [off]\n");

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -28,6 +28,7 @@ class Config {
     bool complete = false;
     bool dynamic = false;
     bool mark_dummy_kmers = false;
+    bool is_monochromatic = false;
     bool filename_anno = false;
     bool annotate_sequence_headers = false;
     bool to_adj_list = false;

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -955,8 +955,9 @@ construct_query_graph(const AnnotatedDBG &anno_graph,
     #pragma omp parallel for num_threads(num_threads)
     for (size_t i = 0; i < contigs.size(); ++i) {
         contigs[i].second.reserve(contigs[i].first.length() - graph_init->get_k() + 1);
-        full_dbg.map_to_nodes(contigs[i].first,
-                              [&](node_index node) { contigs[i].second.push_back(node); });
+        call_annotated_nodes_offsets(full_dbg, contigs[i].first, [&](node_index node, int64_t) {
+            contigs[i].second.push_back(node);
+        });
     }
     logger->trace("[Query graph construction] Contigs mapped to the full graph in {} sec",
                   timer.elapsed());

--- a/metagraph/src/common/algorithms.hpp
+++ b/metagraph/src/common/algorithms.hpp
@@ -53,8 +53,7 @@ namespace utils {
                                                     size_t segment_length) {
         std::vector<bool> mask(array.size(), false);
         size_t last_occurrence
-            = std::find(array.data(), array.data() + array.size(), label)
-                - array.data();
+            = std::find(array.begin(), array.end(), label) - array.begin();
 
         for (size_t i = last_occurrence; i < array.size(); ++i) {
             if (array[i] == label)

--- a/metagraph/src/graph/alignment/annotation_buffer.cpp
+++ b/metagraph/src/graph/alignment/annotation_buffer.cpp
@@ -48,6 +48,7 @@ void AnnotationBuffer::fetch_queued_annotations() {
 
     for (const auto &path : queued_paths_) {
         std::vector<node_index> base_path;
+        std::vector<int64_t> base_path_offsets;
         if (base_graph->get_mode() == DeBruijnGraph::CANONICAL) {
             // TODO: avoid this call of spell_path
             std::string query = spell_path(graph_, path);

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -27,22 +27,9 @@ typedef std::pair<Label, size_t> StringCountPair;
 void call_annotated_nodes_offsets(const SequenceGraph &graph,
                                   std::string_view sequence,
                                   const std::function<void(SequenceGraph::node_index, int64_t)> &callback) {
-    const auto *graph_ptr = &graph;
-    const auto *canonical = dynamic_cast<const CanonicalDBG*>(graph_ptr);
-    if (canonical)
-        graph_ptr = &canonical->get_graph();
-
-    if (const auto *sshash = dynamic_cast<const DBGSSHash*>(graph_ptr)) {
-        if (sshash->is_monochromatic()) {
-            if (canonical || sshash->get_mode() == DeBruijnGraph::CANONICAL) {
-                sshash->map_to_contigs_with_rc<true>(sequence, [&](SequenceGraph::node_index i, int64_t offset, bool) {
-                    callback(i, offset);
-                });
-            } else {
-                sshash->map_to_contigs_with_rc<false>(sequence, [&](SequenceGraph::node_index i, int64_t offset, bool) {
-                    callback(i, offset);
-                });
-            }
+    if (const auto *dbg = dynamic_cast<const DeBruijnGraph*>(&graph)) {
+        if (dbg->is_monochromatic()) {
+            dbg->map_to_contigs(sequence, callback);
             return;
         }
     }

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -177,16 +177,13 @@ void AnnotatedDBG::add_kmer_coord(std::string_view sequence,
     auto it = offsets.begin();
     uint64_t last_coord = std::numeric_limits<uint64_t>::max();
     int64_t last_offset = std::numeric_limits<int64_t>::max();
-    node_index last_i = DeBruijnGraph::npos;
     for (node_index i : indices) {
         // only insert coordinates for matched k-mers and increment the coordinates
         if (i > 0) {
             if (last_coord == std::numeric_limits<uint64_t>::max() || coord - *it != last_coord - last_offset) {
-                assert(last_i != i);
                 annotator_->add_label_coord(graph_to_anno_index(i), labels, coord - *it);
                 last_coord = coord;
                 last_offset = *it;
-                last_i = i;
             }
         }
 
@@ -221,17 +218,14 @@ void AnnotatedDBG::add_kmer_coords(
 
         uint64_t last_coord = std::numeric_limits<uint64_t>::max();
         int64_t last_offset = std::numeric_limits<int64_t>::max();
-        node_index last_i = DeBruijnGraph::npos;
         auto it = offsets[t].begin();
         for (node_index i : ids[t]) {
             // only insert coordinates for matched k-mers and increment the coordinates
             if (i > 0) {
                 if (last_coord == std::numeric_limits<uint64_t>::max() || coord - *it != last_coord - last_offset) {
-                    assert(last_i != i);
                     annotator_->add_label_coord(graph_to_anno_index(i), labels, coord - *it);
                     last_coord = coord;
                     last_offset = *it;
-                    last_i = i;
                 }
             }
             coord++;
@@ -265,16 +259,13 @@ void AnnotatedDBG::annotate_kmer_coords(
 
         uint64_t last_coord = std::numeric_limits<uint64_t>::max();
         int64_t last_offset = std::numeric_limits<int64_t>::max();
-        node_index last_i = DeBruijnGraph::npos;
         call_annotated_nodes_offsets(*graph_, sequence, [&](node_index i, int64_t o) {
             if (i > 0) {
                 if (last_coord == std::numeric_limits<uint64_t>::max() || coord - o != last_coord - last_offset) {
-                    assert(last_i != i);
                     ids[last].push_back(graph_to_anno_index(i));
                     coords[last].emplace_back(graph_to_anno_index(i), coord - o);
                     last_coord = coord;
                     last_offset = o;
-                    last_i = i;
                 }
             }
             coord++;

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -27,7 +27,11 @@ typedef std::pair<Label, size_t> StringCountPair;
 void call_annotated_nodes_offsets(const SequenceGraph &graph,
                                   std::string_view sequence,
                                   const std::function<void(SequenceGraph::node_index, int64_t)> &callback) {
-    if (const auto *sshash = dynamic_cast<const DBGSSHash*>(&graph)) {
+    const auto *graph_ptr = &graph;
+    if (const auto *canonical = dynamic_cast<const CanonicalDBG*>(graph_ptr))
+        graph_ptr = &canonical->get_graph();
+
+    if (const auto *sshash = dynamic_cast<const DBGSSHash*>(graph_ptr)) {
         if (sshash->is_monochromatic()) {
             sshash->map_to_contigs_with_rc(sequence, [&](SequenceGraph::node_index i, int64_t offset, bool) {
                 callback(i, offset);

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -334,7 +334,7 @@ AnnotatedDBG::get_labels(const std::vector<std::pair<row_index, size_t>> &index_
 }
 
 std::vector<Label>
-AnnotatedSequenceGraph::get_labels(node_index index) const {
+AnnotatedSequenceGraph::get_stored_labels(node_index index) const {
     assert(check_compatibility());
     assert(index != SequenceGraph::npos);
 

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -28,14 +28,21 @@ void call_annotated_nodes_offsets(const SequenceGraph &graph,
                                   std::string_view sequence,
                                   const std::function<void(SequenceGraph::node_index, int64_t)> &callback) {
     const auto *graph_ptr = &graph;
-    if (const auto *canonical = dynamic_cast<const CanonicalDBG*>(graph_ptr))
+    const auto *canonical = dynamic_cast<const CanonicalDBG*>(graph_ptr);
+    if (canonical)
         graph_ptr = &canonical->get_graph();
 
     if (const auto *sshash = dynamic_cast<const DBGSSHash*>(graph_ptr)) {
         if (sshash->is_monochromatic()) {
-            sshash->map_to_contigs_with_rc(sequence, [&](SequenceGraph::node_index i, int64_t offset, bool) {
-                callback(i, offset);
-            });
+            if (canonical || sshash->get_mode() == DeBruijnGraph::CANONICAL) {
+                sshash->map_to_contigs_with_rc<true>(sequence, [&](SequenceGraph::node_index i, int64_t offset, bool) {
+                    callback(i, offset);
+                });
+            } else {
+                sshash->map_to_contigs_with_rc<false>(sequence, [&](SequenceGraph::node_index i, int64_t offset, bool) {
+                    callback(i, offset);
+                });
+            }
             return;
         }
     }

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -28,7 +28,10 @@ class AnnotatedSequenceGraph {
 
     virtual ~AnnotatedSequenceGraph() {}
 
-    virtual std::vector<Label> get_labels(node_index index) const;
+    // Return the labels explicitly stored at this node. Some annotation schemes
+    // may not store labels at all nodes
+    // (e.g., canonical-mode graphs only annotate canonical k-mers)
+    virtual std::vector<Label> get_stored_labels(node_index index) const;
 
     // thread-safe, can be called from multiple threads concurrently
     virtual void annotate_sequence(std::string_view sequence,
@@ -72,7 +75,7 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                  std::unique_ptr<Annotator>&& annotation,
                  bool force_fast = false);
 
-    using AnnotatedSequenceGraph::get_labels;
+    using AnnotatedSequenceGraph::get_stored_labels;
 
     const DeBruijnGraph& get_graph() const { return dbg_; }
 

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -149,7 +149,8 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
     get_kmer_coordinates(const std::vector<node_index> &nodes,
                          size_t num_top_labels,
                          double discovery_fraction,
-                         double presence_fraction) const;
+                         double presence_fraction,
+                         const std::vector<int64_t> &offsets = {}) const;
 
     std::vector<std::pair<Label, sdsl::bit_vector>>
     get_top_label_signatures(std::string_view sequence,
@@ -164,6 +165,10 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
   private:
     DeBruijnGraph &dbg_;
 };
+
+void call_annotated_nodes_offsets(const SequenceGraph &graph,
+                                  std::string_view sequence,
+                                  const std::function<void(SequenceGraph::node_index, int64_t)> &callback);
 
 } // namespace graph
 } // namespace mtg

--- a/metagraph/src/graph/representation/base/sequence_graph.cpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.cpp
@@ -482,6 +482,9 @@ void DeBruijnGraph::map_to_contigs(std::string_view sequence,
     map_to_nodes(sequence, [&](node_index node) { callback(node, 0); }, terminate);
 }
 
+node_index DeBruijnGraph::get_contig_id(node_index node) const { return node; }
+node_index DeBruijnGraph::get_last_node_in_contig(node_index contig_id) const { return contig_id; }
+
 void DeBruijnGraph::print(std::ostream &out) const {
     std::string vertex_header("Vertex");
     vertex_header.resize(get_k(), ' ');

--- a/metagraph/src/graph/representation/base/sequence_graph.cpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.cpp
@@ -476,6 +476,12 @@ void DeBruijnGraph
     }, stop_early);
 }
 
+void DeBruijnGraph::map_to_contigs(std::string_view sequence,
+                                   const std::function<void(node_index, int64_t)> &callback,
+                                   const std::function<bool()> &terminate) const {
+    map_to_nodes(sequence, [&](node_index node) { callback(node, 0); }, terminate);
+}
+
 void DeBruijnGraph::print(std::ostream &out) const {
     std::string vertex_header("Vertex");
     vertex_header.resize(get_k(), ' ');

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -173,6 +173,9 @@ class DeBruijnGraph : public SequenceGraph {
                                 const std::function<void(node_index, int64_t)> &callback,
                                 const std::function<bool()> &terminate = [](){ return false; }) const;
 
+    virtual node_index get_contig_id(node_index node) const;
+    virtual node_index get_last_node_in_contig(node_index contig_id) const;
+
     // Given a starting node and a sequence of edge labels, traverse the graph
     // forward. The traversal is terminated once terminate() returns true or
     // when the sequence is exhausted.

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -243,6 +243,8 @@ class DeBruijnGraph : public SequenceGraph {
 
     // Call all nodes that have no incoming edges
     virtual void call_source_nodes(const std::function<void(node_index)> &callback) const;
+
+    virtual bool is_monochromatic() const { return false; }
 };
 
 

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -165,6 +165,14 @@ class DeBruijnGraph : public SequenceGraph {
     // Traverse the incoming edge
     virtual node_index traverse_back(node_index node, char prev_char) const = 0;
 
+    // If a graph has defined contigs, then map each k-mer in sequence to a
+    // representative node of the contig to which it maps and offset (traversal distance)
+    // to that representative node.
+    // If no contigs are defined, this functions identically to map_to_nodes
+    virtual void map_to_contigs(std::string_view sequence,
+                                const std::function<void(node_index, int64_t)> &callback,
+                                const std::function<bool()> &terminate = [](){ return false; }) const;
+
     // Given a starting node and a sequence of edge labels, traverse the graph
     // forward. The traversal is terminated once terminate() returns true or
     // when the sequence is exhausted.

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -180,7 +180,7 @@ void CanonicalDBG::call_outgoing_kmers(node_index node,
     }
 
     if (const auto sshash = std::dynamic_pointer_cast<const DBGSSHash>(graph_)) {
-        sshash->call_outgoing_kmers_with_rc<>(node, [&](node_index next, char c, bool orientation) {
+        sshash->call_outgoing_kmers_with_rc<true>(node, [&](node_index next, char c, bool orientation) {
             callback(orientation ? reverse_complement(next) : next, c);
         });
         return;
@@ -273,7 +273,7 @@ void CanonicalDBG::call_incoming_kmers(node_index node,
     }
 
     if (const auto sshash = std::dynamic_pointer_cast<const DBGSSHash>(graph_)) {
-        sshash->call_incoming_kmers_with_rc<>(node, [&](node_index prev, char c, bool orientation) {
+        sshash->call_incoming_kmers_with_rc<true>(node, [&](node_index prev, char c, bool orientation) {
             callback(orientation ? reverse_complement(prev) : prev, c);
         });
         return;

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -64,7 +64,7 @@ void CanonicalDBG
     path.reserve(sequence.size() - get_k() + 1);
 
     if (const auto sshash = std::dynamic_pointer_cast<const DBGSSHash>(graph_)) {
-        sshash->map_to_nodes_with_rc<>(sequence, [&](node_index node, bool orientation) {
+        sshash->map_to_nodes_with_rc<true>(sequence, [&](node_index node, bool orientation) {
             callback(node && orientation ? reverse_complement(node) : node);
         }, terminate);
         return;

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -115,6 +115,8 @@ class CanonicalDBG : public DBGWrapper<DeBruijnGraph> {
 
     virtual bool operator==(const DeBruijnGraph &other) const override final;
 
+    virtual bool is_monochromatic() const override final { return graph_->is_monochromatic(); }
+
   private:
     const size_t cache_size_;
 

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -49,6 +49,10 @@ class CanonicalDBG : public DBGWrapper<DeBruijnGraph> {
                               const std::function<void(node_index)> &callback,
                               const std::function<bool()> &terminate = [](){ return false; }) const override final;
 
+    virtual void map_to_contigs(std::string_view sequence,
+                                const std::function<void(node_index, int64_t)> &callback,
+                                const std::function<bool()> &terminate = [](){ return false; }) const override final;
+
     // Traverse graph mapping sequence to the graph nodes
     // and run callback for each node until the termination condition is satisfied.
     // Guarantees that nodes are called in the same order as the input sequence

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -262,6 +262,7 @@ void DBGSSHash::map_to_contigs_with_rc(std::string_view sequence,
                     if (is_monochromatic()) {
                         assert(monotig_id_.size() == dict_size());
                         assert(monotig_id_[res.kmer_id] || res.kmer_id_in_contig);
+                        assert(monotig_id_.prev1(res.kmer_id) >= res.kmer_id - res.kmer_id_in_contig);
                         res.kmer_id_in_contig = res.kmer_id - monotig_id_.prev1(res.kmer_id);
                     }
 

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -259,7 +259,7 @@ void DBGSSHash::map_to_contigs_with_rc(std::string_view sequence,
         node_index node = sshash_to_graph_index(res.kmer_id);
         if (node != npos) {
             if (is_monochromatic()) {
-                assert(monotig_id_.size() == num_nodes());
+                assert(monotig_id_.size() == dict_size());
                 assert(monotig_id_[res.kmer_id] || res.kmer_id_in_contig);
                 if (last_node != npos && node == last_node + 1) {
                     if (res.kmer_id == next_breakpoint) {

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -119,12 +119,12 @@ void map_to_nodes_with_rc_impl(size_t k,
 
     using kmer_t = get_kmer_t<Dict>;
 
-    std::vector<bool> seq_encoded(n);
+    std::vector<bool> invalid_char(n);
     for (size_t i = 0; i < n; ++i) {
-        seq_encoded[i] = !kmer_t::is_valid(sequence[i]);
+        invalid_char[i] = !kmer_t::is_valid(sequence[i]);
     }
 
-    auto invalid_kmer = utils::drag_and_mark_segments(seq_encoded, 1, k);
+    auto invalid_kmer = utils::drag_and_mark_segments(invalid_char, true, k);
 
     kmer_t uint_kmer = sshash::util::string_to_uint_kmer<kmer_t>(sequence.data(), k - 1);
     uint_kmer.pad_char();

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -114,8 +114,7 @@ void DBGSSHash
         std::vector<char> seq_encoded;
         seq_encoded.reserve(sequence.size());
         for (size_t i = 0; i < sequence.size(); ++i) {
-            char enc = kmer_t::canonicalize_basepair_forward_map[static_cast<uint8_t>(sequence[i])];
-            seq_encoded.emplace_back(enc == '\0');
+            seq_encoded.emplace_back(!kmer_t::is_valid(sequence[i]));
         }
 
         auto invalid = utils::drag_and_mark_segments(seq_encoded, 1, k_);

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -181,6 +181,8 @@ DBGSSHash::DBGSSHash(const std::string &input_filename,
         auto is_breakpoint = [this,canonical=std::move(canonical)](node_index node) {
             if (canonical) {
                 return !canonical->has_single_incoming(node) || !canonical->has_single_incoming(reverse_complement(node));
+            } else if (mode_ == CANONICAL) {
+                return !has_single_incoming(node) || !has_single_incoming(reverse_complement(node));
             } else {
                 return !has_single_incoming(node);
             }

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -151,9 +151,9 @@ DBGSSHash::DBGSSHash(const std::string &input_filename,
 
         auto is_breakpoint = [this,canonical=std::move(canonical)](node_index node) {
             if (canonical) {
-                return !canonical->has_single_incoming(node) || canonical->has_multiple_outgoing(node);
+                return !canonical->has_single_incoming(node) || !canonical->has_single_incoming(reverse_complement(node));
             } else {
-                return !has_single_incoming(node) || has_multiple_outgoing(node);
+                return !has_single_incoming(node);
             }
         };
 

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -240,6 +240,25 @@ void DBGSSHash::map_to_nodes_with_rc<false>(std::string_view,
                                             const std::function<void(node_index, bool)>&,
                                             const std::function<bool()>&) const;
 
+void DBGSSHash::map_to_contigs(std::string_view sequence,
+                               const std::function<void(node_index, int64_t)>& callback,
+                               const std::function<bool()>& terminate) const {
+    if (!is_monochromatic()) {
+        DeBruijnGraph::map_to_contigs(sequence, callback, terminate);
+        return;
+    }
+
+    if (mode_ != CANONICAL) {
+        map_to_contigs_with_rc<false>(sequence, [&](node_index node, int64_t offset, bool) {
+            callback(node, offset);
+        });
+    } else {
+        map_to_contigs_with_rc<true>(sequence, [&](node_index node, int64_t offset, bool) {
+            callback(node, offset);
+        });
+    }
+}
+
 template <bool with_rc>
 void DBGSSHash::map_to_contigs_with_rc(std::string_view sequence,
                                        const std::function<void(node_index, int64_t, bool)>& callback,

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -100,7 +100,7 @@ void DBGSSHash::add_sequence(std::string_view sequence,
     throw std::logic_error("adding sequences not supported");
 }
 
-template <class Dict, bool with_rc>
+template <bool with_rc, class Dict>
 void map_to_nodes_with_rc_impl(size_t k,
                                const Dict &dict,
                                std::string_view sequence,
@@ -141,7 +141,7 @@ void DBGSSHash::map_to_nodes_with_rc(std::string_view sequence,
                                      const std::function<void(node_index, bool)>& callback,
                                      const std::function<bool()>& terminate) const {
     std::visit([&](const auto &dict) {
-        map_to_nodes_with_rc_impl<decltype(dict), with_rc>(k_, dict, sequence, [&](sshash::lookup_result res) {
+        map_to_nodes_with_rc_impl<with_rc>(k_, dict, sequence, [&](sshash::lookup_result res) {
             callback(sshash_to_graph_index(res.kmer_id), res.kmer_orientation);
         }, terminate);
     }, dict_);

--- a/metagraph/src/graph/representation/hash/dbg_sshash.hpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.hpp
@@ -8,6 +8,7 @@
 #include <sdsl/uint256_t.hpp>
 
 #include "graph/representation/base/sequence_graph.hpp"
+#include "common/vectors/bit_vector_adaptive.hpp"
 
 namespace mtg::graph {
 
@@ -31,7 +32,7 @@ class DBGSSHash : public DeBruijnGraph {
                         sshash::dictionary<kmer_t<KmerInt256>>>;
 
     explicit DBGSSHash(size_t k, Mode mode = BASIC);
-    DBGSSHash(const std::string &input_filename, size_t k, Mode mode = BASIC, size_t num_chars = 0);
+    DBGSSHash(const std::string &input_filename, size_t k, Mode mode = BASIC, size_t num_chars = 0, bool is_monochromatic = false);
 
     // SequenceGraph overrides
     void add_sequence(
@@ -54,6 +55,12 @@ class DBGSSHash : public DeBruijnGraph {
             const std::function<void(node_index, bool)>& callback,
             const std::function<bool()>& terminate = []() { return false; }) const;
 
+    template <bool with_rc = true>
+    void map_to_contigs_with_rc(
+            std::string_view sequence,
+            const std::function<void(node_index, int64_t, bool)>& callback,
+            const std::function<bool()>& terminate = []() { return false; }) const;
+
     uint64_t num_nodes() const override;
 
     bool load(std::istream& in);
@@ -71,6 +78,8 @@ class DBGSSHash : public DeBruijnGraph {
     size_t get_k() const override final { return k_; }
 
     Mode get_mode() const override final { return mode_; }
+
+    bool is_monochromatic() const override { return monotig_id_.size(); }
 
     node_index traverse(node_index node, char next_char) const override;
     node_index traverse_back(node_index node, char prev_char) const override;
@@ -116,6 +125,7 @@ class DBGSSHash : public DeBruijnGraph {
     size_t k_;
     size_t num_nodes_;
     Mode mode_;
+    bit_vector_rrr<> monotig_id_;
 
     void map_to_nodes_with_rc_advanced(
             std::string_view sequence,

--- a/metagraph/src/graph/representation/hash/dbg_sshash.hpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.hpp
@@ -49,6 +49,10 @@ class DBGSSHash : public DeBruijnGraph {
             const std::function<void(node_index)>& callback,
             const std::function<bool()>& terminate = []() { return false; }) const override;
 
+    void map_to_contigs(std::string_view sequence,
+            const std::function<void(node_index, int64_t)>& callback,
+            const std::function<bool()>& terminate = []() { return false; }) const override;
+
     template <bool with_rc = true>
     void map_to_nodes_with_rc(
             std::string_view sequence,

--- a/metagraph/src/graph/representation/hash/dbg_sshash.hpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.hpp
@@ -117,6 +117,12 @@ class DBGSSHash : public DeBruijnGraph {
     size_t num_nodes_;
     Mode mode_;
 
+    void map_to_nodes_with_rc_advanced(
+            std::string_view sequence,
+            const std::function<void(sshash::lookup_result)>& callback,
+            bool with_rc,
+            const std::function<bool()>& terminate = []() { return false; }) const;
+
     size_t dict_size() const;
 };
 

--- a/metagraph/src/graph/representation/hash/dbg_sshash.hpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.hpp
@@ -117,12 +117,6 @@ class DBGSSHash : public DeBruijnGraph {
     size_t num_nodes_;
     Mode mode_;
 
-    void map_to_nodes_with_rc_advanced(
-            std::string_view sequence,
-            const std::function<void(sshash::lookup_result)>& callback,
-            bool with_rc,
-            const std::function<bool()>& terminate = []() { return false; }) const;
-
     size_t dict_size() const;
 };
 

--- a/metagraph/src/graph/representation/hash/dbg_sshash.hpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.hpp
@@ -53,6 +53,9 @@ class DBGSSHash : public DeBruijnGraph {
             const std::function<void(node_index, int64_t)>& callback,
             const std::function<bool()>& terminate = []() { return false; }) const override;
 
+    node_index get_contig_id(node_index node) const override;
+    node_index get_last_node_in_contig(node_index contig_id) const override;
+
     template <bool with_rc = true>
     void map_to_nodes_with_rc(
             std::string_view sequence,

--- a/metagraph/tests/annotation/test_aligner_labeled.cpp
+++ b/metagraph/tests/annotation/test_aligner_labeled.cpp
@@ -52,6 +52,7 @@ class LabeledAlignerTest : public ::testing::Test {};
 
 typedef ::testing::Types<std::pair<DBGHashFast, annot::ColumnCompressed<>>,
                          std::pair<DBGSuccinct, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHash,   annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::RowFlatAnnotator>,
                          std::pair<DBGSuccinct, annot::RowFlatAnnotator>,
                          std::pair<DBGSuccinct, annot::RowDiffColumnAnnotator>> FewGraphAnnotationPairTypes;

--- a/metagraph/tests/annotation/test_aligner_labeled.cpp
+++ b/metagraph/tests/annotation/test_aligner_labeled.cpp
@@ -53,6 +53,7 @@ class LabeledAlignerTest : public ::testing::Test {};
 typedef ::testing::Types<std::pair<DBGHashFast, annot::ColumnCompressed<>>,
                          std::pair<DBGSuccinct, annot::ColumnCompressed<>>,
                          std::pair<DBGSSHash,   annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHashMonochromatic, annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::RowFlatAnnotator>,
                          std::pair<DBGSuccinct, annot::RowFlatAnnotator>,
                          std::pair<DBGSuccinct, annot::RowDiffColumnAnnotator>> FewGraphAnnotationPairTypes;

--- a/metagraph/tests/annotation/test_annotated_dbg.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg.cpp
@@ -28,16 +28,16 @@ void check_labels(const AnnotatedDBG &anno_graph,
                   const std::vector<std::string> labels_present,
                   const std::vector<std::string> labels_not_present) {
     std::set<SequenceGraph::node_index> indices;
-    anno_graph.get_graph().map_to_nodes(
-        sequence,
-        [&](const auto &index) {
-            ASSERT_NE(SequenceGraph::npos, index);
-            indices.insert(index);
-            EXPECT_EQ(labels_present.size(), anno_graph.get_labels(index).size());
-            EXPECT_EQ(convert_to_set(labels_present),
-                      convert_to_set(anno_graph.get_labels(index)));
-        }
-    );
+    call_annotated_nodes_offsets(anno_graph.get_graph(), sequence, [&](auto index, int64_t) {
+        ASSERT_NE(SequenceGraph::npos, index);
+        indices.insert(index);
+        EXPECT_EQ(labels_present.size(), anno_graph.get_labels(index).size());
+        EXPECT_EQ(convert_to_set(labels_present),
+                  convert_to_set(anno_graph.get_labels(index)));
+    });
+
+    EXPECT_EQ(convert_to_set(labels_present),
+              convert_to_set(anno_graph.get_labels(sequence)));
 
     for (const auto &label : labels_present) {
         std::set<SequenceGraph::node_index> cur_indices;
@@ -985,6 +985,7 @@ typedef ::testing::Types<std::pair<DBGBitmap, annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::ColumnCompressed<>>,
                          std::pair<DBGSuccinct, annot::ColumnCompressed<>>,
                          std::pair<DBGSSHash, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHashMonochromatic, annot::ColumnCompressed<>>,
                          std::pair<DBGBitmap, annot::RowFlatAnnotator>,
                          std::pair<DBGHashString, annot::RowFlatAnnotator>,
                          std::pair<DBGHashOrdered, annot::RowFlatAnnotator>,
@@ -1015,6 +1016,7 @@ typedef ::testing::Types<std::pair<DBGBitmap, annot::ColumnCompressed<>>,
                          std::pair<DBGHashOrdered, annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::ColumnCompressed<>>,
                          std::pair<DBGSSHash, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHashMonochromatic, annot::ColumnCompressed<>>,
                          std::pair<DBGBitmap, annot::RowFlatAnnotator>,
                          std::pair<DBGHashOrdered, annot::RowFlatAnnotator>,
                          std::pair<DBGHashFast, annot::RowFlatAnnotator>,

--- a/metagraph/tests/annotation/test_annotated_dbg.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg.cpp
@@ -4,15 +4,12 @@
 #include "gtest/gtest.h"
 
 #include "../test_helpers.hpp"
+#include "../graph/all/test_dbg_helpers.hpp"
 
 #include "common/threads/threading.hpp"
 #include "common/vectors/bit_vector_dyn.hpp"
 #include "common/vectors/vector_algorithm.hpp"
 #include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
-#include "graph/representation/bitmap/dbg_bitmap.hpp"
-#include "graph/representation/hash/dbg_hash_string.hpp"
-#include "graph/representation/hash/dbg_hash_ordered.hpp"
-#include "graph/representation/hash/dbg_hash_fast.hpp"
 
 #define protected public
 #define private public
@@ -987,6 +984,7 @@ typedef ::testing::Types<std::pair<DBGBitmap, annot::ColumnCompressed<>>,
                          std::pair<DBGHashOrdered, annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::ColumnCompressed<>>,
                          std::pair<DBGSuccinct, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHash, annot::ColumnCompressed<>>,
                          std::pair<DBGBitmap, annot::RowFlatAnnotator>,
                          std::pair<DBGHashString, annot::RowFlatAnnotator>,
                          std::pair<DBGHashOrdered, annot::RowFlatAnnotator>,
@@ -1016,6 +1014,7 @@ class AnnotatedDBGNoNTest : public ::testing::Test {};
 typedef ::testing::Types<std::pair<DBGBitmap, annot::ColumnCompressed<>>,
                          std::pair<DBGHashOrdered, annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHash, annot::ColumnCompressed<>>,
                          std::pair<DBGBitmap, annot::RowFlatAnnotator>,
                          std::pair<DBGHashOrdered, annot::RowFlatAnnotator>,
                          std::pair<DBGHashFast, annot::RowFlatAnnotator>,

--- a/metagraph/tests/annotation/test_annotated_dbg.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg.cpp
@@ -32,7 +32,7 @@ void check_labels(const AnnotatedDBG &anno_graph,
     call_annotated_nodes_offsets(graph, sequence, [&](auto index, int64_t) {
         ASSERT_NE(SequenceGraph::npos, index);
         indices.insert(index);
-        auto cur_labels = anno_graph.get_labels(index);
+        auto cur_labels = anno_graph.get_stored_labels(index);
         EXPECT_EQ(labels_present.size(), cur_labels.size());
         EXPECT_EQ(convert_to_set(labels_present), convert_to_set(cur_labels));
 
@@ -46,7 +46,7 @@ void check_labels(const AnnotatedDBG &anno_graph,
                       convert_to_set(cur_labels));
 
             for (DeBruijnGraph::node_index node = contig_id + 1; node <= last_node; ++node) {
-                EXPECT_TRUE(anno_graph.get_labels(node).empty());
+                EXPECT_TRUE(anno_graph.get_stored_labels(node).empty());
             }
         }
     });

--- a/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
@@ -236,6 +236,7 @@ template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashOrdered, ColumnCo
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashFast, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashString, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGSSHash, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
+template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGSSHashMonochromatic, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGSuccinct, RowFlatAnnotator>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGBitmap, RowFlatAnnotator>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);

--- a/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
@@ -235,6 +235,7 @@ template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGBitmap, ColumnCompres
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashOrdered, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashFast, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashString, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
+template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGSSHash, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGSuccinct, RowFlatAnnotator>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGBitmap, RowFlatAnnotator>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -159,7 +159,7 @@ build_graph<DBGSSHash>(uint64_t k,
     if (sequences.empty())
         return std::make_shared<DBGSSHash>(k, mode);
 
-    // use DBGHashString to get contigs for SSHash
+    // use DBGHashFast to get contigs for SSHash
     auto string_graph = build_graph<DBGHashFast>(k, sequences, mode);
 
     std::vector<std::string> contigs;

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -1,6 +1,10 @@
 #include "test_dbg_helpers.hpp"
 
+#include "../../annotation/test_annotated_dbg_helpers.hpp"
+#include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
+
 #include "gtest/gtest.h"
+#include "graph/annotated_dbg.hpp"
 #include "graph/representation/canonical_dbg.hpp"
 #include "graph/representation/succinct/boss.hpp"
 #include "graph/representation/succinct/boss_construct.hpp"

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -249,6 +249,11 @@ build_graph<DBGSSHashMonochromatic>(uint64_t k,
     if (contigs.empty())
         return std::make_shared<DBGSSHash>(k, mode);
 
+    for (const auto &contig : contigs) {
+        EXPECT_EQ(string_anno_graph->get_labels(contig, 0.0),
+                  string_anno_graph->get_labels(contig, 1.0));
+    }
+
     std::string dump_path = "../tests/data/sshash_sequences/contigs.fa";
     writeFastaFile(contigs, dump_path);
 

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -1,6 +1,10 @@
 #include "test_dbg_helpers.hpp"
 
+#include "../../annotation/test_annotated_dbg_helpers.hpp"
+#include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
+
 #include "gtest/gtest.h"
+#include "graph/annotated_dbg.hpp"
 #include "graph/representation/canonical_dbg.hpp"
 #include "graph/representation/succinct/boss.hpp"
 #include "graph/representation/succinct/boss_construct.hpp"
@@ -146,6 +150,7 @@ void writeFastaFile(const std::vector<std::string>& sequences, const std::string
 
     fastaFile.close();
 }
+
 template <>
 std::shared_ptr<DeBruijnGraph>
 build_graph<DBGSSHash>(uint64_t k,
@@ -155,7 +160,7 @@ build_graph<DBGSSHash>(uint64_t k,
         return std::make_shared<DBGSSHash>(k, mode);
 
     // use DBGHashString to get contigs for SSHash
-    auto string_graph = build_graph<DBGHashString>(k, sequences, mode);
+    auto string_graph = build_graph<DBGHashFast>(k, sequences, mode);
 
     std::vector<std::string> contigs;
     size_t num_kmers = 0;

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -198,11 +198,19 @@ build_graph<DBGSSHashMonochromatic>(uint64_t k,
     if (sequences.empty())
         return std::make_shared<DBGSSHash>(k, mode);
 
+    std::string alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    std::vector<std::string> label_reserve;
+    label_reserve.reserve(alphabet.size());
+    for (char c : alphabet) {
+        label_reserve.emplace_back(1, c);
+    }
+
     std::vector<std::string> labels;
     labels.reserve(sequences.size());
-    char end_char = 'A' + sequences.size();
-    for (char c = 'A'; c < end_char; ++c) {
-        labels.emplace_back(1, c);
+    for (size_t i = 0; i < sequences.size(); ++i) {
+        label_reserve[i % alphabet.size()] += std::string(i / alphabet.size(),
+                                                          alphabet[i % alphabet.size()]);
+        labels.emplace_back(label_reserve[i % alphabet.size()]);
     }
 
     // use DBGHashString to get contigs for SSHash

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -1,10 +1,6 @@
 #include "test_dbg_helpers.hpp"
 
-#include "../../annotation/test_annotated_dbg_helpers.hpp"
-#include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
-
 #include "gtest/gtest.h"
-#include "graph/annotated_dbg.hpp"
 #include "graph/representation/canonical_dbg.hpp"
 #include "graph/representation/succinct/boss.hpp"
 #include "graph/representation/succinct/boss_construct.hpp"

--- a/metagraph/tests/graph/all/test_dbg_helpers.hpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.hpp
@@ -53,6 +53,13 @@ class DBGSuccinctCached : public DBGSuccinct {
           : DBGSuccinct(std::forward<Args>(args)...) {}
 };
 
+class DBGSSHashMonochromatic : public DBGSSHash {
+  public:
+    template <typename... Args>
+    DBGSSHashMonochromatic(Args&&... args)
+          : DBGSSHash(std::forward<Args>(args)...) {}
+};
+
 template <class Graph>
 std::shared_ptr<DeBruijnGraph>
 build_graph(uint64_t k,
@@ -93,6 +100,7 @@ typedef ::testing::Types<DBGBitmap,
                          DBGHashOrdered,
                          DBGHashFast,
                          DBGSSHash,
+                         DBGSSHashMonochromatic,
                          DBGSuccinct,
                          DBGSuccinctIndexed<1>,
                          DBGSuccinctIndexed<2>,

--- a/metagraph/tests/graph/test_canonical_dbg.cpp
+++ b/metagraph/tests/graph/test_canonical_dbg.cpp
@@ -38,7 +38,8 @@ typedef ::testing::Types<DBGBitmap,
                          DBGSuccinct,
                          DBGSuccinctBloom<4, 1>,
                          DBGSuccinctCached,
-                         DBGSSHash> CanonicalGraphTypes;
+                         DBGSSHash,
+                         DBGSSHashMonochromatic> CanonicalGraphTypes;
 
 TYPED_TEST_SUITE(CanonicalDBGTest, CanonicalGraphTypes);
 

--- a/metagraph/tests/graph/test_dbg_canonical.cpp
+++ b/metagraph/tests/graph/test_dbg_canonical.cpp
@@ -26,7 +26,8 @@ typedef ::testing::Types<DBGBitmap,
                          DBGSuccinct,
                          DBGSuccinctBloom<4, 1>,
                          DBGSuccinctCached,
-                         DBGSSHash> CanonicalGraphTypes;
+                         DBGSSHash,
+                         DBGSSHashMonochromatic> CanonicalGraphTypes;
 TYPED_TEST_SUITE(DeBruijnGraphCanonicalTest, CanonicalGraphTypes);
 
 


### PR DESCRIPTION
Currently this is only implemented for SSHash graphs.

This change stores a bit vector that indicates the breakpoints for monochromatic unitigs in the SSHash graph. This allows us to maintain a lossless annotation while only annotating these breakpoints.