### PR TITLE
Validate diff-assembly JSON has 'groups' array

### DIFF
--- a/metagraph/docs/source/sequence_assembly.rst
+++ b/metagraph/docs/source/sequence_assembly.rst
@@ -17,7 +17,28 @@ MetaGraph allows for sequences to be assembled from a defined subgraph of an inp
 
 These subgraphs can be defined using a JSON configuration file. Examples are provided `here <https://github.com/ratschlab/metagraph/blob/master/metagraph/tests/data/example.diff.json>`__ and `here <https://github.com/ratschlab/metagraph/blob/master/metagraph/tests/data/example_simple.diff.json>`__.
 
-Several differential assembly experiments may be defined for a single input annotated graph. These are organized into *groups* and *experiments*. A *group* is defined by a list of experiments and sets of foreground and background labels which are shared by these experiments. We recommend that labels with a substantially larger number of k-mers, such as reference genomes, are defined as shared. An *experiment* is defined by its own set of foreground and background labels, and by the assembly experiment parameters.
+The expected schema is::
+
+    {
+        "groups": [
+            {
+                "shared_labels": {  // optional
+                    "in":  [...],
+                    "out": [...]
+                },
+                "experiments": [
+                    {
+                        "name": "...",
+                        "in":  [...],
+                        "out": [...],
+                        ...
+                    }
+                ]
+            }
+        ]
+    }
+
+Several differential assembly experiments may be defined for a single input annotated graph. These are organized into *groups* and *experiments*. A *group* is defined by a list of experiments and an optional ``shared_labels`` field whose foreground/background labels are merged into every experiment in the group. We recommend that labels with a substantially larger number of k-mers, such as reference genomes, are defined as shared. An *experiment* is defined by its own set of foreground and background labels, and by the assembly experiment parameters.
 
 The assembly proceeds in four stages. In the first stage, the k-mers labeled with at least one of the foreground and background labels are enumerated to determine the initial subgraph. In the second stage, all labels associated with the subgraph unitigs are checked against the group's shared label set, updating the foreground and background label counts accordingly. In the third stage, the foreground and background label counts, and assembly parameters, are used to determine which k-mers are filtered out from the subgraph. In the fourth stage, sequences are assembled from the subgraph constructed in stage three.
 

--- a/metagraph/integration_tests/test_assemble.py
+++ b/metagraph/integration_tests/test_assemble.py
@@ -319,15 +319,21 @@ class TestDiffAssembly(TestingBase):
         self.assertEqual(len(results['>metasub_by_kmer']), 1)
         self.assertEqual(results['>metasub_by_kmer'][0], 'CTTGGATCACACTCTTCTCAGAGCCCAGGCCAGGGGCCCCCAAGAAAGGCTCTGGTGGAGAACCTGTGCATGAAGGCTGTCAACCAGTCCATAGGCAGGGCCATCAGGCACCAAAGGGATTCTGCCAGCATAGTGCTCCTGGACCAGTGATACACCCGGCACCCTGTCCTGGACATGCTGTTGGCCTGGATCTGAGCCCTCGTGGAGGTCAAAGCCACCTTTGGTTCTGCCATTGCTGCTGTGTGGAAGTTCACTCAAGTAGGCCTCTTCCTG')
 
-    def test_diff_assembly_invalid_config_no_groups(self):
-        """A config without a 'groups' array must error out cleanly. The
-        previous behavior was a silent exit with no output file."""
-        bad_config = self.tempdir.name + '/no_groups.json'
+    @parameterized.expand([
+        ('top_level_experiments', '{"experiments": [{"name": "x", "in": [], "out": []}]}'),
+        ('empty_groups',          '{"groups": []}'),
+        ('groups_wrong_type',     '{"groups": "not_an_array"}'),
+    ])
+    def test_diff_assembly_invalid_config(self, _name, content):
+        """Configs without a non-empty 'groups' array must error out cleanly.
+        The previous behavior was a silent exit with no output file."""
+        bad_config = self.tempdir.name + f'/bad_{_name}.json'
         with open(bad_config, 'w') as f:
-            f.write('{"experiments": [{"name": "x", "in": [], "out": []}]}')
+            f.write(content)
+        out_base = self.tempdir.name + f'/should_not_exist_{_name}'
         cmd = (f'{METAGRAPH} assemble -p {NUM_THREADS} '
                f'-a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} '
-               f'-o {self.tempdir.name}/should_not_exist '
+               f'-o {out_base} '
                f'--diff-assembly-rules {bad_config} '
                f'{self.tempdir.name}/graph{graph_file_extension[self.graph_repr]}')
         res = subprocess.run([cmd], shell=True, stderr=subprocess.PIPE)
