### PR TITLE
use 'top_labels' instead of 'num_labels' in metagraph-core api

### DIFF
--- a/metagraph/api/python/metagraph/client.py
+++ b/metagraph/api/python/metagraph/client.py
@@ -75,7 +75,7 @@ class GraphClientJson:
 
         param_dict = {"count_labels": True,
                       "discovery_fraction": discovery_threshold,
-                      "num_labels": top_labels,
+                      "top_labels": top_labels,
                       "with_signature": with_signature,
                       "abundance_sum": abundance_sum,
                       "query_counts": query_counts,

--- a/metagraph/api/python/notebooks/metagraph_http_api_examples.ipynb
+++ b/metagraph/api/python/notebooks/metagraph_http_api_examples.ipynb
@@ -339,7 +339,7 @@
     "\n",
     "Additional parameters are supported:\n",
     "\n",
-    "* `num_labels`: return the `num_labels` top results per sequence with respect to the kmer count \n",
+    "* `top_labels`: return the `top_labels` top results per sequence with respect to the kmer count \n",
     "\n",
     "\n",
     "There is also the possibility to *align* a sequence first and used the aligned sequence to query the graph. This can be done via the `align=True` parameter, default is `align=False`. In case of `align=True`, the parameter `max_num_nodes_per_seq_char` is also supported (see \"Alignment\" section below).\n",
@@ -407,7 +407,7 @@
     "req = {\"FASTA\": fasta_str,\n",
     "       \"discovery_fraction\": 0.4,\n",
     "       \"align\": True,  \n",
-    "       \"num_labels\": 2}\n",
+    "       \"top_labels\": 2}\n",
     "\n",
     "ret = requests.post(url=f'{base_url}/search', json=req)\n",
     "ret.json()"

--- a/metagraph/integration_tests/test_api.py
+++ b/metagraph/integration_tests/test_api.py
@@ -80,7 +80,7 @@ class TestAPIRaw(TestAPIBase):
 
     def test_api_raw_invalid_params(self):
         payload = json.dumps({
-                    "num_labels": 'not_a_number',
+                    "top_labels": 'not_a_number',
                     "FASTA": "\n".join([">query",
                                         'AATAAAGGTGTGAGATAACCCCAGCGGTGCCAGGATCCGTGCA',
                                         ]),
@@ -94,7 +94,7 @@ class TestAPIRaw(TestAPIBase):
 
     def test_api_raw_missing_params(self):
         payload = json.dumps({
-            "num_labels": 100,
+            "top_labels": 100,
             "discovery_fraction": 1 / 100
         })
 
@@ -109,13 +109,13 @@ class TestAPIRaw(TestAPIBase):
                                 'TCGA',
                                 ]),
             "discovery_fraction": 1.1,
-            "num_labels": 1,
+            "top_labels": 1,
         })
         ret = self.raw_post_request('search', payload)
 
         self.assertEqual(ret.status_code, 400)
 
-    def test_api_raw_missing_num_labels(self):
+    def test_api_raw_missing_top_labels(self):
         payload = json.dumps({
             "FASTA": "\n".join([">query",
                                 'TCGA',
@@ -137,7 +137,7 @@ class TestAPIRaw(TestAPIBase):
                                         'SEQUENCE_NOT_IN_GRAPH',
                                         ]),
                     "discovery_fraction": 1 / 100,
-                    "num_labels": 1,
+                    "top_labels": 1,
                     })
         ret = self.raw_post_request('search', payload)
         json_ret = ret.json()
@@ -222,14 +222,14 @@ class TestAPIRaw(TestAPIBase):
 
     def test_api_raw_search_empty_fasta_desc(self):
         fasta_str = ">\nCCTCTGTGGAATCCAATCTGTCTTCCATCCTGCGTGGCCGAGGG"
-        payload = json.dumps({"FASTA": fasta_str, 'num_labels': 5, 'min_exact_match': 0.1})
+        payload = json.dumps({"FASTA": fasta_str, 'top_labels': 5, 'min_exact_match': 0.1})
         ret = self.raw_post_request('search', payload).json()
 
         self.assertEqual(ret[0]['seq_description'], '')
 
     def test_api_raw_search_no_coordinate_support(self):
         fasta_str = ">query\nCCTCTGTGGAATCCAATCTGTCTTCCATCCTGCGTGGCCGAGGG"
-        payload = json.dumps({"FASTA": fasta_str, 'num_labels': 5, 'min_exact_match': 0.1,
+        payload = json.dumps({"FASTA": fasta_str, 'top_labels': 5, 'min_exact_match': 0.1,
                               'query_coords': True})
 
         ret = self.raw_post_request('search', payload)
@@ -239,7 +239,7 @@ class TestAPIRaw(TestAPIBase):
 
     def test_api_raw_search_no_count_support(self):
         fasta_str = ">query\nCCTCTGTGGAATCCAATCTGTCTTCCATCCTGCGTGGCCGAGGG"
-        payload = json.dumps({"FASTA": fasta_str, 'num_labels': 5, 'min_exact_match': 0.1,
+        payload = json.dumps({"FASTA": fasta_str, 'top_labels': 5, 'min_exact_match': 0.1,
                               'abundance_sum': True})
 
         ret = self.raw_post_request('search', payload)

--- a/metagraph/src/cli/server.cpp
+++ b/metagraph/src/cli/server.cpp
@@ -62,7 +62,7 @@ std::string process_search_request(const std::string &received_message,
                 + std::to_string(config.alignment_min_exact_match));
     }
 
-    config.num_top_labels = json.get("num_labels", config.num_top_labels).asInt();
+    config.num_top_labels = json.get("top_labels", config.num_top_labels).asInt();
 
     if (json.get("query_coords", false).asBool()) {
         config.query_mode = COORDS;


### PR DESCRIPTION
Previously it was mixed: metagraph python api was using `top_labels`, and it was converting it internally before sending a request to the core metagraph http server, which was expecting that value by flag `num_labels`.
So, if one was sending requests to metagraph endpoints directly without using the python api, they would have to use `num_labels` instead of `top_labels`.

Now it consistently uses `top_labels` in both APIs.