### PR TITLE
map sequences to graph with dynamic omp schedule for better performance

### DIFF
--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -1032,7 +1032,7 @@ construct_query_graph(const AnnotatedDBG &anno_graph,
 
     std::vector<std::pair<uint64_t, uint64_t>> from_full_to_small;
 
-    #pragma omp parallel for num_threads(num_threads) schedule(dynamic, 100)
+    #pragma omp parallel for num_threads(num_threads)
     for (size_t i = 0; i < contigs.size(); ++i) {
         const std::string &contig = contigs[i].first;
         const std::vector<node_index> &nodes_in_full = contigs[i].second;


### PR DESCRIPTION
Use dynamic scheduling to fix the imbalanced load on the threads


### **tara_assemblies:**

```
/usr/bin/time -v ./metagraph query /data/random_stud/queries/100_studies_50k_short.fq --mmap -p 40 -v -i graph_small.indexed.dbg -a annotation.v4.row_diff_sparse.annodbg -v --batch-size 10000000000 --query-mode matches > /dev/null
```

```
# Before:
[trace] Contigs mapped to the full graph (found 1721062 / 568137958 k-mers) in 401.965816809 sec
# After:
[trace] Contigs mapped to the full graph (found 1721062 / 568137958 k-mers) in 251.316558261 sec
```

### **all_sra/data/metagenome/1315:**

```
# Before:
[trace] Contigs mapped to the full graph (found 18968780 / 532119762 k-mers) in 573.547590432 sec
# After:
[trace] Contigs mapped to the full graph (found 18968780 / 532119762 k-mers) in 381.756807251 sec
```
