### PR TITLE
Fix for queries with invalid characters

### DIFF
--- a/metagraph/src/common/algorithms.hpp
+++ b/metagraph/src/common/algorithms.hpp
@@ -53,8 +53,7 @@ namespace utils {
                                                     size_t segment_length) {
         std::vector<bool> mask(array.size(), false);
         size_t last_occurrence
-            = std::find(array.data(), array.data() + array.size(), label)
-                - array.data();
+            = std::find(array.begin(), array.end(), label) - array.begin();
 
         for (size_t i = last_occurrence; i < array.size(); ++i) {
             if (array[i] == label)

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -180,7 +180,7 @@ void CanonicalDBG::call_outgoing_kmers(node_index node,
     }
 
     if (const auto sshash = std::dynamic_pointer_cast<const DBGSSHash>(graph_)) {
-        sshash->call_outgoing_kmers_with_rc<>(node, [&](node_index next, char c, bool orientation) {
+        sshash->call_outgoing_kmers_with_rc<true>(node, [&](node_index next, char c, bool orientation) {
             callback(orientation ? reverse_complement(next) : next, c);
         });
         return;
@@ -273,7 +273,7 @@ void CanonicalDBG::call_incoming_kmers(node_index node,
     }
 
     if (const auto sshash = std::dynamic_pointer_cast<const DBGSSHash>(graph_)) {
-        sshash->call_incoming_kmers_with_rc<>(node, [&](node_index prev, char c, bool orientation) {
+        sshash->call_incoming_kmers_with_rc<true>(node, [&](node_index prev, char c, bool orientation) {
             callback(orientation ? reverse_complement(prev) : prev, c);
         });
         return;

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -64,7 +64,7 @@ void CanonicalDBG
     path.reserve(sequence.size() - get_k() + 1);
 
     if (const auto sshash = std::dynamic_pointer_cast<const DBGSSHash>(graph_)) {
-        sshash->map_to_nodes_with_rc<>(sequence, [&](node_index node, bool orientation) {
+        sshash->map_to_nodes_with_rc<true>(sequence, [&](node_index node, bool orientation) {
             callback(node && orientation ? reverse_complement(node) : node);
         }, terminate);
         return;

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -119,12 +119,12 @@ void map_to_nodes_with_rc_impl(size_t k,
 
     using kmer_t = get_kmer_t<Dict>;
 
-    std::vector<bool> seq_encoded(n);
+    std::vector<bool> invalid_char(n);
     for (size_t i = 0; i < n; ++i) {
-        seq_encoded[i] = !kmer_t::is_valid(sequence[i]);
+        invalid_char[i] = !kmer_t::is_valid(sequence[i]);
     }
 
-    auto invalid_kmer = utils::drag_and_mark_segments(seq_encoded, 1, k);
+    auto invalid_kmer = utils::drag_and_mark_segments(invalid_char, true, k);
 
     kmer_t uint_kmer = sshash::util::string_to_uint_kmer<kmer_t>(sequence.data(), k - 1);
     uint_kmer.pad_char();

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -114,8 +114,7 @@ void DBGSSHash
         std::vector<char> seq_encoded;
         seq_encoded.reserve(sequence.size());
         for (size_t i = 0; i < sequence.size(); ++i) {
-            char enc = kmer_t::canonicalize_basepair_forward_map[static_cast<uint8_t>(sequence[i])];
-            seq_encoded.emplace_back(enc == '\0');
+            seq_encoded.emplace_back(!kmer_t::is_valid(sequence[i]));
         }
 
         auto invalid = utils::drag_and_mark_segments(seq_encoded, 1, k_);

--- a/metagraph/src/graph/representation/hash/dbg_sshash.cpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.cpp
@@ -100,7 +100,7 @@ void DBGSSHash::add_sequence(std::string_view sequence,
     throw std::logic_error("adding sequences not supported");
 }
 
-template <class Dict, bool with_rc>
+template <bool with_rc, class Dict>
 void map_to_nodes_with_rc_impl(size_t k,
                                const Dict &dict,
                                std::string_view sequence,
@@ -141,7 +141,7 @@ void DBGSSHash::map_to_nodes_with_rc(std::string_view sequence,
                                      const std::function<void(node_index, bool)>& callback,
                                      const std::function<bool()>& terminate) const {
     std::visit([&](const auto &dict) {
-        map_to_nodes_with_rc_impl<decltype(dict), with_rc>(k_, dict, sequence, [&](sshash::lookup_result res) {
+        map_to_nodes_with_rc_impl<with_rc>(k_, dict, sequence, [&](sshash::lookup_result res) {
             callback(sshash_to_graph_index(res.kmer_id), res.kmer_orientation);
         }, terminate);
     }, dict_);

--- a/metagraph/src/graph/representation/hash/dbg_sshash.hpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.hpp
@@ -117,6 +117,12 @@ class DBGSSHash : public DeBruijnGraph {
     size_t num_nodes_;
     Mode mode_;
 
+    void map_to_nodes_with_rc_advanced(
+            std::string_view sequence,
+            const std::function<void(sshash::lookup_result)>& callback,
+            bool with_rc,
+            const std::function<bool()>& terminate = []() { return false; }) const;
+
     size_t dict_size() const;
 };
 

--- a/metagraph/src/graph/representation/hash/dbg_sshash.hpp
+++ b/metagraph/src/graph/representation/hash/dbg_sshash.hpp
@@ -117,12 +117,6 @@ class DBGSSHash : public DeBruijnGraph {
     size_t num_nodes_;
     Mode mode_;
 
-    void map_to_nodes_with_rc_advanced(
-            std::string_view sequence,
-            const std::function<void(sshash::lookup_result)>& callback,
-            bool with_rc,
-            const std::function<bool()>& terminate = []() { return false; }) const;
-
     size_t dict_size() const;
 };
 

--- a/metagraph/tests/annotation/test_aligner_labeled.cpp
+++ b/metagraph/tests/annotation/test_aligner_labeled.cpp
@@ -52,6 +52,7 @@ class LabeledAlignerTest : public ::testing::Test {};
 
 typedef ::testing::Types<std::pair<DBGHashFast, annot::ColumnCompressed<>>,
                          std::pair<DBGSuccinct, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHash,   annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::RowFlatAnnotator>,
                          std::pair<DBGSuccinct, annot::RowFlatAnnotator>,
                          std::pair<DBGSuccinct, annot::RowDiffColumnAnnotator>> FewGraphAnnotationPairTypes;

--- a/metagraph/tests/annotation/test_annotated_dbg.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg.cpp
@@ -4,15 +4,12 @@
 #include "gtest/gtest.h"
 
 #include "../test_helpers.hpp"
+#include "../graph/all/test_dbg_helpers.hpp"
 
 #include "common/threads/threading.hpp"
 #include "common/vectors/bit_vector_dyn.hpp"
 #include "common/vectors/vector_algorithm.hpp"
 #include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
-#include "graph/representation/bitmap/dbg_bitmap.hpp"
-#include "graph/representation/hash/dbg_hash_string.hpp"
-#include "graph/representation/hash/dbg_hash_ordered.hpp"
-#include "graph/representation/hash/dbg_hash_fast.hpp"
 
 #define protected public
 #define private public
@@ -987,6 +984,7 @@ typedef ::testing::Types<std::pair<DBGBitmap, annot::ColumnCompressed<>>,
                          std::pair<DBGHashOrdered, annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::ColumnCompressed<>>,
                          std::pair<DBGSuccinct, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHash, annot::ColumnCompressed<>>,
                          std::pair<DBGBitmap, annot::RowFlatAnnotator>,
                          std::pair<DBGHashString, annot::RowFlatAnnotator>,
                          std::pair<DBGHashOrdered, annot::RowFlatAnnotator>,
@@ -1016,6 +1014,7 @@ class AnnotatedDBGNoNTest : public ::testing::Test {};
 typedef ::testing::Types<std::pair<DBGBitmap, annot::ColumnCompressed<>>,
                          std::pair<DBGHashOrdered, annot::ColumnCompressed<>>,
                          std::pair<DBGHashFast, annot::ColumnCompressed<>>,
+                         std::pair<DBGSSHash, annot::ColumnCompressed<>>,
                          std::pair<DBGBitmap, annot::RowFlatAnnotator>,
                          std::pair<DBGHashOrdered, annot::RowFlatAnnotator>,
                          std::pair<DBGHashFast, annot::RowFlatAnnotator>,

--- a/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
@@ -235,6 +235,7 @@ template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGBitmap, ColumnCompres
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashOrdered, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashFast, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGHashString, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
+template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGSSHash, ColumnCompressed<>>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGSuccinct, RowFlatAnnotator>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);
 template std::unique_ptr<AnnotatedDBG> build_anno_graph<DBGBitmap, RowFlatAnnotator>(uint64_t, const std::vector<std::string> &, const std::vector<std::string>&, DeBruijnGraph::Mode, bool);

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -159,7 +159,7 @@ build_graph<DBGSSHash>(uint64_t k,
     if (sequences.empty())
         return std::make_shared<DBGSSHash>(k, mode);
 
-    // use DBGHashString to get contigs for SSHash
+    // use DBGHashFast to get contigs for SSHash
     auto string_graph = build_graph<DBGHashFast>(k, sequences, mode);
 
     std::vector<std::string> contigs;

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -1,6 +1,10 @@
 #include "test_dbg_helpers.hpp"
 
+#include "../../annotation/test_annotated_dbg_helpers.hpp"
+#include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
+
 #include "gtest/gtest.h"
+#include "graph/annotated_dbg.hpp"
 #include "graph/representation/canonical_dbg.hpp"
 #include "graph/representation/succinct/boss.hpp"
 #include "graph/representation/succinct/boss_construct.hpp"
@@ -146,6 +150,7 @@ void writeFastaFile(const std::vector<std::string>& sequences, const std::string
 
     fastaFile.close();
 }
+
 template <>
 std::shared_ptr<DeBruijnGraph>
 build_graph<DBGSSHash>(uint64_t k,
@@ -155,7 +160,7 @@ build_graph<DBGSSHash>(uint64_t k,
         return std::make_shared<DBGSSHash>(k, mode);
 
     // use DBGHashString to get contigs for SSHash
-    auto string_graph = build_graph<DBGHashString>(k, sequences, mode);
+    auto string_graph = build_graph<DBGHashFast>(k, sequences, mode);
 
     std::vector<std::string> contigs;
     size_t num_kmers = 0;

--- a/metagraph/tests/graph/all/test_dbg_helpers.cpp
+++ b/metagraph/tests/graph/all/test_dbg_helpers.cpp
@@ -1,10 +1,6 @@
 #include "test_dbg_helpers.hpp"
 
-#include "../../annotation/test_annotated_dbg_helpers.hpp"
-#include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
-
 #include "gtest/gtest.h"
-#include "graph/annotated_dbg.hpp"
 #include "graph/representation/canonical_dbg.hpp"
 #include "graph/representation/succinct/boss.hpp"
 #include "graph/representation/succinct/boss_construct.hpp"


### PR DESCRIPTION
Changes:
- Pre-encode query sequences to discard invalid characters
- Add `AnnotatedDBG` and `LabeledAligner` tests with DBGSSHash to test annotated graph queries