### PR TITLE
Build succinct graphs in place by default; --in-ram for building in RAM

### DIFF
--- a/metagraph/docs/source/faq.rst
+++ b/metagraph/docs/source/faq.rst
@@ -129,7 +129,8 @@ How to handle large datasets?
 3. **Extremely large graphs:**
 
 Extremely large succinct graphs can be constructed by building their parts separately
-and writing them to disk on the fly with flag ``--inplace``.
+and writing them to disk on the fly. This is the default succinct build path;
+pass ``--in-ram`` to construct the graph in RAM instead (requires more RAM, normally not needed).
 
 Annotation
 ==========

--- a/metagraph/experiments/large_index_scripts.md
+++ b/metagraph/experiments/large_index_scripts.md
@@ -1979,7 +1979,6 @@ for G in {0..5}; do
             /usr/bin/time -v $METAGRAPH build -v \
                 -k 31 \
                 --mode canonical \
-                --inplace \
                 -o $DIR/graph_canonical_${G} \
                 --mem-cap-gb 80 \
                 --disk-swap ~/metagenome/scratch/nobackup/ \
@@ -2010,7 +2009,6 @@ bsub -J "metazoa_canonical" \
      -n 36 -R "rusage[mem=80000] span[hosts=1]" \
     "/usr/bin/time -v $METAGRAPH build -v \
             -k 31 \
-            --inplace \
             -o $DIR/graph_basic \
             --disk-swap ~/metagenome/scratch/nobackup/ \
             --mem-cap-gb 180 \
@@ -2369,7 +2367,6 @@ sbatch -J "metazoa1k" \
     --wrap="cat ${DIR}/samples.txt \
         | /usr/bin/time -v $METAGRAPH build -v \
             -k 31 \
-            --inplace \
             --mode canonical \
             --mem-cap-gb 50 \
             --disk-swap ~/metagenome/scratch/nobackup \
@@ -2592,7 +2589,6 @@ for i in {0,9}; do
         --wrap="cat ${DIR}/samples.txt \
             | /usr/bin/time -v $METAGRAPH build -v \
                 -k 31 \
-                --inplace \
                 --mode canonical \
                 --mem-cap-gb 50 \
                 --disk-swap ~/metagenome/scratch/nobackup \
@@ -2941,7 +2937,6 @@ sbatch -J "random100" \
     --wrap="cat ${DIR}/samples.txt \
         | /usr/bin/time -v $METAGRAPH build -v \
             -k 31 \
-            --inplace \
             --mode canonical \
             --mem-cap-gb 50 \
             --disk-swap ~/metagenome/scratch/nobackup \
@@ -3181,7 +3176,6 @@ sbatch -J "random10K_cleaned_2" \
         /usr/bin/time -v $METAGRAPH build -v \
             -k 31 \
             --mode canonical \
-            --inplace \
             --mem-cap-gb 20 \
             --count-kmers \
             --disk-swap ~/metagenome/scratch/nobackup \
@@ -3233,7 +3227,6 @@ sbatch -J "random5K" \
     --wrap="cat ${DIR}/5k_list.txt \
         | /usr/bin/time -v $METAGRAPH build -v \
             -k 31 \
-            --inplace \
             --mode canonical \
             --mem-cap-gb 50 \
             --disk-swap ~/metagenome/scratch/nobackup \
@@ -3530,7 +3523,6 @@ sbatch -J "random5K" \
     --wrap="cat ${DIR}/5k_list.txt \
         | /usr/bin/time -v $METAGRAPH build -v \
             -k 31 \
