### PR TITLE
Warning fixes

### DIFF
--- a/metagraph/CMakeLists.txt
+++ b/metagraph/CMakeLists.txt
@@ -334,6 +334,8 @@ target_compile_options(zlib
     -Wno-implicit-fallthrough
     -Wno-deprecated-non-prototype
     -Wno-unknown-warning-option
+    -Wno-unused-parameter
+    -Wno-maybe-uninitialized
 )
 
 add_library(progress_bar STATIC

--- a/metagraph/src/common/serialization.cpp
+++ b/metagraph/src/common/serialization.cpp
@@ -22,6 +22,7 @@
 
 #endif
 
+#include <boost/locale.hpp>
 #include <tsl/hopscotch_map.h>
 #include <sdsl/int_vector.hpp>
 
@@ -171,9 +172,7 @@ template bool load_number_vector<bool>(std::istream &in, std::vector<bool> *);
 void encode_utf8(uint32_t num, std::ostream &out) {
     if (num > 0x7FFFFFFF)
         throw std::runtime_error("Encoding value out of range for code.");
-
-    std::string enc = std::wstring_convert<std::codecvt_utf8<char32_t>,
-                                           char32_t>().to_bytes(num);
+    std::string enc = boost::locale::conv::utf_to_utf<char>(std::u32string(1, num));
     out.write(enc.c_str(), enc.size());
 }
 

--- a/metagraph/tests/test_utils.cpp
+++ b/metagraph/tests/test_utils.cpp
@@ -102,7 +102,7 @@ TEST(Utils, TempFileCheckStateFlow) {
     {
         utils::TempFile tmp;
         ASSERT_TRUE(tmp.ifstream().good());
-        EXPECT_DEBUG_DEATH(tmp.ofstream().good(), "Can't write after reading");
+        EXPECT_DEBUG_DEATH((void)tmp.ofstream().good(), "Can't write after reading");
     }
     {
         utils::TempFile tmp;
@@ -110,7 +110,7 @@ TEST(Utils, TempFileCheckStateFlow) {
         ASSERT_TRUE(tmp.ofstream().good());
         ASSERT_TRUE(tmp.ifstream().good());
         ASSERT_TRUE(tmp.ifstream().good());
-        EXPECT_DEBUG_DEATH(tmp.ofstream().good(), "Can't write after reading");
+        EXPECT_DEBUG_DEATH((void)tmp.ofstream().good(), "Can't write after reading");
     }
 }
 


### PR DESCRIPTION
- Update `zlib`
- Add `-Wno-unused-parameter` and `-Wno-maybe-unitialized` for `zlib`
- Fix `maybe-unitialized` in `bloom_filter.cpp`
- Fix deprecated `wstring_convert` in `serialization.cpp`
- Fix ignored return value in `test_utils.cpp`