### PR TITLE
MADV_RANDOM for graphs loaded with mmap

### DIFF
--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -118,6 +118,8 @@ Config::Config(int argc, char *argv[]) {
             common::set_verbose(true);
         } else if (!strcmp(argv[i], "--mmap")) {
             utils::set_mmap(true);
+        } else if (!strcmp(argv[i], "--madv-random")) {
+            utils::set_madvise(true);
         } else if (!strcmp(argv[i], "--print")) {
             print_graph = true;
         } else if (!strcmp(argv[i], "--advanced")) {
@@ -1414,6 +1416,8 @@ if (advanced) {
 
     fprintf(stderr, "\nGeneral options:\n");
     fprintf(stderr, "\t   --mmap \t\tuse memory mapping when loading to reduce RAM [off]\n");
+    if (identity == SERVER_QUERY)
+        fprintf(stderr, "\t   --madv-random \tenable MADV_RANDOM hints for graphs loaded with mmap (speeds up tiny queries, may slow down large ones) [off]\n");
     fprintf(stderr, "\t-v --verbose \t\tswitch on verbose output [off]\n");
     fprintf(stderr, "\t   --advanced \t\tshow other advanced and legacy options [off]\n");
     fprintf(stderr, "\t-h --help \t\tprint usage info\n");

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -27,6 +27,7 @@ std::vector<std::string> TMP_DIRS;
 std::mutex TMP_DIRS_MUTEX;
 
 static bool WITH_MMAP = false;
+static bool WITH_MADVISE = false;
 
 void set_mmap(bool set_bit) {
     WITH_MMAP = set_bit;
@@ -34,6 +35,14 @@ void set_mmap(bool set_bit) {
 
 bool with_mmap() {
     return WITH_MMAP;
+}
+
+void set_madvise(bool set_bit) {
+    WITH_MADVISE = set_bit;
+}
+
+bool with_madvise() {
+    return WITH_MADVISE;
 }
 
 std::unique_ptr<std::ifstream> open_ifstream(const std::string &filename, bool mmap_stream) {

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -29,6 +29,10 @@ void rename_or_move_file(const std::string &old_fname, const std::string &new_fn
 bool with_mmap();
 void set_mmap(bool set_bit);
 
+// Returns true if madvise hints are enabled. Use set_madvise() to change.
+bool with_madvise();
+void set_madvise(bool set_bit);
+
 std::unique_ptr<std::ifstream>
 open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
 

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <string>
 #include <filesystem>
+#include <sys/mman.h>
 
 #include "common/seq_tools/reverse_complement.hpp"
 #include "common/serialization.hpp"
@@ -695,26 +696,22 @@ bool DBGSuccinct::load_without_mask(const std::string &filename) {
         std::unique_ptr<std::ifstream> in
             = utils::open_ifstream(utils::make_suffix(filename, kExtension));
 
-        if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream*>(in.get())) {
-            madvise(mmap_in->get_mmap_context()->data(),
-                    mmap_in->get_mmap_context()->file_size_bytes(),
-                    MADV_RANDOM);
-        }
-
         if (!boss_graph_->load(*in))
             return false;
 
         mode_ = static_cast<Mode>(load_number(*in));
 
-        if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream*>(in.get())) {
-            auto offset = in->tellg();
-            madvise(mmap_in->get_mmap_context()->data() + offset,
-                    mmap_in->get_mmap_context()->file_size_bytes() - offset,
-                    MADV_WILLNEED);
-        }
-
         if (!boss_graph_->load_suffix_ranges(*in))
             logger->warn("No index for node ranges could be loaded");
+
+        if (utils::with_madvise()) {
+            if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream*>(in.get())) {
+                // hint random access for query-time traversal of the loaded data
+                madvise(mmap_in->get_mmap_context()->data(),
+                        mmap_in->get_mmap_context()->file_size_bytes(),
+                        MADV_RANDOM);
+            }
+        }
     }
 
     return true;

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -5,7 +5,6 @@
 #include <algorithm>
 #include <string>
 #include <filesystem>
-#include <sys/mman.h>
 
 #include "common/seq_tools/reverse_complement.hpp"
 #include "common/serialization.hpp"
@@ -707,9 +706,11 @@ bool DBGSuccinct::load_without_mask(const std::string &filename) {
         if (utils::with_madvise()) {
             if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream*>(in.get())) {
                 // hint random access for query-time traversal of the loaded data
-                madvise(mmap_in->get_mmap_context()->data(),
-                        mmap_in->get_mmap_context()->file_size_bytes(),
-                        MADV_RANDOM);
+                if (madvise(mmap_in->get_mmap_context()->data(),
+                            mmap_in->get_mmap_context()->file_size_bytes(),
+                            MADV_RANDOM)) {
+                    logger->warn("madvise(MADV_RANDOM) failed");
+                }
             }
         }
     }

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -695,10 +695,23 @@ bool DBGSuccinct::load_without_mask(const std::string &filename) {
         std::unique_ptr<std::ifstream> in
             = utils::open_ifstream(utils::make_suffix(filename, kExtension));
 
+        if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream*>(in.get())) {
+            madvise(mmap_in->get_mmap_context()->data(),
+                    mmap_in->get_mmap_context()->file_size_bytes(),
+                    MADV_RANDOM);
+        }
+
         if (!boss_graph_->load(*in))
             return false;
 
         mode_ = static_cast<Mode>(load_number(*in));
+
+        if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream*>(in.get())) {
+            auto offset = in->tellg();
+            madvise(mmap_in->get_mmap_context()->data() + offset,
+                    mmap_in->get_mmap_context()->file_size_bytes() - offset,
+                    MADV_WILLNEED);
+        }
 
         if (!boss_graph_->load_suffix_ranges(*in))
             logger->warn("No index for node ranges could be loaded");


### PR DESCRIPTION
PR Review: Optional `MADV_RANDOM` for mmap-loaded graphs

Summary

This branch adds a new `--madv-random` CLI flag that, when used with `--mmap`, calls `madvise(MADV_RANDOM)` on the graph's memory-mapped region after loading. The intent is to disable kernel read-ahead, which benefits small random-access queries but may hurt sequential scans.

For annotations (queried in ordered batches), `madvise` only made it slower, so we don't do `madvise` for that.