### PR TITLE
Updated Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,39 +8,21 @@ FROM ubuntu:22.04 AS metagraph_dev_env
 RUN export DEBIAN_FRONTEND="noninteractive" && apt-get update && apt-get install -y \
     autoconf \
     automake \
-    binutils-dev \
     ccache \
-    curl \
     g++-11 \
     git \
     cmake \
-    libcurl4-gnutls-dev \
     libboost-all-dev \
-    libbrotli-dev \
     libbz2-dev \
     libdeflate-dev \
-    libdouble-conversion-dev \
-    libevent-dev \
-    libgflags-dev \
-    libgoogle-glog-dev \
-    libhts-dev \
-    libiberty-dev \
     libjemalloc-dev \
-    liblz4-dev \
-    liblzma-dev \
     libzstd-dev \
-    libsnappy-dev \
     libssl-dev \
-    libtool \
-    libunwind-dev \
     make \
     pkg-config \
     python3 \
     python3-pip \
     python3-venv \
-    vim \
-    wget \
-    zlib1g-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
@@ -71,17 +53,16 @@ ARG CODE_BASE
 
 RUN apt-get update && apt-get install -y \
     libatomic1 \
-    libcurl4-gnutls-dev \
     libdeflate-dev \
     libzstd-dev \
     libgomp1 \
-    libhts3 \
     libjemalloc2 \
     python3 \
     python3-pip \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=metagraph_bin ${CODE_BASE}/metagraph/build/metagraph_* /usr/local/bin/
+COPY --from=metagraph_bin ${CODE_BASE}/metagraph/build/external-libraries/htslib/lib/lib* /usr/lib/
 
 RUN ln -s /usr/local/bin/metagraph_DNA /usr/local/bin/metagraph
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,8 @@ ARG CODE_BASE
 # the metagraph binary and python API code. This image is published on github's container registry (`ghcr.io/ratschlab/metagraph`).
 
 RUN apt-get update && apt-get install -y \
-    libatomic1 \
     libdeflate-dev \
     libzstd-dev \
-    libgomp1 \
     libjemalloc2 \
     python3 \
     python3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,17 +12,12 @@ RUN export DEBIAN_FRONTEND="noninteractive" && apt-get update && apt-get install
     g++-11 \
     git \
     cmake \
+    make \
     libboost-all-dev \
     libbz2-dev \
     libdeflate-dev \
     libjemalloc-dev \
     libzstd-dev \
-    libssl-dev \
-    make \
-    pkg-config \
-    python3 \
-    python3-pip \
-    python3-venv \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt
@@ -71,5 +66,8 @@ COPY . ${CODE_BASE}
 
 RUN pip3 install ${CODE_BASE}/metagraph/api/python
 RUN pip3 install ${CODE_BASE}/metagraph/workflows
+
+# check that it runs fine
+RUN metagraph_DNA --version
 
 ENTRYPOINT ["metagraph"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN export DEBIAN_FRONTEND="noninteractive" && apt-get update && apt-get install
     libevent-dev \
     libgflags-dev \
     libgoogle-glog-dev \
+    libhts-dev \
     libiberty-dev \
     libjemalloc-dev \
     liblz4-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,7 +55,6 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=metagraph_bin ${CODE_BASE}/metagraph/build/metagraph_* /usr/local/bin/
-COPY --from=metagraph_bin ${CODE_BASE}/metagraph/build/external-libraries/htslib/lib/lib* /usr/lib/
 
 RUN ln -s /usr/local/bin/metagraph_DNA /usr/local/bin/metagraph
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,6 +65,6 @@ RUN pip3 install ${CODE_BASE}/metagraph/api/python
 RUN pip3 install ${CODE_BASE}/metagraph/workflows
 
 # check that it runs fine
-RUN metagraph_DNA --version && metagraph_Protein --version
+RUN metagraph --version && metagraph_DNA --version && metagraph_Protein --version
 
 ENTRYPOINT ["metagraph"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update && apt-get install -y \
     libdeflate-dev \
     libzstd-dev \
     libgomp1 \
+    libhts3 \
     libjemalloc2 \
     python3 \
     python3-pip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,6 @@ RUN pip3 install ${CODE_BASE}/metagraph/api/python
 RUN pip3 install ${CODE_BASE}/metagraph/workflows
 
 # check that it runs fine
-RUN metagraph_DNA --version
+RUN metagraph_DNA --version && metagraph_Protein --version
 
 ENTRYPOINT ["metagraph"]

--- a/metagraph/api/python/requirements_dev.txt
+++ b/metagraph/api/python/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==23.3
+pip==25.2
 bumpversion==0.5.3
 wheel==0.38.1
 watchdog==0.8.3


### PR DESCRIPTION
* ~~copy locally compiled htslib .so files to /usr/lib (since after [#445](https://github.com/ratschlab/metagraph/pull/445) metagraph is linked against a locally compiled htslib)~~ not needed after [#534](https://github.com/ratschlab/metagraph/pull/534). Now htslib is always linked statically.
* check if the binary runs fine
* removed unnecessary libs
