### PR TITLE
Support loading RowDisk annotations without mmap

### DIFF
--- a/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
+++ b/metagraph/src/annotation/binary_matrix/row_diff/row_diff.hpp
@@ -13,6 +13,7 @@
 #include "common/vector.hpp"
 #include "common/logger.hpp"
 #include "common/unix_tools.hpp"
+#include "common/utils/file_utils.hpp"
 #include "common/utils/template_utils.hpp"
 #include "common/hashers/hash.hpp"
 #include "graph/annotated_dbg.hpp"
@@ -284,13 +285,17 @@ bool RowDiff<BaseMatrix>::load(std::istream &f) {
     std::string version(4, '\0');
     if (f.read(version.data(), 4) && version == "v2.0") {
         if constexpr(!std::is_same_v<BaseMatrix, ColumnMajor>) {
+            auto anchor_start = f.tellg();
             if (!anchor_.load(f) || !fork_succ_.load(f))
                 return false;
+            // anchor_ / fork_succ_ are accessed randomly, hint the kernel.
+            utils::madvise_random_range(f, anchor_start, f.tellg() - anchor_start);
         }
     } else {
         // backward compatibility
         f.seekg(pos);
         if constexpr(!std::is_same_v<BaseMatrix, ColumnMajor>) {
+            auto anchor_start = f.tellg();
             if (!anchor_.load(f))
                 return false;
 
@@ -298,6 +303,8 @@ bool RowDiff<BaseMatrix>::load(std::istream &f) {
                 "Loading old version of RowDiff without a fork routing bitmap."
                 " The last outgoing edges will be used as successors.");
             fork_succ_ = fork_succ_bv_type();
+            // anchor_ is accessed randomly, hint the kernel.
+            utils::madvise_random_range(f, anchor_start, f.tellg() - anchor_start);
         }
     }
     return diffs_.load(f);

--- a/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
@@ -50,14 +50,13 @@ BinaryMatrix::SetBitPositions RowDisk::View::get_row(Row row) const {
 }
 
 bool RowDisk::load(std::istream &f) {
-    auto _f = dynamic_cast<sdsl::mmap_ifstream *>(&f);
-    assert(_f);
     try {
         num_columns_ = load_number(f);
 
         auto boundary_start = load_number(f);
 
-        buffer_params_.filename = _f->get_filename();
+        // int_vector_buffer<> opens the row data by filename + offset.
+        buffer_params_.filename = utils::get_filename(f);
         buffer_params_.offset = f.tellg();
 
         assert(boundary_start >= buffer_params_.offset);

--- a/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
@@ -62,15 +62,8 @@ bool RowDisk::load(std::istream &f) {
         iv_size_on_disk_ = boundary_start - buffer_params_.offset;
 
         // boundary_ is too large to load into RAM, always mmap it.
-        sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
-        boundary_in.seekg(boundary_start, ios_base::beg);
-        boundary_.load(boundary_in);
-        // boundary_ is accessed via select1, hint random access.
-        if (madvise(boundary_in.get_mmap_context()->data(),
-                    boundary_in.get_mmap_context()->file_size_bytes(),
-                    MADV_RANDOM)) {
-            logger->warn("madvise(MADV_RANDOM) on RowDisk boundary failed");
-        }
+        utils::load_mmap_random(buffer_params_.filename, boundary_start,
+                                [&](std::istream &in) { boundary_.load(in); });
 
         num_rows_ = boundary_.num_set_bits();
         num_relations_ = boundary_.size() - num_rows_;

--- a/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
@@ -61,9 +61,10 @@ bool RowDisk::load(std::istream &f) {
         assert(boundary_start >= buffer_params_.offset);
         iv_size_on_disk_ = boundary_start - buffer_params_.offset;
 
-        f.seekg(boundary_start, ios_base::beg);
-
-        boundary_.load(f);
+        // boundary_ is too large to load into RAM, always mmap it.
+        sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
+        boundary_in.seekg(boundary_start, ios_base::beg);
+        boundary_.load(boundary_in);
 
         num_rows_ = boundary_.num_set_bits();
         num_relations_ = boundary_.size() - num_rows_;

--- a/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
@@ -55,7 +55,6 @@ bool RowDisk::load(std::istream &f) {
 
         auto boundary_start = load_number(f);
 
-        // int_vector_buffer<> opens the row data by filename + offset.
         buffer_params_.filename = utils::get_filename(f);
         buffer_params_.offset = f.tellg();
 

--- a/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
+++ b/metagraph/src/annotation/binary_matrix/row_disk/row_disk.cpp
@@ -65,6 +65,12 @@ bool RowDisk::load(std::istream &f) {
         sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
         boundary_in.seekg(boundary_start, ios_base::beg);
         boundary_.load(boundary_in);
+        // boundary_ is accessed via select1, hint random access.
+        if (madvise(boundary_in.get_mmap_context()->data(),
+                    boundary_in.get_mmap_context()->file_size_bytes(),
+                    MADV_RANDOM)) {
+            logger->warn("madvise(MADV_RANDOM) on RowDisk boundary failed");
+        }
 
         num_rows_ = boundary_.num_set_bits();
         num_relations_ = boundary_.size() - num_rows_;

--- a/metagraph/src/annotation/int_matrix/row_diff/int_row_diff.hpp
+++ b/metagraph/src/annotation/int_matrix/row_diff/int_row_diff.hpp
@@ -150,7 +150,12 @@ template <class BaseMatrix>
 bool IntRowDiff<BaseMatrix>::load(std::istream &in) {
     std::string version(4, '\0');
     in.read(version.data(), 4);
-    return anchor_.load(in) && fork_succ_.load(in) && diffs_.load(in);
+    auto anchor_start = in.tellg();
+    if (!anchor_.load(in) || !fork_succ_.load(in))
+        return false;
+    // anchor_ / fork_succ_ are accessed randomly, hint the kernel.
+    utils::madvise_random_range(in, anchor_start, in.tellg() - anchor_start);
+    return diffs_.load(in);
 }
 
 template <class BaseMatrix>

--- a/metagraph/src/annotation/int_matrix/row_diff/tuple_row_diff.hpp
+++ b/metagraph/src/annotation/int_matrix/row_diff/tuple_row_diff.hpp
@@ -156,7 +156,12 @@ template <class BaseMatrix>
 bool TupleRowDiff<BaseMatrix>::load(std::istream &in) {
     std::string version(4, '\0');
     in.read(version.data(), 4);
-    return anchor_.load(in) && fork_succ_.load(in) && diffs_.load(in);
+    auto anchor_start = in.tellg();
+    if (!anchor_.load(in) || !fork_succ_.load(in))
+        return false;
+    // anchor_ / fork_succ_ are accessed randomly, hint the kernel.
+    utils::madvise_random_range(in, anchor_start, in.tellg() - anchor_start);
+    return diffs_.load(in);
 }
 
 template <class BaseMatrix>

--- a/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
@@ -161,10 +161,11 @@ bool CoordRowDisk::load(std::istream &f) {
 
         assert(boundary_start >= buffer_params_.offset);
 
-        f.seekg(boundary_start, std::ios_base::beg);
-
-        boundary_.load(f);
-        num_attributes_ = load_number(f);
+        // boundary_ is too large to load into RAM, always mmap it.
+        sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
+        boundary_in.seekg(boundary_start, std::ios_base::beg);
+        boundary_.load(boundary_in);
+        num_attributes_ = load_number(boundary_in);
 
         num_rows_ = boundary_.num_set_bits();
 

--- a/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
@@ -162,16 +162,11 @@ bool CoordRowDisk::load(std::istream &f) {
         assert(boundary_start >= buffer_params_.offset);
 
         // boundary_ is too large to load into RAM, always mmap it.
-        sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
-        boundary_in.seekg(boundary_start, std::ios_base::beg);
-        boundary_.load(boundary_in);
-        num_attributes_ = load_number(boundary_in);
-        // boundary_ is accessed via select1, hint random access.
-        if (madvise(boundary_in.get_mmap_context()->data(),
-                    boundary_in.get_mmap_context()->file_size_bytes(),
-                    MADV_RANDOM)) {
-            logger->warn("madvise(MADV_RANDOM) on CoordRowDisk boundary failed");
-        }
+        utils::load_mmap_random(buffer_params_.filename, boundary_start,
+                                [&](std::istream &in) {
+            boundary_.load(in);
+            num_attributes_ = load_number(in);
+        });
 
         num_rows_ = boundary_.num_set_bits();
 

--- a/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
@@ -156,7 +156,6 @@ bool CoordRowDisk::load(std::istream &f) {
         bits_for_number_of_vals_ = load_number(f);
         bits_for_single_value_ = load_number(f);
 
-        // int_vector_buffer<> opens the row data by filename + offset.
         buffer_params_.filename = utils::get_filename(f);
         buffer_params_.offset = f.tellg();
 

--- a/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
@@ -166,6 +166,12 @@ bool CoordRowDisk::load(std::istream &f) {
         boundary_in.seekg(boundary_start, std::ios_base::beg);
         boundary_.load(boundary_in);
         num_attributes_ = load_number(boundary_in);
+        // boundary_ is accessed via select1, hint random access.
+        if (madvise(boundary_in.get_mmap_context()->data(),
+                    boundary_in.get_mmap_context()->file_size_bytes(),
+                    MADV_RANDOM)) {
+            logger->warn("madvise(MADV_RANDOM) on CoordRowDisk boundary failed");
+        }
 
         num_rows_ = boundary_.num_set_bits();
 

--- a/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/coord_row_disk.cpp
@@ -147,8 +147,6 @@ CoordRowDisk::View::get_row_tuples(const std::vector<Row> &rows) const {
 
 
 bool CoordRowDisk::load(std::istream &f) {
-    auto _f = dynamic_cast<sdsl::mmap_ifstream *>(&f);
-    assert(_f);
     try {
         num_columns_ = load_number(f);
         auto boundary_start = load_number(f);
@@ -158,7 +156,8 @@ bool CoordRowDisk::load(std::istream &f) {
         bits_for_number_of_vals_ = load_number(f);
         bits_for_single_value_ = load_number(f);
 
-        buffer_params_.filename = _f->get_filename();
+        // int_vector_buffer<> opens the row data by filename + offset.
+        buffer_params_.filename = utils::get_filename(f);
         buffer_params_.offset = f.tellg();
 
         assert(boundary_start >= buffer_params_.offset);

--- a/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
@@ -94,8 +94,6 @@ IntRowDisk::View::get_row_values(const std::vector<Row> &row_ids) const {
 }
 
 bool IntRowDisk::load(std::istream &f) {
-    auto _f = dynamic_cast<sdsl::mmap_ifstream *>(&f);
-    assert(_f);
     try {
         num_columns_ = load_number(f);
         auto boundary_start = load_number(f);
@@ -104,7 +102,8 @@ bool IntRowDisk::load(std::istream &f) {
         bits_for_col_id_ = load_number(f);
         bits_for_value_ = load_number(f);
 
-        buffer_params_.filename = _f->get_filename();
+        // int_vector_buffer<> opens the row data by filename + offset.
+        buffer_params_.filename = utils::get_filename(f);
         buffer_params_.offset = f.tellg();
 
         assert(boundary_start >= buffer_params_.offset);

--- a/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
@@ -111,6 +111,12 @@ bool IntRowDisk::load(std::istream &f) {
         sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
         boundary_in.seekg(boundary_start, std::ios_base::beg);
         boundary_.load(boundary_in);
+        // boundary_ is accessed via select1, hint random access.
+        if (madvise(boundary_in.get_mmap_context()->data(),
+                    boundary_in.get_mmap_context()->file_size_bytes(),
+                    MADV_RANDOM)) {
+            logger->warn("madvise(MADV_RANDOM) on IntRowDisk boundary failed");
+        }
 
         num_rows_ = boundary_.num_set_bits();
 

--- a/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
@@ -108,15 +108,8 @@ bool IntRowDisk::load(std::istream &f) {
         assert(boundary_start >= buffer_params_.offset);
 
         // boundary_ is too large to load into RAM, always mmap it.
-        sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
-        boundary_in.seekg(boundary_start, std::ios_base::beg);
-        boundary_.load(boundary_in);
-        // boundary_ is accessed via select1, hint random access.
-        if (madvise(boundary_in.get_mmap_context()->data(),
-                    boundary_in.get_mmap_context()->file_size_bytes(),
-                    MADV_RANDOM)) {
-            logger->warn("madvise(MADV_RANDOM) on IntRowDisk boundary failed");
-        }
+        utils::load_mmap_random(buffer_params_.filename, boundary_start,
+                                [&](std::istream &in) { boundary_.load(in); });
 
         num_rows_ = boundary_.num_set_bits();
 

--- a/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
@@ -102,7 +102,6 @@ bool IntRowDisk::load(std::istream &f) {
         bits_for_col_id_ = load_number(f);
         bits_for_value_ = load_number(f);
 
-        // int_vector_buffer<> opens the row data by filename + offset.
         buffer_params_.filename = utils::get_filename(f);
         buffer_params_.offset = f.tellg();
 

--- a/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
+++ b/metagraph/src/annotation/int_matrix/row_disk/int_row_disk.cpp
@@ -107,9 +107,10 @@ bool IntRowDisk::load(std::istream &f) {
 
         assert(boundary_start >= buffer_params_.offset);
 
-        f.seekg(boundary_start, std::ios_base::beg);
-
-        boundary_.load(f);
+        // boundary_ is too large to load into RAM, always mmap it.
+        sdsl::mmap_ifstream boundary_in(buffer_params_.filename);
+        boundary_in.seekg(boundary_start, std::ios_base::beg);
+        boundary_.load(boundary_in);
 
         num_rows_ = boundary_.num_set_bits();
 

--- a/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
+++ b/metagraph/src/annotation/representation/annotation_matrix/annotation_matrix.cpp
@@ -34,11 +34,7 @@ StaticBinRelAnnotator<BinaryMatrixType, Label>
 template <class BinaryMatrixType, typename Label>
 bool StaticBinRelAnnotator<BinaryMatrixType, Label>::load(const std::string &filename) {
     const auto &fname = make_suffix(filename, kExtension);
-    using T = StaticBinRelAnnotator<BinaryMatrixType, Label>;
-    bool use_mmap = std::is_same_v<T, RowDiffDiskAnnotator>
-                        || std::is_same_v<T, IntRowDiffDiskAnnotator>
-                        || std::is_same_v<T, RowDiffDiskCoordAnnotator>;
-    std::unique_ptr<std::ifstream> in = utils::open_ifstream(fname, use_mmap || utils::with_mmap());
+    std::unique_ptr<std::ifstream> in = utils::open_ifstream(fname, utils::with_mmap());
     if (!in->good()) {
         logger->error("Cannot open annotation file '{}': {}", fname,
                       utils::file_read_failure_detail(fname));

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -77,9 +77,18 @@ std::unique_ptr<std::ifstream> open_ifstream(const std::string &filename, bool m
     if (mmap_stream) {
         in.reset(new sdsl::mmap_ifstream(filename, std::ios_base::binary));
     } else {
-        in.reset(new std::ifstream(filename, std::ios_base::binary));
+        in.reset(new named_ifstream(filename, std::ios_base::binary));
     }
     return in;
+}
+
+const std::string& get_filename(std::istream &f) {
+    if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream *>(&f))
+        return mmap_in->get_filename();
+    if (auto *named_in = dynamic_cast<named_ifstream *>(&f))
+        return named_in->get_filename();
+    throw std::runtime_error(
+            "get_filename: stream is neither sdsl::mmap_ifstream nor utils::named_ifstream");
 }
 
 std::string file_read_failure_detail(const fs::path &path) {

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -97,6 +97,8 @@ void madvise_random_range(std::istream &f, std::streamoff start, std::streamoff 
     auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream *>(&f);
     if (!mmap_in)
         return;
+    if (length < 0)
+        length = mmap_in->get_mmap_context()->file_size_bytes() - start;
     const std::streamoff pagesize = sysconf(_SC_PAGESIZE);
     std::streamoff aligned_start = start - start % pagesize;
     if (madvise(mmap_in->get_mmap_context()->data() + aligned_start,
@@ -111,7 +113,7 @@ void load_mmap_random(const std::string &filename, std::streamoff offset,
     sdsl::mmap_ifstream in(filename);
     in.seekg(offset, std::ios_base::beg);
     fn(in);
-    madvise_random_range(in, 0, in.get_mmap_context()->file_size_bytes());
+    madvise_random_range(in);
 }
 
 std::string file_read_failure_detail(const fs::path &path) {

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -91,6 +91,21 @@ const std::string& get_filename(std::istream &f) {
             "get_filename: stream is neither sdsl::mmap_ifstream nor utils::named_ifstream");
 }
 
+void madvise_random_range(std::istream &f, std::streamoff start, std::streamoff length) {
+    if (!with_madvise())
+        return;
+    auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream *>(&f);
+    if (!mmap_in)
+        return;
+    const std::streamoff pagesize = sysconf(_SC_PAGESIZE);
+    std::streamoff aligned_start = start - start % pagesize;
+    if (madvise(mmap_in->get_mmap_context()->data() + aligned_start,
+                length + (start - aligned_start),
+                MADV_RANDOM)) {
+        logger->warn("madvise(MADV_RANDOM) failed for range [{}, {})", start, start + length);
+    }
+}
+
 std::string file_read_failure_detail(const fs::path &path) {
     std::error_code ec;
     fs::file_status st = fs::status(path, ec);

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -113,7 +113,7 @@ void load_mmap_random(const std::string &filename, std::streamoff offset,
     sdsl::mmap_ifstream in(filename);
     in.seekg(offset, std::ios_base::beg);
     fn(in);
-    madvise_random_range(in);
+    madvise_random_range(in, offset);
 }
 
 std::string file_read_failure_detail(const fs::path &path) {

--- a/metagraph/src/common/utils/file_utils.cpp
+++ b/metagraph/src/common/utils/file_utils.cpp
@@ -106,6 +106,14 @@ void madvise_random_range(std::istream &f, std::streamoff start, std::streamoff 
     }
 }
 
+void load_mmap_random(const std::string &filename, std::streamoff offset,
+                      const std::function<void(std::istream &)> &fn) {
+    sdsl::mmap_ifstream in(filename);
+    in.seekg(offset, std::ios_base::beg);
+    fn(in);
+    madvise_random_range(in, 0, in.get_mmap_context()->file_size_bytes());
+}
+
 std::string file_read_failure_detail(const fs::path &path) {
     std::error_code ec;
     fs::file_status st = fs::status(path, ec);

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -52,8 +52,6 @@ open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
 
 // Returns the filename from a stream opened by `open_ifstream`
 // (i.e. `sdsl::mmap_ifstream` or `utils::named_ifstream`); throws otherwise.
-// Used by disk-resident loaders that need to open auxiliary readers
-// (e.g. `int_vector_buffer<>`) by filename + offset.
 const std::string& get_filename(std::istream &f);
 
 // Hint MADV_RANDOM on `[start, start + length)` of the file mmapped by `f`.
@@ -66,9 +64,7 @@ void madvise_random_range(std::istream &f,
 
 // Open `filename` as an `sdsl::mmap_ifstream` seeked to `offset`, invoke
 // `fn` so the caller can load from it, then (if `with_madvise()`) hint
-// MADV_RANDOM on the whole file mapping. Used by disk-resident loaders
-// to bring up an auxiliary mmap reader (e.g. for `boundary_`) without
-// re-implementing the open/seek/advise dance at every callsite.
+// MADV_RANDOM on the whole file mapping.
 void load_mmap_random(const std::string &filename, std::streamoff offset,
                       const std::function<void(std::istream &)> &fn);
 

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -55,6 +55,12 @@ open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
 // (e.g. `int_vector_buffer<>`) by filename + offset.
 const std::string& get_filename(std::istream &f);
 
+// Hint MADV_RANDOM on `[start, start + length)` of the file mmap'd by `f`.
+// No-op when `with_madvise()` is false or `f` is not an `sdsl::mmap_ifstream`.
+// The range is rounded out to enclosing page boundaries (madvise requires
+// page-aligned start).
+void madvise_random_range(std::istream &f, std::streamoff start, std::streamoff length);
+
 // Explains likely reasons why a file could not be read (permissions, missing file, etc.).
 std::string file_read_failure_detail(const std::filesystem::path &path);
 

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -33,8 +33,25 @@ void set_mmap(bool set_bit);
 bool with_madvise();
 void set_madvise(bool set_bit);
 
+// `std::ifstream` that remembers the path it was opened from.
+// Mirrors `sdsl::mmap_ifstream` so loaders can recover the filename via cast.
+class named_ifstream : public std::ifstream {
+  public:
+    explicit named_ifstream(const std::string &filename,
+                            std::ios_base::openmode mode = std::ios_base::in)
+          : std::ifstream(filename, mode), filename_(filename) {}
+    const std::string& get_filename() const { return filename_; }
+
+  private:
+    std::string filename_;
+};
+
 std::unique_ptr<std::ifstream>
 open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
+
+// Returns the filename from a stream opened by `open_ifstream`
+// (i.e. `sdsl::mmap_ifstream` or `utils::named_ifstream`); throws otherwise.
+const std::string& get_filename(std::istream &f);
 
 // Explains likely reasons why a file could not be read (permissions, missing file, etc.).
 std::string file_read_failure_detail(const std::filesystem::path &path);

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -38,7 +38,7 @@ void set_madvise(bool set_bit);
 class named_ifstream : public std::ifstream {
   public:
     explicit named_ifstream(const std::string &filename,
-                            std::ios_base::openmode mode = std::ios_base::in)
+                            std::ios_base::openmode mode = std::ios_base::binary)
           : std::ifstream(filename, mode), filename_(filename) {}
     const std::string& get_filename() const { return filename_; }
 
@@ -51,6 +51,8 @@ open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
 
 // Returns the filename from a stream opened by `open_ifstream`
 // (i.e. `sdsl::mmap_ifstream` or `utils::named_ifstream`); throws otherwise.
+// Used by disk-resident loaders that need to open auxiliary readers
+// (e.g. `int_vector_buffer<>`) by filename + offset.
 const std::string& get_filename(std::istream &f);
 
 // Explains likely reasons why a file could not be read (permissions, missing file, etc.).

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 #include <fstream>
+#include <functional>
 #include <future>
 #include <filesystem>
 #include <iostream>
@@ -55,11 +56,19 @@ open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
 // (e.g. `int_vector_buffer<>`) by filename + offset.
 const std::string& get_filename(std::istream &f);
 
-// Hint MADV_RANDOM on `[start, start + length)` of the file mmap'd by `f`.
+// Hint MADV_RANDOM on `[start, start + length)` of the file mmapped by `f`.
 // No-op when `with_madvise()` is false or `f` is not an `sdsl::mmap_ifstream`.
 // The range is rounded out to enclosing page boundaries (madvise requires
 // page-aligned start).
 void madvise_random_range(std::istream &f, std::streamoff start, std::streamoff length);
+
+// Open `filename` as an `sdsl::mmap_ifstream` seeked to `offset`, invoke
+// `fn` so the caller can load from it, then (if `with_madvise()`) hint
+// MADV_RANDOM on the whole file mapping. Used by disk-resident loaders
+// to bring up an auxiliary mmap reader (e.g. for `boundary_`) without
+// re-implementing the open/seek/advise dance at every callsite.
+void load_mmap_random(const std::string &filename, std::streamoff offset,
+                      const std::function<void(std::istream &)> &fn);
 
 // Explains likely reasons why a file could not be read (permissions, missing file, etc.).
 std::string file_read_failure_detail(const std::filesystem::path &path);

--- a/metagraph/src/common/utils/file_utils.hpp
+++ b/metagraph/src/common/utils/file_utils.hpp
@@ -57,10 +57,12 @@ open_ifstream(const std::string &filename, bool mmap_stream = with_mmap());
 const std::string& get_filename(std::istream &f);
 
 // Hint MADV_RANDOM on `[start, start + length)` of the file mmapped by `f`.
+// `length < 0` (the default) means "to end of file". `start` is rounded
+// down to a page boundary (madvise requires page-aligned start).
 // No-op when `with_madvise()` is false or `f` is not an `sdsl::mmap_ifstream`.
-// The range is rounded out to enclosing page boundaries (madvise requires
-// page-aligned start).
-void madvise_random_range(std::istream &f, std::streamoff start, std::streamoff length);
+void madvise_random_range(std::istream &f,
+                          std::streamoff start = 0,
+                          std::streamoff length = -1);
 
 // Open `filename` as an `sdsl::mmap_ifstream` seeked to `offset`, invoke
 // `fn` so the caller can load from it, then (if `with_madvise()`) hint

--- a/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
+++ b/metagraph/src/graph/representation/succinct/dbg_succinct.cpp
@@ -703,16 +703,8 @@ bool DBGSuccinct::load_without_mask(const std::string &filename) {
         if (!boss_graph_->load_suffix_ranges(*in))
             logger->warn("No index for node ranges could be loaded");
 
-        if (utils::with_madvise()) {
-            if (auto *mmap_in = dynamic_cast<sdsl::mmap_ifstream*>(in.get())) {
-                // hint random access for query-time traversal of the loaded data
-                if (madvise(mmap_in->get_mmap_context()->data(),
-                            mmap_in->get_mmap_context()->file_size_bytes(),
-                            MADV_RANDOM)) {
-                    logger->warn("madvise(MADV_RANDOM) failed");
-                }
-            }
-        }
+        // hint random access for query-time traversal of the loaded data
+        utils::madvise_random_range(*in);
     }
 
     return true;

--- a/metagraph/tests/annotation/test_annotated_dbg.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg.cpp
@@ -2045,4 +2045,46 @@ TEST(AnnotatedDBG, score_kmer_presence_mask) {
     }
 }
 
+// `RowDiff<RowDisk>` previously forced mmap; now it loads via either
+// `sdsl::mmap_ifstream` or `utils::named_ifstream`. Verify both paths
+// produce the same query results.
+TEST(RowDiffDiskAnnotatorTest, LoadConsistentAcrossMmapSettings) {
+    const std::vector<std::string> sequences {
+        std::string(80, 'A') + std::string(5, 'C'),
+        std::string(80, 'T') + std::string(5, 'G'),
+        std::string(80, 'G') + std::string(5, 'A'),
+    };
+    const std::vector<std::string> labels { "First", "Second", "Third" };
+    constexpr size_t k = 7;
+
+    const bool mmap_orig = utils::with_mmap();
+
+    utils::set_mmap(true);
+    auto anno_mmap = build_anno_graph<DBGSuccinct, annot::RowDiffDiskAnnotator>(
+            k, sequences, labels);
+
+    utils::set_mmap(false);
+    auto anno_plain = build_anno_graph<DBGSuccinct, annot::RowDiffDiskAnnotator>(
+            k, sequences, labels);
+
+    utils::set_mmap(mmap_orig);
+
+    ASSERT_NE(nullptr, anno_mmap);
+    ASSERT_NE(nullptr, anno_plain);
+
+    auto labels_per_node = [](const AnnotatedDBG &g, const std::string &seq) {
+        std::vector<std::set<std::string>> result;
+        g.get_graph().map_to_nodes(seq, [&](auto idx) {
+            EXPECT_NE(SequenceGraph::npos, idx);
+            result.push_back(convert_to_set(g.get_labels(idx)));
+        });
+        return result;
+    };
+
+    for (const auto &seq : sequences) {
+        EXPECT_EQ(labels_per_node(*anno_mmap, seq),
+                  labels_per_node(*anno_plain, seq));
+    }
+}
+
 } // namespace

--- a/metagraph/tests/annotation/test_annotated_dbg.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg.cpp
@@ -9,6 +9,9 @@
 #include "common/threads/threading.hpp"
 #include "common/vectors/bit_vector_dyn.hpp"
 #include "common/vectors/vector_algorithm.hpp"
+#include "annotation/binary_matrix/row_disk/row_disk.hpp"
+#include "annotation/int_matrix/row_disk/coord_row_disk.hpp"
+#include "annotation/int_matrix/row_disk/int_row_disk.hpp"
 #include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
 
 #define protected public
@@ -2085,6 +2088,93 @@ TEST(RowDiffDiskAnnotatorTest, LoadConsistentAcrossMmapSettings) {
         EXPECT_EQ(labels_per_node(*anno_mmap, seq),
                   labels_per_node(*anno_plain, seq));
     }
+}
+
+// `IntRowDisk::load` no longer forces mmap; verify both paths produce the
+// same row reads from a freshly serialized matrix.
+TEST(IntRowDiskTest, LoadConsistentAcrossMmapSettings) {
+    using mtg::annot::matrix::IntRowDisk;
+    using mtg::annot::matrix::IntMatrix;
+    using mtg::annot::matrix::BinaryMatrix;
+
+    const std::string fname = test_dump_dir() + "/test_int_row_disk.bin";
+    { std::ofstream tmp(fname, std::ios::binary | std::ios::trunc); }
+
+    std::vector<IntMatrix::RowValues> input_rows = {
+        { { 0, 5 }, { 2, 7 } },
+        { { 1, 3 } },
+        { { 0, 1 }, { 1, 2 }, { 2, 4 } },
+    };
+    constexpr uint64_t num_set_bits = 6;
+    constexpr uint8_t  max_val = 7;
+    constexpr uint64_t num_cols = 3;
+
+    IntRowDisk::serialize(fname,
+        [&](std::function<void(const IntMatrix::RowValues &)> write_row) {
+            for (const auto &row : input_rows) write_row(row);
+        },
+        num_cols, input_rows.size(), num_set_bits, max_val);
+
+    auto query = [&](bool mmap) {
+        const bool orig = utils::with_mmap();
+        utils::set_mmap(mmap);
+        auto in = utils::open_ifstream(fname);
+        IntRowDisk d;
+        EXPECT_TRUE(d.load(*in));
+        std::vector<BinaryMatrix::Row> all_rows(input_rows.size());
+        std::iota(all_rows.begin(), all_rows.end(), 0u);
+        auto got = d.get_row_values(all_rows);
+        utils::set_mmap(orig);
+        return got;
+    };
+
+    EXPECT_EQ(input_rows, query(true));
+    EXPECT_EQ(input_rows, query(false));
+}
+
+// `CoordRowDisk::load` reads `num_attributes_` from the boundary stream
+// after loading `boundary_`; verify mmap on/off paths are consistent.
+TEST(CoordRowDiskTest, LoadConsistentAcrossMmapSettings) {
+    using mtg::annot::matrix::CoordRowDisk;
+    using mtg::annot::matrix::MultiIntMatrix;
+    using mtg::annot::matrix::BinaryMatrix;
+    using Tuple = MultiIntMatrix::Tuple;
+
+    const std::string fname = test_dump_dir() + "/test_coord_row_disk.bin";
+    { std::ofstream tmp(fname, std::ios::binary | std::ios::trunc); }
+
+    std::vector<MultiIntMatrix::RowTuples> input_rows = {
+        { { 0, Tuple{ 5, 8 } }, { 2, Tuple{ 7 } } },
+        { { 1, Tuple{ 3 } } },
+        { { 0, Tuple{ 1 } }, { 1, Tuple{ 2, 4 } } },
+    };
+    constexpr uint64_t num_set_bits    = 5;  // total (col, Tuple) pairs
+    constexpr uint64_t num_values      = 7;  // total tuple elements
+    constexpr uint64_t max_val         = 8;
+    constexpr uint64_t max_tuple_size  = 2;
+    constexpr uint64_t num_cols        = 3;
+
+    CoordRowDisk::serialize(fname,
+        [&](std::function<void(const MultiIntMatrix::RowTuples &)> write_row) {
+            for (const auto &row : input_rows) write_row(row);
+        },
+        num_cols, input_rows.size(), num_set_bits, num_values, max_val, max_tuple_size);
+
+    auto query = [&](bool mmap) {
+        const bool orig = utils::with_mmap();
+        utils::set_mmap(mmap);
+        auto in = utils::open_ifstream(fname);
+        CoordRowDisk d;
+        EXPECT_TRUE(d.load(*in));
+        std::vector<BinaryMatrix::Row> all_rows(input_rows.size());
+        std::iota(all_rows.begin(), all_rows.end(), 0u);
+        auto got = d.get_row_tuples(all_rows);
+        utils::set_mmap(orig);
+        return got;
+    };
+
+    EXPECT_EQ(input_rows, query(true));
+    EXPECT_EQ(input_rows, query(false));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary
The disk-resident row-diff annotators (`RowDiff<RowDisk>`, `IntRowDiff<IntRowDisk>`, `TupleRowDiff<CoordRowDisk>`) previously forced mmap regardless of `--mmap`. Now they respect the flag, with one exception: `boundary_` is always mmap'd (too large to materialize into RAM) and gets `madvise(MADV_RANDOM)` since access is `select1`-driven.

| Component | `--mmap` on | `--mmap` off |
|---|---|---|
| `set_bits_` (`int_vector_buffer<>`) | disk-resident | disk-resident |
| `boundary_` | mmap | **mmap** |
| `anchor_`, `fork_succ_` | mmap | RAM |

## Mechanism
- `utils::named_ifstream` mirrors `sdsl::mmap_ifstream` (carries the filename); `utils::get_filename(istream&)` recovers it via `dynamic_cast` so loaders work with either stream type.
- `RowDisk`/`IntRowDisk`/`CoordRowDisk` `load()` open a fresh `mmap_ifstream` for `boundary_`.
- `annotation_matrix.cpp` drops the `is_same_v<T, RowDiffDisk*Annotator>` mmap override.

## Test plan
- [x] `RowDiffDiskAnnotatorTest.LoadConsistentAcrossMmapSettings` — round-trip with mmap on/off
- [x] `AnnotatedDBGWithNTest/5.*` (all `RowDiff<RowDisk>` typed tests)
- [x] CI green
