### PR TITLE
Hide progress bar when building query graph

### DIFF
--- a/metagraph/src/graph/representation/base/sequence_graph.cpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.cpp
@@ -341,7 +341,8 @@ void call_sequences(const DeBruijnGraph &graph,
                     size_t num_threads,
                     bool call_unitigs,
                     uint64_t min_tip_size,
-                    bool kmers_in_single_form) {
+                    bool kmers_in_single_form,
+                    bool verbose = common::get_verbose()) {
     // TODO: port over the implementation from BOSS
     std::ignore = num_threads;
 
@@ -351,7 +352,7 @@ void call_sequences(const DeBruijnGraph &graph,
 
     ProgressBar progress_bar(visited.size() - sdsl::util::cnt_one_bits(visited),
                              "Traverse graph",
-                             std::cerr, !common::get_verbose());
+                             std::cerr, !verbose);
 
     auto call_paths_from = [&](node_index node) {
         call_sequences_from(graph,
@@ -417,8 +418,9 @@ void call_sequences(const DeBruijnGraph &graph,
 
 void DeBruijnGraph::call_sequences(const CallPath &callback,
                                    size_t num_threads,
-                                   bool kmers_in_single_form) const {
-    ::mtg::graph::call_sequences(*this, callback, num_threads, false, 0, kmers_in_single_form);
+                                   bool kmers_in_single_form,
+                                   bool verbose) const {
+    ::mtg::graph::call_sequences(*this, callback, num_threads, false, 0, kmers_in_single_form, verbose);
 }
 
 void DeBruijnGraph::call_unitigs(const CallPath &callback,

--- a/metagraph/src/graph/representation/base/sequence_graph.hpp
+++ b/metagraph/src/graph/representation/base/sequence_graph.hpp
@@ -191,7 +191,8 @@ class DeBruijnGraph : public SequenceGraph {
      */
     virtual void call_sequences(const CallPath &callback,
                                 size_t num_threads = 1,
-                                bool kmers_in_single_form = false) const;
+                                bool kmers_in_single_form = false,
+                                bool verbose = common::get_verbose()) const;
     /**
      * Call all unitigs except short tips, where tips are
      * the unitigs with InDegree(first) + OutDegree(last) < 2.

--- a/metagraph/src/graph/representation/canonical_dbg.cpp
+++ b/metagraph/src/graph/representation/canonical_dbg.cpp
@@ -424,12 +424,13 @@ size_t CanonicalDBG::indegree(node_index node) const {
 
 void CanonicalDBG::call_sequences(const CallPath &callback,
                                   size_t num_threads,
-                                  bool kmers_in_single_form) const {
+                                  bool kmers_in_single_form,
+                                  bool verbose) const {
     if (kmers_in_single_form) {
-        graph_->call_sequences(callback, num_threads, true);
+        graph_->call_sequences(callback, num_threads, true, verbose);
     } else {
         // TODO: port over implementation from DBGSuccinct to DeBruijnGraph
-        DeBruijnGraph::call_sequences(callback, num_threads, false);
+        DeBruijnGraph::call_sequences(callback, num_threads, false, verbose);
     }
 }
 

--- a/metagraph/src/graph/representation/canonical_dbg.hpp
+++ b/metagraph/src/graph/representation/canonical_dbg.hpp
@@ -84,7 +84,8 @@ class CanonicalDBG : public DBGWrapper<DeBruijnGraph> {
 
     virtual void call_sequences(const CallPath &callback,
                                 size_t num_threads = 1,
-                                bool kmers_in_single_form = false) const override final;
+                                bool kmers_in_single_form = false,
+                                bool verbose = common::get_verbose()) const override final;
 
     virtual void call_unitigs(const CallPath &callback,
                               size_t num_threads = 1,

--- a/metagraph/src/graph/representation/masked_graph.cpp
+++ b/metagraph/src/graph/representation/masked_graph.cpp
@@ -106,7 +106,8 @@ bit_vector_stat get_boss_mask(const DBGSuccinct &dbg_succ,
 
 void MaskedDeBruijnGraph::call_sequences(const CallPath &callback,
                                          size_t num_threads,
-                                         bool kmers_in_single_form) const {
+                                         bool kmers_in_single_form,
+                                         bool verbose) const {
     if (auto *dbg_succ = dynamic_cast<const DBGSuccinct*>(graph_.get())) {
         bit_vector_stat mask = get_boss_mask(*dbg_succ, *kmers_in_graph_,
                                              only_valid_nodes_in_mask_);
@@ -117,10 +118,10 @@ void MaskedDeBruijnGraph::call_sequences(const CallPath &callback,
             }
             callback(sequence, path);
 
-        }, num_threads, kmers_in_single_form, &mask);
+        }, num_threads, kmers_in_single_form, verbose, &mask);
 
     } else {
-        DeBruijnGraph::call_sequences(callback, num_threads, kmers_in_single_form);
+        DeBruijnGraph::call_sequences(callback, num_threads, kmers_in_single_form, verbose);
     }
 }
 

--- a/metagraph/src/graph/representation/masked_graph.hpp
+++ b/metagraph/src/graph/representation/masked_graph.hpp
@@ -75,7 +75,8 @@ class MaskedDeBruijnGraph : public DBGWrapper<DeBruijnGraph> {
 
     virtual void call_sequences(const CallPath &callback,
                                 size_t num_threads = 1,
-                                bool kmers_in_single_form = false) const override;
+                                bool kmers_in_single_form = false,
+                                bool verbose = common::get_verbose()) const override;
 
     virtual void call_unitigs(const CallPath &callback,
                               size_t num_threads = 1,

--- a/metagraph/src/graph/representation/succinct/boss.cpp
+++ b/metagraph/src/graph/representation/succinct/boss.cpp
@@ -2081,6 +2081,7 @@ void BOSS::call_paths(Call<std::vector<edge_index> &&, std::vector<TAlphabet> &&
                       size_t num_threads,
                       bool split_to_unitigs,
                       bool kmers_in_single_form,
+                      bool verbose,
                       const bitmap *subgraph_mask,
                       bool trim_sentinels) const {
     assert(!subgraph_mask || subgraph_mask->size() == W_->size());
@@ -2106,7 +2107,7 @@ void BOSS::call_paths(Call<std::vector<edge_index> &&, std::vector<TAlphabet> &&
 
     ProgressBar progress_bar(visited.size() - sdsl::util::cnt_one_bits(visited),
                              "Traverse BOSS",
-                             std::cerr, !common::get_verbose());
+                             std::cerr, !verbose);
 
     ThreadPool thread_pool(num_threads ? num_threads : 1, TASK_POOL_SIZE);
     bool async = true;
@@ -2693,6 +2694,7 @@ call_path(const BOSS &boss,
 void BOSS::call_sequences(Call<std::string&&, std::vector<edge_index>&&> callback,
                           size_t num_threads,
                           bool kmers_in_single_form,
+                          bool verbose,
                           const bitmap *subgraph_mask) const {
     call_paths([&](std::vector<edge_index>&& edges, std::vector<TAlphabet>&& path) {
         assert(path.size() >= k_ + 1);
@@ -2705,7 +2707,7 @@ void BOSS::call_sequences(Call<std::string&&, std::vector<edge_index>&&> callbac
 
         callback(std::move(sequence), std::move(edges));
 
-    }, num_threads, false, kmers_in_single_form, subgraph_mask, true);
+    }, num_threads, false, kmers_in_single_form, verbose, subgraph_mask, true);
 }
 
 // Reach all k-mers that merge into anchor |edge| by following their diff paths.
@@ -3046,7 +3048,7 @@ void BOSS::call_unitigs(Call<std::string&&, std::vector<edge_index>&&> callback,
         // this is not a tip
         callback(std::move(sequence), std::move(edges));
 
-    }, num_threads, true, kmers_in_single_form, subgraph_mask, true);
+    }, num_threads, true, kmers_in_single_form, common::get_verbose(), subgraph_mask, true);
 }
 
 /**

--- a/metagraph/src/graph/representation/succinct/boss.hpp
+++ b/metagraph/src/graph/representation/succinct/boss.hpp
@@ -136,6 +136,7 @@ class BOSS {
                     size_t num_threads = 1,
                     bool unitigs = false,
                     bool kmers_in_single_form = false,
+                    bool verbose = common::get_verbose(),
                     const bitmap *subgraph_mask = NULL,
                     bool trim_sentinels = false) const;
 
@@ -145,6 +146,7 @@ class BOSS {
     void call_sequences(Call<std::string&&, std::vector<edge_index>&&> callback,
                         size_t num_threads = 1,
                         bool kmers_in_single_form = false,
+                        bool verbose = common::get_verbose(),
                         const bitmap *subgraph_mask = NULL) const;
 
     /**

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -499,7 +499,8 @@ void DBGSuccinct::map_to_nodes(std::string_view sequence,
 
 void DBGSuccinct::call_sequences(const CallPath &callback,
                                  size_t num_threads,
-                                 bool kmers_in_single_form) const {
+                                 bool kmers_in_single_form,
+                                 bool verbose) const {
     assert(boss_graph_.get());
     boss_graph_->call_sequences(
         [&](std::string&& seq, auto&& path) {
@@ -509,7 +510,8 @@ void DBGSuccinct::call_sequences(const CallPath &callback,
             callback(std::move(seq), std::move(path));
         },
         num_threads,
-        kmers_in_single_form
+        kmers_in_single_form,
+        verbose
     );
 }
 

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.hpp
@@ -68,7 +68,8 @@ class DBGSuccinct : public DeBruijnGraph {
 
     virtual void call_sequences(const CallPath &callback,
                                 size_t num_threads = 1,
-                                bool kmers_in_single_form = false) const override final;
+                                bool kmers_in_single_form = false,
+                                bool verbose = common::get_verbose()) const override final;
 
     virtual void call_unitigs(const CallPath &callback,
                               size_t num_threads = 1,


### PR DESCRIPTION
* Disable progress bar in batch query (when extracting contigs from the query graph)
* Also print the number of k-mer matches and annotation rows in logs