### PR TITLE
Also include metagraph_DNA5 in the docker image (for search with Ns)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,9 @@ COPY . ${CODE_BASE}
 
 WORKDIR ${CODE_BASE}
 RUN make build-sdsl-lite \
-    && make build-metagraph alphabet=Protein \
-    && make build-metagraph alphabet=DNA
+    && make build-metagraph alphabet=DNA \
+    && make build-metagraph alphabet=DNA5 \
+    && make build-metagraph alphabet=Protein
 
 FROM ubuntu:22.04
 ARG CODE_BASE
@@ -65,6 +66,9 @@ RUN pip3 install ${CODE_BASE}/metagraph/api/python
 RUN pip3 install ${CODE_BASE}/metagraph/workflows
 
 # check that it runs fine
-RUN metagraph --version && metagraph_DNA --version && metagraph_Protein --version
+RUN metagraph --version \
+    && metagraph_DNA --version \
+    && metagraph_DNA5 --version \
+    && metagraph_Protein --version
 
 ENTRYPOINT ["metagraph"]

--- a/README.md
+++ b/README.md
@@ -47,19 +47,28 @@ If docker is available on the system, immediately get started with
 ```
 docker pull ghcr.io/ratschlab/metagraph:master
 docker run -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master \
-    build -v -k 10 -o /mnt/transcripts_1000 /mnt/transcripts_1000.fa
+    metagraph build -v -k 10 -o /mnt/transcripts_1000 /mnt/transcripts_1000.fa
 ```
 and replace `${HOME}` with a directory on the host system to map it under `/mnt` in the container.
 
-To run the binary compiled for the `Protein` alphabet, just add `--entrypoint metagraph_Protein`:
+By default, it executes the binary compiled for the DNA alphabet {A,C,G,T}.
+To run the binary compiled for the `DNA5` or `Protein` alphabet, just replace `metagraph` with `metagraph_DNA5` or `metagraph_Protein`, respectively, e.g.:
 ```
-docker run -v ${HOME}:/mnt --entrypoint metagraph_Protein ghcr.io/ratschlab/metagraph:master \
-    build -v -k 10 -o /mnt/graph /mnt/protein.fa
+docker run -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master \
+    metagraph_Protein build -v -k 10 -o /mnt/graph /mnt/protein.fa
 ```
 
 As you see, running MetaGraph from docker containers is very easy. Also, the following command (or similar) may be handy to see what directory is mounted in the container or other sort of debugging of the command:
 ```
-docker run -v ${HOME}:/mnt --entrypoint ls ghcr.io/ratschlab/metagraph:master /mnt
+docker run -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master ls /mnt
+```
+
+For more complex workflows, consider running docker in the interactive regime:
+```
+$ docker run -it --entrypoint /bin/bash -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master
+
+root@5c42291cc9cf:/# ls /mnt/
+root@5c42291cc9cf:/# metagraph --version
 ```
 
 All different versions of the container image are listed [here](https://github.com/ratschlab/metagraph/pkgs/container/metagraph).
@@ -194,6 +203,10 @@ Stats for both
 ```
 
 ## Developer Notes
+
+### Build a docker container
+
+Simply run `docker build .`
 
 ### Makefile
 

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ docker run -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master \
 ```
 and replace `${HOME}` with a directory on the host system to map it under `/mnt` in the container.
 
-By default, it executes the binary compiled for the DNA alphabet {A,C,G,T}.
+By default, it executes the binary compiled for the `DNA` alphabet {A,C,G,T}.
 To run the binary compiled for the `DNA5` or `Protein` alphabet, just replace `metagraph` with `metagraph_DNA5` or `metagraph_Protein`, respectively, e.g.:
 ```
 docker run -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master \
     metagraph_Protein build -v -k 10 -o /mnt/graph /mnt/protein.fa
 ```
 
-As you see, running MetaGraph from docker containers is very easy. Also, the following command (or similar) may be handy to see what directory is mounted in the container or other sort of debugging of the command:
+One can see that running MetaGraph with docker is very easy. Also, the following command (or similar) may be handy to see what directory is mounted in the container:
 ```
 docker run -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master ls /mnt
 ```
 
-For more complex workflows, consider running docker in the interactive regime:
+For more complex workflows, consider running docker in the interactive mode:
 ```
 $ docker run -it --entrypoint /bin/bash -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master
 

--- a/metagraph/docs/source/installation.rst
+++ b/metagraph/docs/source/installation.rst
@@ -24,7 +24,7 @@ Docker container
 If docker is available on your system, you can immediately get started with::
 
     docker run -v ${DATA_DIR_HOST}:/mnt ghcr.io/ratschlab/metagraph:master \
-        build -v -k 10 -o /mnt/transcripts_1000 /mnt/transcripts_1000.fa
+        metagraph build -v -k 31 -o /mnt/transcripts_1000 /mnt/transcripts_1000.fa
 
 
 where ``${DATA_DIR_HOST}`` should be replaced with a directory on the host system that will be
@@ -33,18 +33,27 @@ the source `GitHub repository <https://github.com/ratschlab/metagraph>`_ (branch
 See also the `image overview <https://github.com/ratschlab/metagraph/pkgs/container/metagraph>`_ for
 other versions of the image.
 
-By default, it executes the binary compiled for the DNA alphabet.
-To run the binary compiled for the `Protein` alphabet, just add ``--entrypoint metagraph_Protein``::
+By default, it executes the binary compiled for the `DNA` alphabet {A,C,G,T}.
+To run the binary compiled for the `DNA5` or `Protein` alphabet, replace ``metagraph`` with ``metagraph_DNA5`` or ``metagraph_Protein``, respectively::
 
-    docker run --entrypoint metagraph_Protein \
-               -v ${DATA_DIR_HOST}:/mnt ghcr.io/ratschlab/metagraph:master \
-        build -v -k 10 -o /mnt/graph /mnt/protein.fa
+    docker run -v ${DATA_DIR_HOST}:/mnt ghcr.io/ratschlab/metagraph:master \
+        metagraph_DNA5 build -v -k 31 -o /mnt/transcripts_1000 /mnt/transcripts_1000.fa
+
+    docker run -v ${DATA_DIR_HOST}:/mnt ghcr.io/ratschlab/metagraph:master \
+        metagraph_Protein build -v -k 10 -o /mnt/graph /mnt/protein.fa
 
 As you can see, running MetaGraph from docker containers is very easy.
-Also, the following command (or similar) may be handy to see what directory is mounted in the
-container or to do other sorts of debugging::
+The following command (or similar) is handy to see what directory is mounted in the
+container::
 
-    docker run -v ${DATA_DIR_HOST}:/mnt --entrypoint ls ghcr.io/ratschlab/metagraph:master /mnt
+    docker run -v ${DATA_DIR_HOST}:/mnt ghcr.io/ratschlab/metagraph:master ls /mnt
+
+For more complex workflows, consider running docker in the interactive mode::
+
+    $ docker run -it --entrypoint /bin/bash -v ${HOME}:/mnt ghcr.io/ratschlab/metagraph:master
+
+    root@5c42291cc9cf:/# ls /mnt/
+    root@5c42291cc9cf:/# metagraph --version
 
 
 Install from source


### PR DESCRIPTION
solves #480

Usage:
```
docker run -v ../tests/data/:/mnt --entrypoint metagraph_DNA5 <IMAGE>     build -v -k 10 -o /mnt/transcripts_1000 /mnt/transcripts_1000.fa
```