-            --inplace \
             --mode canonical \
             --mem-cap-gb 50 \
             --disk-swap ~/metagenome/scratch/nobackup \

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -30,7 +30,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -62,7 +62,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -92,7 +92,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -126,7 +126,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -156,7 +156,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -179,7 +179,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -211,7 +211,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -244,7 +244,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -273,7 +273,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT.primary',
                           k=11, repr=representation, mode='primary',
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT.primary' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -306,7 +306,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT.primary',
                           k=11, repr=representation, mode='primary',
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT.primary' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -335,7 +335,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])
@@ -361,7 +361,7 @@ class TestDNAAlign(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/genome.MT.fa',
                           output=self.tempdir.name + '/genome.MT',
                           k=11, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         params = self._get_stats(self.tempdir.name + '/genome.MT' + graph_file_extension[representation])
         self.assertEqual('11', params['k'])

--- a/metagraph/integration_tests/test_annotate.py
+++ b/metagraph/integration_tests/test_annotate.py
@@ -30,7 +30,7 @@ class TestAnnotate(TestingBase):
     @parameterized.expand([repr for repr in GRAPH_TYPES if not (repr == 'bitmap' and PROTEIN_MODE)])
     def test_simple_all_graphs(self, graph_repr):
 
-        construct_command = '{exe} build --mask-dummy -p {num_threads} \
+        construct_command = '{exe} build --mask-dummy --in-ram -p {num_threads} \
                 --graph {repr} -k 20 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             num_threads=NUM_THREADS,
@@ -75,7 +75,7 @@ class TestAnnotate(TestingBase):
     @unittest.skipIf(PROTEIN_MODE, "No canonical mode for Protein alphabets")
     def test_simple_all_graphs_canonical(self, graph_repr):
 
-        construct_command = '{exe} build --mask-dummy -p {num_threads} \
+        construct_command = '{exe} build --mask-dummy --in-ram -p {num_threads} \
                 --graph {repr} --mode canonical -k 20 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             num_threads=NUM_THREADS,
@@ -120,7 +120,7 @@ class TestAnnotate(TestingBase):
         Annotate non-canonical graph constructed from non-canonical KMC database
         """
 
-        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+        construct_command = f'{METAGRAPH} build --mask-dummy --in-ram -p {NUM_THREADS} \
                             --graph {graph_repr} -k 11 \
                             -o {self.tempdir.name}/graph \
                             {TEST_DATA_DIR}/transcripts_1000_kmc_counters.kmc_suf'
@@ -161,7 +161,7 @@ class TestAnnotate(TestingBase):
         Annotate non-canonical graph constructed from canonical KMC database
         """
 
-        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+        construct_command = f'{METAGRAPH} build --mask-dummy --in-ram -p {NUM_THREADS} \
                             --graph {graph_repr} -k 11 \
                             -o {self.tempdir.name}/graph \
                             {TEST_DATA_DIR}/transcripts_1000_kmc_counters_both_strands.kmc_suf'
@@ -224,7 +224,7 @@ class TestAnnotate(TestingBase):
         Annotate canonical graph with k-mers from KMC
         """
 
-        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+        construct_command = f'{METAGRAPH} build --mask-dummy --in-ram -p {NUM_THREADS} \
                             --graph {graph_repr} --mode canonical -k 11 \
                             -o {self.tempdir.name}/graph \
                             {TEST_DATA_DIR}/transcripts_1000_kmc_counters.kmc_suf'
@@ -283,7 +283,7 @@ class TestAnnotate(TestingBase):
         graph_repr = 'succinct'
         anno_repr = 'column'
 
-        construct_command = '{exe} build --mask-dummy -p {num_threads} \
+        construct_command = '{exe} build --mask-dummy --in-ram -p {num_threads} \
                 --graph {repr} -k 20 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             num_threads=NUM_THREADS,
@@ -325,7 +325,7 @@ class TestAnnotate(TestingBase):
     @parameterized.expand(GRAPH_TYPES)
     def test_annotate_coordinates(self, graph_repr):
 
-        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+        construct_command = f'{METAGRAPH} build --mask-dummy --in-ram -p {NUM_THREADS} \
                               --graph {graph_repr} -k 11 \
                               -o {self.tempdir.name}/graph \
                               {TEST_DATA_DIR}/transcripts_100.fa'
@@ -345,7 +345,7 @@ class TestAnnotate(TestingBase):
     @parameterized.expand(GRAPH_TYPES)
     def test_annotate_coordinates_with_disk_swap(self, graph_repr):
 
-        construct_command = f'{METAGRAPH} build --mask-dummy -p {NUM_THREADS} \
+        construct_command = f'{METAGRAPH} build --mask-dummy --in-ram -p {NUM_THREADS} \
                               --graph {graph_repr} -k 11 \
                               -o {self.tempdir.name}/graph \
                               {TEST_DATA_DIR}/transcripts_100.fa'

--- a/metagraph/integration_tests/test_assemble.py
+++ b/metagraph/integration_tests/test_assemble.py
@@ -38,7 +38,7 @@ gfa_tests = {
 }
 
 GFAs = [name for name, _ in gfa_tests.items()]
-MASKED = ['','--mask-dummy']
+MASKED = ['','--mask-dummy --in-ram']
 
 
 class TestAnnotate(unittest.TestCase):
@@ -77,7 +77,7 @@ class TestAnnotate(unittest.TestCase):
                 --mode canonical -k {k} -o {outfile} {input}'.format(
             exe=METAGRAPH,
             num_threads=NUM_THREADS,
-            mask_dummy='--mask-dummy' if mask == 'mask' else '',
+            mask_dummy='--mask-dummy --in-ram' if mask == 'mask' else '',
             k=k,
             outfile=self.tempdir.name + '/graph',
             input=gfa_tests[gfa_test]['fasta_path']
@@ -228,7 +228,7 @@ class TestDiffAssembly(TestingBase):
                 --graph {repr} -k {k} -o {outfile} {input}'.format(
             exe=METAGRAPH,
             num_threads=NUM_THREADS,
-            mask_dummy='--mask-dummy' if cls.mask_dummy else '',
+            mask_dummy='--mask-dummy --in-ram' if cls.mask_dummy else '',
             repr=cls.graph_repr,
             k=k,
             outfile=cls.tempdir.name + '/graph',

--- a/metagraph/integration_tests/test_augment.py
+++ b/metagraph/integration_tests/test_augment.py
@@ -32,7 +32,7 @@ class TestAugment(TestingBase):
 
     def _build_initial_graph(self, representation, mode='basic', with_weights=False):
         initial_graph_base = self.tempdir.name + '/graph_initial'
-        build_flags = '--mask-dummy --disk-swap ""'
+        build_flags = '--mask-dummy --in-ram --disk-swap ""'
         if with_weights:
             build_flags += ' --count-kmers'
 

--- a/metagraph/integration_tests/test_build.py
+++ b/metagraph/integration_tests/test_build.py
@@ -30,7 +30,7 @@ class TestBuild(TestingBase):
     def test_simple_all_graphs(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy --graph {repr} --disk-swap {tmp_dir} -k 20 -o {outfile} {input}'.format(
+        construct_command = '{exe} build --mask-dummy --in-ram --graph {repr} --disk-swap {tmp_dir} -k 20 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
             tmp_dir=tmp_dir,
@@ -48,9 +48,9 @@ class TestBuild(TestingBase):
         self.assertEqual('basic', stats_graph['mode'])
 
     @parameterized.expand(succinct_states)
-    def test_build_succinct_inplace(self, state):
+    def test_build_succinct_in_ram(self, state):
         construct_command = f'{METAGRAPH} build -k 20 --graph succinct --state {state} \
-                                            --inplace \
+                                            --in-ram \
                                             -o {self.tempdir.name}/graph \
                                             {TEST_DATA_DIR}/transcripts_1000.fa'
 
@@ -68,7 +68,7 @@ class TestBuild(TestingBase):
     def test_simple_bloom_graph(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy --graph {repr} --disk-swap {tmp_dir} -k 20 -o {outfile} {input}'.format(
+        construct_command = '{exe} build --mask-dummy --in-ram --graph {repr} --disk-swap {tmp_dir} -k 20 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
             tmp_dir=tmp_dir,
@@ -112,7 +112,7 @@ class TestBuild(TestingBase):
         """
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --mode canonical -k 20 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -134,7 +134,7 @@ class TestBuild(TestingBase):
     def test_build_tiny_k(self, build):
         representation, tmp_dir = build_params[build]
 
-        args = [METAGRAPH, 'build', '--mask-dummy', '--graph', representation,
+        args = [METAGRAPH, 'build', '--mask-dummy --in-ram', '--graph', representation,
                 '-k', '2',
                 '--disk-swap', tmp_dir,
                 '-o', self.tempdir.name + '/graph',
@@ -156,7 +156,7 @@ class TestBuild(TestingBase):
     def test_build_tiny_k_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        args = [METAGRAPH, 'build', '--mask-dummy', '--graph', representation, '--mode canonical',
+        args = [METAGRAPH, 'build', '--mask-dummy --in-ram', '--graph', representation, '--mode canonical',
                 '-k', '2',
                 '--disk-swap', tmp_dir,
                 '-o', self.tempdir.name + '/graph',
@@ -176,7 +176,7 @@ class TestBuild(TestingBase):
     def test_build_tiny_k_parallel(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = f'{METAGRAPH} build --mask-dummy --graph {representation} \
+        construct_command = f'{METAGRAPH} build --mask-dummy --in-ram --graph {representation} \
                                 -k 2 -p 100 --disk-swap {tmp_dir} \
                                 -o {self.tempdir.name}/graph \
                                 {TEST_DATA_DIR}/transcripts_1000.fa'
@@ -196,7 +196,7 @@ class TestBuild(TestingBase):
     def test_build_tiny_k_parallel_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = f'{METAGRAPH} build --mask-dummy --graph {representation} \
+        construct_command = f'{METAGRAPH} build --mask-dummy --in-ram --graph {representation} \
                                 --mode canonical \
                                 -k 2 -p 100 --disk-swap {tmp_dir} \
                                 -o {self.tempdir.name}/graph \
@@ -215,7 +215,7 @@ class TestBuild(TestingBase):
     def test_build_from_kmc(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy --graph {repr} --disk-swap {tmp_dir} -k 11 -o {outfile} {input}'.format(
+        construct_command = '{exe} build --mask-dummy --in-ram --graph {repr} --disk-swap {tmp_dir} -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
             tmp_dir=tmp_dir,
@@ -236,7 +236,7 @@ class TestBuild(TestingBase):
     def test_build_from_kmc_both(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy --graph {repr} --disk-swap {tmp_dir} -k 11 -o {outfile} {input}'.format(
+        construct_command = '{exe} build --mask-dummy --in-ram --graph {repr} --disk-swap {tmp_dir} -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
             tmp_dir=tmp_dir,
@@ -258,7 +258,7 @@ class TestBuild(TestingBase):
     def test_build_from_kmc_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --disk-swap {tmp_dir} --mode canonical -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -281,7 +281,7 @@ class TestBuild(TestingBase):
     def test_build_from_kmc_both_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --disk-swap {tmp_dir} --mode canonical -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -306,7 +306,7 @@ class TestBuild(TestingBase):
 
         # Build chunks
         for suffix in ['$', 'A', 'C', 'G', 'T']:
-            construct_command = '{exe} build --mask-dummy --disk-swap {tmp_dir} \
+            construct_command = '{exe} build --mask-dummy --in-ram --disk-swap {tmp_dir} \
                                 --graph {repr} -k 11 --suffix {suffix} -o {outfile} {input}'.format(
                 exe=METAGRAPH,
                 repr=representation,
@@ -345,7 +345,7 @@ class TestBuild(TestingBase):
 
         # Build chunks
         for suffix in ['$', 'A', 'C', 'G', 'T']:
-            construct_command = '{exe} build --mask-dummy --disk-swap {tmp_dir} --graph {repr} --mode canonical -k 11 \
+            construct_command = '{exe} build --mask-dummy --in-ram --disk-swap {tmp_dir} --graph {repr} --mode canonical -k 11 \
                     --suffix {suffix} -o {outfile} {input}'.format(
                 exe=METAGRAPH,
                 repr=representation,

--- a/metagraph/integration_tests/test_build_weighted.py
+++ b/metagraph/integration_tests/test_build_weighted.py
@@ -35,7 +35,7 @@ class TestBuildWeighted(TestingBase):
     def test_simple_all_graphs(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} -k 20 --count-kmers --disk-swap {tmp_dir} -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -59,7 +59,7 @@ class TestBuildWeighted(TestingBase):
     def test_simple_all_graphs_contigs(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} -k 20 --count-kmers --disk-swap {tmp_dir} -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -77,7 +77,7 @@ class TestBuildWeighted(TestingBase):
         res = subprocess.run([command], shell=True)
         self.assertEqual(res.returncode, 0)
 
-        command = f'{METAGRAPH} build --mask-dummy \
+        command = f'{METAGRAPH} build --mask-dummy --in-ram \
                 --graph {representation} -k 20 --count-kmers --disk-swap {tmp_dir} \
                 -o {self.tempdir.name}/graph {self.tempdir.name}/graph_.fasta.gz'
 
@@ -98,7 +98,7 @@ class TestBuildWeighted(TestingBase):
     def test_simple_all_graphs_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --mode canonical --count-kmers --disk-swap {tmp_dir} -k 20 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -121,7 +121,7 @@ class TestBuildWeighted(TestingBase):
     @parameterized.expand(BUILDS)
     def test_build_tiny_k(self, build):
         representation, tmp_dir = build_params[build]
-        args = [METAGRAPH, 'build', '--mask-dummy', '--graph', representation,
+        args = [METAGRAPH, 'build', '--mask-dummy --in-ram', '--graph', representation,
                 '--count-kmers',
                 '--disk-swap', tmp_dir,
                 '-k', '2',
@@ -146,7 +146,7 @@ class TestBuildWeighted(TestingBase):
     def test_build_tiny_k_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        args = [METAGRAPH, 'build', '--mask-dummy', '--graph', representation, '--mode canonical',
+        args = [METAGRAPH, 'build', '--mask-dummy --in-ram', '--graph', representation, '--mode canonical',
                 '--count-kmers',
                 '--disk-swap', tmp_dir,
                 '-k', '2',
@@ -169,7 +169,7 @@ class TestBuildWeighted(TestingBase):
     def test_build_from_kmc(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --count-kmers --disk-swap {tmp_dir} -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -193,7 +193,7 @@ class TestBuildWeighted(TestingBase):
     def test_build_from_kmc_both(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --count-kmers --disk-swap {tmp_dir} -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -219,7 +219,7 @@ class TestBuildWeighted(TestingBase):
     def test_build_from_kmc_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --count-kmers --disk-swap {tmp_dir} --mode canonical -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -245,7 +245,7 @@ class TestBuildWeighted(TestingBase):
     def test_build_from_kmc_both_canonical(self, build):
         representation, tmp_dir = build_params[build]
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} --count-kmers --disk-swap {tmp_dir} --mode canonical -k 11 -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -281,7 +281,7 @@ class TestBuildWeighted(TestingBase):
         representation, tmp_dir = build_params[build]
         count_width, avg_count_expected = width_result
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} -k 4 --count-kmers --disk-swap {tmp_dir} --count-width {width} -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,
@@ -339,7 +339,7 @@ class TestBuildWeighted(TestingBase):
             f.write(b'>CG_10^6times\n')
             f.write(b'CG' * 10**6)
 
-        construct_command = '{exe} build --mask-dummy \
+        construct_command = '{exe} build --mask-dummy --in-ram \
                 --graph {repr} -k {k} --count-kmers --disk-swap {tmp_dir} --count-width {width} -o {outfile} {input}'.format(
             exe=METAGRAPH,
             repr=representation,

--- a/metagraph/integration_tests/test_clean.py
+++ b/metagraph/integration_tests/test_clean.py
@@ -25,7 +25,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -42,7 +42,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -57,7 +57,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers --count-width 2")
+                          extra_params="--mask-dummy --in-ram --count-kmers --count-width 2")
 
         stats = self._get_stats(self.tempdir.name + '/graph' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -74,7 +74,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -89,7 +89,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -99,7 +99,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -112,7 +112,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -122,7 +122,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -137,7 +137,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -147,7 +147,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -161,7 +161,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -171,7 +171,7 @@ class TestCleanWeighted(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=20, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('20', stats['k'])
@@ -193,7 +193,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -210,7 +210,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -226,7 +226,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers --count-width 2")
+                          extra_params="--mask-dummy --in-ram --count-kmers --count-width 2")
 
         stats = self._get_stats(self.tempdir.name + '/graph' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -243,7 +243,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -258,7 +258,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -268,7 +268,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy")
+                          extra_params="--mask-dummy --in-ram")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -281,7 +281,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -291,7 +291,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -306,7 +306,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=31, repr=representation,
-                          extra_params="--mask-dummy --count-kmers --fwd-and-reverse")
+                          extra_params="--mask-dummy --in-ram --count-kmers --fwd-and-reverse")
 
         # extract all unitigs, not only the primary ones
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
@@ -317,7 +317,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=31, repr=representation,
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -332,7 +332,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -342,7 +342,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])
@@ -357,7 +357,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=TEST_DATA_DIR + '/transcripts_1000.fa',
                           output=self.tempdir.name + '/graph',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         clean_fasta = self.tempdir.name + '/contigs.fasta.gz'
         self._clean(self.tempdir.name + '/graph' + graph_file_extension[representation],
@@ -367,7 +367,7 @@ class TestCleanWeightedCanonical(TestingBase):
         self._build_graph(input=clean_fasta,
                           output=self.tempdir.name + '/graph_clean',
                           k=31, repr=representation, mode='canonical',
-                          extra_params="--mask-dummy --count-kmers")
+                          extra_params="--mask-dummy --in-ram --count-kmers")
 
         stats = self._get_stats(self.tempdir.name + '/graph_clean' + graph_file_extension[representation])
         self.assertEqual('31', stats['k'])

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -137,7 +137,7 @@ class TestQuery(TestingBase):
         cls._build_graph(TEST_DATA_DIR + '/transcripts_100.fa',
                          cls.tempdir.name + '/graph',
                          20, cls.graph_repr, 'basic',
-                         '--mask-dummy' if cls.mask_dummy else '')
+                         '--mask-dummy --in-ram' if cls.mask_dummy else '')
 
         stats_graph = cls._get_stats(f'{cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}')
         assert(stats_graph['returncode'] == 0)
@@ -426,7 +426,7 @@ class TestQueryTinyLinear(TestingBase):
             cls.graph_repr = 'succinct'
             cls.mask_dummy = True
 
-        cls._build_graph(cls.fasta_graph, cls.tempdir.name + '/graph', 5, cls.graph_repr, 'basic', '--mask-dummy')
+        cls._build_graph(cls.fasta_graph, cls.tempdir.name + '/graph', 5, cls.graph_repr, 'basic', '--mask-dummy --in-ram')
 
         stats_graph = cls._get_stats(f'{cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}')
         assert(stats_graph['returncode'] == 0)
@@ -506,7 +506,7 @@ class TestQuery1Column(TestingBase):
         cls._build_graph(TEST_DATA_DIR + '/transcripts_100.fa',
                          cls.tempdir.name + '/graph',
                          20, cls.graph_repr, 'basic',
-                         '--mask-dummy' if cls.mask_dummy else '')
+                         '--mask-dummy --in-ram' if cls.mask_dummy else '')
 
         stats_graph = cls._get_stats(cls.tempdir.name + '/graph' + graph_file_extension[cls.graph_repr])
         assert(stats_graph['returncode'] == 0)
@@ -692,7 +692,7 @@ class TestQueryCounts(TestingBase):
             cls.mask_dummy = True
 
         cls._build_graph((cls.fasta_file_1, cls.fasta_file_2), cls.tempdir.name + '/graph',
-                         cls.k, cls.graph_repr, 'basic', '--mask-dummy' if cls.mask_dummy else '')
+                         cls.k, cls.graph_repr, 'basic', '--mask-dummy --in-ram' if cls.mask_dummy else '')
 
         stats_graph = cls._get_stats(f'{cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}')
         assert(stats_graph['returncode'] == 0)
@@ -872,7 +872,7 @@ class TestQueryCanonical(TestingBase):
         cls._build_graph(TEST_DATA_DIR + '/transcripts_100.fa',
                          cls.tempdir.name + '/graph',
                          20, cls.graph_repr, 'canonical',
-                         '--mask-dummy' if cls.mask_dummy else '')
+                         '--mask-dummy --in-ram' if cls.mask_dummy else '')
 
         stats_graph = cls._get_stats(f'{cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}')
         assert(stats_graph['returncode'] == 0)
@@ -980,7 +980,7 @@ class TestQueryPrimary(TestingBase):
         cls._build_graph(TEST_DATA_DIR + '/transcripts_100.fa',
                          cls.tempdir.name + '/graph',
                          20, cls.graph_repr, 'primary',
-                         '--mask-dummy' if cls.mask_dummy else '')
+                         '--mask-dummy --in-ram' if cls.mask_dummy else '')
 
         stats_graph = cls._get_stats(f'{cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}')
         assert(stats_graph['returncode'] == 0)

--- a/metagraph/integration_tests/test_transform_anno.py
+++ b/metagraph/integration_tests/test_transform_anno.py
@@ -26,7 +26,7 @@ class TestColumnOperations(TestingBase):
 
         cls._build_graph(TEST_DATA_DIR + '/transcripts_100.fa',
                          cls.tempdir.name + '/graph',
-                         20, cls.graph_repr, 'basic', '--mask-dummy')
+                         20, cls.graph_repr, 'basic', '--mask-dummy --in-ram')
 
         stats_graph = cls._get_stats(f'{cls.tempdir.name}/graph{graph_file_extension[cls.graph_repr]}')
         assert(stats_graph['returncode'] == 0)
@@ -162,7 +162,7 @@ class TestColumnOperationsWithCounts(TestingBase):
         fasta_paths = [f'{TEST_DATA_DIR}/{dataset}.fa' for dataset in cls.datasets]
         cls._build_graph(fasta_paths,
                          cls.tempdir.name + '/graph',
-                         20, cls.graph_repr, 'basic', '--mask-dummy')
+                         20, cls.graph_repr, 'basic', '--mask-dummy --in-ram')
 
         # Store test k-mers with their count arrays from each annotation
         # Format: kmer -> (logan_30_counts, logan_30_alt_counts)
@@ -414,7 +414,7 @@ class TestRowDiffAnnoConverters(TestingBase):
         cls.tempdir = TemporaryDirectory()
         cls._build_graph(TEST_DATA_DIR + '/transcripts_100.fa',
                          cls.tempdir.name + '/graph',
-                         20, 'succinct', 'basic', '--mask-dummy')
+                         20, 'succinct', 'basic', '--mask-dummy --in-ram')
         cls.graph_path = cls.tempdir.name + '/graph' + graph_file_extension['succinct']
 
         # Build the two starting points via the full column -> row_diff -> {brwt,flat}

