### PR TITLE
support conversion from RowDiff<Mutli-BRWT> to RowDiff<RowFlat>

### DIFF
--- a/metagraph/src/annotation/annotation_converters.hpp
+++ b/metagraph/src/annotation/annotation_converters.hpp
@@ -80,6 +80,10 @@ void convert_to_row_diff(const std::vector<std::string> &files,
                          size_t num_threads,
                          size_t mem_bytes);
 
+template <class RowDiffAnnotator>
+void convert_to_row_diff(const RowDiffBRWTAnnotator &anno,
+                         const std::string &outfbase);
+
 void merge_row_compressed(const std::vector<std::string> &filenames,
                           const std::string &outfile);
 

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
@@ -14,7 +14,7 @@ namespace mtg {
 namespace annot {
 namespace matrix {
 
-const size_t kNumRowsInBlock = 50'000;
+const size_t kNumRowsInBlock = 250'000;
 
 
 bool BRWT::get(Row row, Column column) const {

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
@@ -81,8 +81,7 @@ void BRWT::call_rows(const std::function<void(const Vector<Column> &)> &callback
         #pragma omp ordered
         {
             Vector<Column> row;
-            auto row_begin = slice.begin();
-            for (size_t i = 0; i < end - begin; ++i) {
+            for (auto row_begin = slice.begin(); row_begin < slice.end(); ) {
                 // every row in `slice` ends with `-1`
                 auto row_end = std::find(row_begin, slice.end(),
                                          std::numeric_limits<Column>::max());

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
@@ -3,6 +3,8 @@
 #include <queue>
 #include <numeric>
 
+#include <progress_bar.hpp>
+
 #include "common/algorithms.hpp"
 #include "common/serialization.hpp"
 #include "common/utils/template_utils.hpp"
@@ -11,6 +13,9 @@
 namespace mtg {
 namespace annot {
 namespace matrix {
+
+const size_t kNumRowsInBlock = 50'000;
+
 
 bool BRWT::get(Row row, Column column) const {
     assert(row < num_rows());
@@ -53,6 +58,43 @@ BRWT::get_rows(const std::vector<Row> &row_ids) const {
 
     return rows;
 }
+
+void BRWT::slice_rows(Row begin, Row end, Vector<Column> *slice) const {
+    // TODO: It may be faster if index columns are queried in ranges instead of with element-wise
+    // access queries.
+    slice_rows(utils::arange<Row>(begin, end - begin), slice);
+}
+
+void BRWT::call_rows(const std::function<void(const Vector<Column> &)> &callback,
+                     bool show_progress) const {
+    Vector<Column> slice;
+    ProgressBar progress_bar(num_rows(), "Queried BRWT rows", std::cerr, !show_progress);
+
+    #pragma omp parallel for ordered num_threads(get_num_threads()) schedule(dynamic) private(slice)
+    for (uint64_t i = 0; i < num_rows(); i += kNumRowsInBlock) {
+        uint64_t begin = i;
+        uint64_t end = std::min(i + kNumRowsInBlock, num_rows());
+        assert(begin <= end);
+
+        slice_rows(begin, end, &slice);
+
+        #pragma omp ordered
+        {
+            Vector<Column> row;
+            auto row_begin = slice.begin();
+            for (size_t i = 0; i < end - begin; ++i) {
+                // every row in `slice` ends with `-1`
+                auto row_end = std::find(row_begin, slice.end(),
+                                         std::numeric_limits<Column>::max());
+                row.assign(row_begin, row_end);
+                callback(row);
+                ++progress_bar;
+                row_begin = row_end + 1;
+            }
+        }
+    }
+}
+
 
 std::vector<Vector<std::pair<BRWT::Column, uint64_t>>>
 BRWT::get_column_ranks(const std::vector<Row> &row_ids) const {

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
@@ -87,6 +87,7 @@ void BRWT::call_rows(const std::function<void(const Vector<Column> &)> &callback
                 auto row_end = std::find(row_begin, slice.end(),
                                          std::numeric_limits<Column>::max());
                 row.assign(row_begin, row_end);
+                std::sort(row.begin(), row.end());
                 callback(row);
                 ++progress_bar;
                 row_begin = row_end + 1;

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.cpp
@@ -76,6 +76,7 @@ void BRWT::call_rows(const std::function<void(const Vector<Column> &)> &callback
         uint64_t end = std::min(i + kNumRowsInBlock, num_rows());
         assert(begin <= end);
 
+        slice.resize(0);
         slice_rows(begin, end, &slice);
 
         #pragma omp ordered

--- a/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.hpp
+++ b/metagraph/src/annotation/binary_matrix/multi_brwt/brwt.hpp
@@ -34,6 +34,8 @@ class BRWT : public BinaryMatrix, public GetEntrySupport {
     // query row and get ranks of each set bit in its column
     std::vector<Vector<std::pair<Column, uint64_t>>>
     get_column_ranks(const std::vector<Row> &rows) const;
+    void call_rows(const std::function<void(const Vector<Column> &)> &callback,
+                   bool show_progress = common::get_verbose()) const;
 
     bool load(std::istream &in) override;
     void serialize(std::ostream &out) const override;
@@ -56,6 +58,8 @@ class BRWT : public BinaryMatrix, public GetEntrySupport {
     // appends to `slice`
     template <typename T>
     void slice_rows(const std::vector<Row> &rows, Vector<T> *slice) const;
+
+    void slice_rows(Row begin, Row end, Vector<Column> *slice) const;
 
     // assigns columns to the child nodes
     RangePartition assignments_;

--- a/metagraph/src/cli/transform_annotation.cpp
+++ b/metagraph/src/cli/transform_annotation.cpp
@@ -894,6 +894,17 @@ int transform_annotation(Config *config) {
                 logger->trace("Serialized to {}", config->outfbase);
             }
         }
+    } else if (input_anno_type == Config::RowDiffBRWT && config->anno_type == Config::RowDiffRowFlat) {
+        if (files.size() != 1) {
+            logger->error("Can only convert row_diff_brwt annotations one at a time");
+            exit(1);
+        }
+        RowDiffBRWTAnnotator annotator;
+        annotator.load(files[0]);
+
+        convert_to_row_diff<RowDiffRowFlatAnnotator>(annotator, config->outfbase);
+        logger->trace("Serialized to {}", config->outfbase);
+
     } else {
         logger->error(
                 "Conversion to other representations is not implemented for {} "


### PR DESCRIPTION
Example:
```bash
./metagraph build -k 31 -o test ../tests/data/transcripts_100.fa

./metagraph annotate -v -i test.dbg --anno-header -o annotation ../tests/data/transcripts_1000.fa
./metagraph transform_anno -v -p 36 --anno-type row_diff --row-diff-stage 0 -i test.dbg -o annotation_rd --mem-cap-gb 300 annotation.column.annodbg
./metagraph transform_anno -v -p 36 --anno-type row_diff --row-diff-stage 1 -i test.dbg -o annotation_rd --mem-cap-gb 300 annotation.column.annodbg
./metagraph transform_anno -v -p 36 --anno-type row_diff --row-diff-stage 2 -i test.dbg -o annotation_rd --mem-cap-gb 300 annotation.column.annodbg

./metagraph transform_anno -v -p 0 --anno-type row_diff_brwt -i test.dbg -o annotation --mem-cap-gb 300 annotation.row_diff.annodbg
./metagraph transform_anno -v -p 0 --anno-type row_diff_flat -i test.dbg -o annotation --mem-cap-gb 300 annotation.row_diff.annodbg

./metagraph transform_anno -v -p 0 --anno-type row_diff_flat -i IGNORED -o annotation_converted annotation.row_diff_brwt.annodbg
```