@@ -335,5 +341,5 @@ class TestDiffAssembly(TestingBase):
             msg="expected non-zero exit for malformed config")
         self.assertIn(b"groups", res.stderr,
             msg=f"expected error to mention 'groups', got: {res.stderr.decode()}")
-        self.assertFalse(os.path.exists(self.tempdir.name + '/should_not_exist.fasta.gz'),
+        self.assertFalse(os.path.exists(out_base + '.fasta.gz'),
             msg="output file should not have been created")

--- a/metagraph/integration_tests/test_assemble.py
+++ b/metagraph/integration_tests/test_assemble.py
@@ -318,3 +318,22 @@ class TestDiffAssembly(TestingBase):
         self.assertTrue('>metasub_by_kmer' in results)
         self.assertEqual(len(results['>metasub_by_kmer']), 1)
         self.assertEqual(results['>metasub_by_kmer'][0], 'CTTGGATCACACTCTTCTCAGAGCCCAGGCCAGGGGCCCCCAAGAAAGGCTCTGGTGGAGAACCTGTGCATGAAGGCTGTCAACCAGTCCATAGGCAGGGCCATCAGGCACCAAAGGGATTCTGCCAGCATAGTGCTCCTGGACCAGTGATACACCCGGCACCCTGTCCTGGACATGCTGTTGGCCTGGATCTGAGCCCTCGTGGAGGTCAAAGCCACCTTTGGTTCTGCCATTGCTGCTGTGTGGAAGTTCACTCAAGTAGGCCTCTTCCTG')
+
+    def test_diff_assembly_invalid_config_no_groups(self):
+        """A config without a 'groups' array must error out cleanly. The
+        previous behavior was a silent exit with no output file."""
+        bad_config = self.tempdir.name + '/no_groups.json'
+        with open(bad_config, 'w') as f:
+            f.write('{"experiments": [{"name": "x", "in": [], "out": []}]}')
+        cmd = (f'{METAGRAPH} assemble -p {NUM_THREADS} '
+               f'-a {self.tempdir.name}/annotation{anno_file_extension[self.anno_repr]} '
+               f'-o {self.tempdir.name}/should_not_exist '
+               f'--diff-assembly-rules {bad_config} '
+               f'{self.tempdir.name}/graph{graph_file_extension[self.graph_repr]}')
+        res = subprocess.run([cmd], shell=True, stderr=subprocess.PIPE)
+        self.assertNotEqual(res.returncode, 0,
+            msg="expected non-zero exit for malformed config")
+        self.assertIn(b"groups", res.stderr,
+            msg=f"expected error to mention 'groups', got: {res.stderr.decode()}")
+        self.assertFalse(os.path.exists(self.tempdir.name + '/should_not_exist.fasta.gz'),
+            msg="output file should not have been created")

--- a/metagraph/src/cli/assemble.cpp
+++ b/metagraph/src/cli/assemble.cpp
@@ -86,7 +86,8 @@ void call_masked_graphs(const AnnotatedDBG &anno_graph,
     if (!diff_json.isMember("groups") || !diff_json["groups"].isArray()
             || diff_json["groups"].empty()) {
         logger->error("'{}' has no 'groups' array. Expected: "
-                      "{{\"groups\": [{{\"experiments\": [...]}}]}}",
+                      "{{\"groups\": [{{\"experiments\": [...]}}]}}. "
+                      "See metagraph/tests/data/example_simple.diff.json.",
                       config->assembly_config_file);
         exit(1);
     }

--- a/metagraph/src/cli/assemble.cpp
+++ b/metagraph/src/cli/assemble.cpp
@@ -81,6 +81,16 @@ void call_masked_graphs(const AnnotatedDBG &anno_graph,
     Json::Value diff_json;
     fin >> diff_json;
 
+    // Validate the JSON shape early. Without this, missing 'groups' silently
+    // produces an empty output.
+    if (!diff_json.isMember("groups") || !diff_json["groups"].isArray()
+            || diff_json["groups"].empty()) {
+        logger->error("'{}' has no 'groups' array. Expected: "
+                      "{{\"groups\": [{{\"experiments\": [...]}}]}}",
+                      config->assembly_config_file);
+        exit(1);
+    }
+
     tsl::hopscotch_set<std::string> foreground_labels;
     tsl::hopscotch_set<std::string> background_labels;
     tsl::hopscotch_set<std::string> shared_foreground_labels;


### PR DESCRIPTION
Missing or empty 'groups' silently produced an empty output (no error, no fasta) — impossible to debug from the user side. Now errors out with the expected schema.

Add an integration test for the malformed-config case and an inline schema skeleton + `shared_labels` description to the docs alongside the linked examples.