--- a/metagraph/src/cli/build.cpp
+++ b/metagraph/src/cli/build.cpp
@@ -164,10 +164,10 @@ int build_graph(Config *config) {
                     utils::make_suffix(config->outfbase, DBGSuccinct::kExtension));
         }
 
-        if (config->inplace) {
+        if (!config->in_ram) {
             if (config->mark_dummy_kmers) {
-                logger->warn("Graph is being constructed in-place, dummy k-mers will"
-                             " not be marked. Run `metagraph transform --clear-dummy` manually after construction.");
+                logger->error("--mask-dummy requires --in-ram (dummy marking needs the graph in RAM)");
+                exit(1);
             }
             DBGSuccinct::serialize(std::move(graph_data), config->outfbase,
                                    config->graph_mode, config->state);

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -377,8 +377,8 @@ Config::Config(int argc, char *argv[]) {
             count_dummy = true;
         } else if (!strcmp(argv[i], "--clear-dummy")) {
             clear_dummy = true;
-        } else if (!strcmp(argv[i], "--inplace")) {
-            inplace = true;
+        } else if (!strcmp(argv[i], "--in-ram")) {
+            in_ram = true;
         } else if (!strcmp(argv[i], "--index-ranges")) {
             node_suffix_length = atoi(get_value(i++));
         } else if (!strcmp(argv[i], "--no-postprocessing")) {
@@ -1001,7 +1001,7 @@ if (advanced) {
             fprintf(stderr, "\n");
             fprintf(stderr, "\t   --graph [STR] \tgraph representation: succinct / bitmap / hash / hashstr / hashfast [succinct] / sshash\n");
             fprintf(stderr, "\t   --state [STR] \tstate of succinct graph: small / dynamic / stat / fast [stat]\n");
-            fprintf(stderr, "\t   --inplace \t\tconstruct succinct graph in-place and serialize without loading to RAM [off]\n");
+            fprintf(stderr, "\t   --in-ram \t\tconstruct succinct graph in RAM instead of inplace [off]\n");
             fprintf(stderr, "\t   --count-kmers \tcount k-mers and build weighted graph [off]\n");
             fprintf(stderr, "\t   --count-width \tnumber of bits used to represent k-mer abundance [8]\n");
             fprintf(stderr, "\t   --index-ranges [INT]\tindex all node ranges in BOSS for suffixes of given length [%zu]\n", kDefaultIndexSuffixLen);
@@ -1019,7 +1019,7 @@ if (advanced) {
 }
             fprintf(stderr, "\t-o --outfile-base [STR]\tbasename of output file []\n");
 if (advanced) {
-            fprintf(stderr, "\t   --mask-dummy \tbuild mask for dummy k-mers (only for Succinct graph) [off]\n");
+            fprintf(stderr, "\t   --mask-dummy \tbuild mask for dummy k-mers (only for Succinct graph; requires --in-ram) [off]\n");
 }
             fprintf(stderr, "\t-p --parallel [INT] \tuse multiple threads for computation [1]\n");
             fprintf(stderr, "\t   --disk-swap [STR] \tdirectory to use for temporary files [off]\n");

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -47,7 +47,7 @@ class Config {
     bool subsample_rows = false;
     bool batch_align = false;
     bool suppress_unlabeled = false;
-    bool inplace = false;
+    bool in_ram = false;
     bool clear_dummy = false;
     bool count_dummy = false;
     bool greedy_brwt = false;

--- a/projects/BIGSI/README.md
+++ b/projects/BIGSI/README.md
@@ -192,7 +192,6 @@ sbatch -J "BIGSI_build" \
     --wrap="find ${DIR}/../data -name \"*.unitigs.fasta.gz\" \
         | /usr/bin/time -v $METAGRAPH build -v \
             -k 31 \
-            --inplace \
             --mode canonical \
             --mem-cap-gb 50 \
             --disk-swap ~/metagenome/scratch/nobackup \


### PR DESCRIPTION
- Now succinct graphs are constructed in place by default.
- Deprecated flag `--inplace`.