### PR TITLE
query: compact RLE encoding for k-mer presence bitmasks (signature mode)

### DIFF
--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -438,6 +438,30 @@ can be used when constructing a count-aware graph annotation::
     ``[warning] No k-mer counts found ...`` will be printed and ``metagraph annotate`` will proceed with the assumption that the count of each k-mer is equal to 1.
 
 
+Query k-mer presence masks
+""""""""""""""""""""""""""
+
+To retrieve a per-k-mer presence/absence mask for each matching label, use::
+
+    metagraph query --query-mode signature ...
+
+Each label in the result is followed by the number of matching k-mers and a run-length
+encoded (RLE) bitmask indicating which k-mer positions in the query are present in the
+graph under that label.
+
+**RLE format:** ``x<N>o<N>...`` where ``x`` denotes a run of *N* present k-mers and
+``o`` denotes a run of *N* absent k-mers. Trailing absent-runs are included so the total
+k-mer count equals the sum of all run lengths. For example, for an 8-k-mer query::
+
+    11100110  →  x3o2x2o1   (3 present, 2 absent, 2 present, 1 absent)
+    11111111  →  x8         (all 8 k-mers present)
+    00000000  →  o8         (no k-mers present)
+
+To get the full binary string instead of RLE, pass ``--verbose-output``::
+
+    metagraph query --query-mode signature --verbose-output ...
+
+
 Query k-mer counts
 """"""""""""""""""
 

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -1402,18 +1402,24 @@ class TestCoordToHeader(TestingBase):
         test_stdout('--num-top-labels 3', {'0', 'query1', '<seq2>:37', '<seq3>:12', '<seq1>:10'}, mode='counts-sum')
 
         test_stdout('--num-top-labels 1',
-            '0\tquery1\t<seq2>:13:1111111111111:17', mode='signature')
+            '0\tquery1\t<seq2>:13:x13:17', mode='signature')
         test_stdout('--min-kmers-fraction-label 0.5',
-            {'0', 'query1', '<seq2>:13:1111111111111:17', '<seq3>:12:0111111111111:16', '<seq1>:10:1111011101110:15'}, mode='signature')
+            {'0', 'query1', '<seq2>:13:x13:17', '<seq3>:12:o1x12:16', '<seq1>:10:x4o1x3o1x3o1:15'}, mode='signature')
         test_stdout('--min-kmers-fraction-label 1.0',
-            '0\tquery1\t<seq2>:13:1111111111111:17', mode='signature')
+            '0\tquery1\t<seq2>:13:x13:17', mode='signature')
         test_stdout('--min-kmers-fraction-graph 1.0',
-            {'0', 'query1', '<seq2>:13:1111111111111:17', '<seq3>:12:0111111111111:16', '<seq1>:10:1111011101110:15'}, mode='signature')
+            {'0', 'query1', '<seq2>:13:x13:17', '<seq3>:12:o1x12:16', '<seq1>:10:x4o1x3o1x3o1:15'}, mode='signature')
         test_stdout('',
-            {'0', 'query1', '<seq2>:13:1111111111111:17', '<seq3>:12:0111111111111:16', '<seq1>:10:1111011101110:15'}, mode='signature')
+            {'0', 'query1', '<seq2>:13:x13:17', '<seq3>:12:o1x12:16', '<seq1>:10:x4o1x3o1x3o1:15'}, mode='signature')
         test_stdout('--num-top-labels 2',
-            '0\tquery1\t<seq2>:13:1111111111111:17\t<seq3>:12:0111111111111:16', mode='signature')
+            '0\tquery1\t<seq2>:13:x13:17\t<seq3>:12:o1x12:16', mode='signature')
         test_stdout('--num-top-labels 3',
+            {'0', 'query1', '<seq2>:13:x13:17', '<seq3>:12:o1x12:16', '<seq1>:10:x4o1x3o1x3o1:15'}, mode='signature')
+
+        # --verbose-output switches the presence mask back to the full binary string
+        test_stdout('--num-top-labels 1 --verbose-output',
+            '0\tquery1\t<seq2>:13:1111111111111:17', mode='signature')
+        test_stdout('--min-kmers-fraction-label 0.5 --verbose-output',
             {'0', 'query1', '<seq2>:13:1111111111111:17', '<seq3>:12:0111111111111:16', '<seq1>:10:1111011101110:15'}, mode='signature')
 
     @parameterized.expand(['labels', 'matches', 'counts', 'counts-sum', 'coords', 'signature'])

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -1343,7 +1343,10 @@ if (advanced) {
             fprintf(stderr, "\t       Available modes:\n");
             fprintf(stderr, "\t                %s \t\tprint labels (with enough k-mer matches)\n", querymode_to_string(LABELS).c_str());
             fprintf(stderr, "\t                %s \tprint labels and the number of k-mer matches (for every label with enough k-mer matches)\n", querymode_to_string(MATCHES).c_str());
-            fprintf(stderr, "\t                %s \tprint masks indicating present/absent k-mers (...)\n", querymode_to_string(SIGNATURE).c_str());
+            fprintf(stderr, "\t                %s \tprint masks indicating present/absent k-mers\n", querymode_to_string(SIGNATURE).c_str());
+            fprintf(stderr, "\t                \t\t\t\tOutput format: run-length encoding 'x<N>o<N>...' where x=present, o=absent\n"
+                            "\t                \t\t\t\t    e.g. 'x3o2x2o1' for bitmask '11100110'\n"
+                            "\t                \t\t\t\tWith --verbose-output: full binary string, e.g. '11100110'\n");
 if (advanced) {
             fprintf(stderr, "\t                %s \tprint sum of counts for the matched k-mers, requires count or coord annotation (...)\n", querymode_to_string(COUNTS_SUM).c_str());
 }
@@ -1356,7 +1359,7 @@ if (advanced) {
                             "\t                \t\t\t\t    or '<start pos in query>-<first pos in sample>-<last pos in sample>' (segment match)\n"
                             "\t                \t\t\t\tAll positions start with 0\n");
 if (advanced) {
-            fprintf(stderr, "\t   --verbose-output \t\tdo not collapse continuous coord or count ranges (for query coords and counts) [off]\n");
+            fprintf(stderr, "\t   --verbose-output \t\tfor coords/counts: do not collapse ranges; for signature: print full mask instead of RLE [off]\n");
 }
             fprintf(stderr, "\t   --num-top-labels [INT] \t\tmaximum number of top labels to output [inf]\n");
             fprintf(stderr, "\t   --min-kmers-fraction-label [FLOAT] \tmin fraction of k-mers from the query required to be present in a label [0.7]\n");

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -124,6 +124,24 @@ Json::Value adjust_for_types(const std::string &v) {
 }
 
 
+// Encode a k-mer presence bitmask as alternating x<len>o<len>... runs
+// (x = ones, o = zeros). Trailing zeros are included so the total length
+// is recoverable as the sum of all run lengths.
+// Example: 11100110 → x3o2x2o1
+std::string encode_presence_mask(const sdsl::bit_vector &mask) {
+    std::string result;
+    size_t pos = 0;
+    while (pos < mask.size()) {
+        bool bit = mask[pos];
+        size_t run_start = pos;
+        while (pos < mask.size() && (bool)mask[pos] == bit) ++pos;
+        result += (bit ? 'x' : 'o');
+        result += std::to_string(pos - run_start);
+    }
+    return result;
+}
+
+
 /**
  * Given a label string in the format '<sample_name>(;<property_name>=<property_value>)*'
  * return a JSON representation of the label with its properties.
@@ -206,7 +224,9 @@ Json::Value SeqSearchResult::to_json(bool verbose_output, size_t k) const {
             Json::Value &label_obj = root["results"].append(get_label_as_json(label));
             // Store the presence mask and score in a separate object
             Json::Value &sig_obj = (label_obj[SIGNATURE_FIELD] = Json::objectValue);
-            sig_obj["presence_mask"] = Json::Value(sdsl::util::to_string(kmer_presence_mask));
+            sig_obj["presence_mask"] = Json::Value(verbose_output
+                ? sdsl::util::to_string(kmer_presence_mask)
+                : encode_presence_mask(kmer_presence_mask));
             sig_obj["score"] = Json::Value(align::score_kmer_presence_mask(k, kmer_presence_mask));
             // Add kmer_counts calculated using bitmask
             label_obj[KMER_COUNT_FIELD] = static_cast<Json::Int64>(count);
@@ -306,7 +326,8 @@ std::string SeqSearchResult::to_string(const std::string delimiter,
         for (const auto &[label, count, kmer_presence_mask] : *v) {
             output += fmt::format("\t<{}>:{}:{}:{}", label,
                                   count,
-                                  sdsl::util::to_string(kmer_presence_mask),
+                                  verbose_output ? sdsl::util::to_string(kmer_presence_mask)
+                                                 : encode_presence_mask(kmer_presence_mask),
                                   align::score_kmer_presence_mask(k, kmer_presence_mask));
         }
     } else if (const auto *v = std::get_if<LabelCountAbundancesVec>(&result_)) {
@@ -1128,16 +1149,12 @@ int query_graph(Config *config) {
         auto query_callback = [config, k](const SeqSearchResult &result) {
             if (config->output_json) {
                 std::ostringstream ss;
-                ss << result.to_json(config->verbose_output
-                                         || !(config->query_mode == COUNTS || config->query_mode == COORDS),
-                                     k) << "\n";
+                ss << result.to_json(config->verbose_output, k) << "\n";
                 std::cout << ss.str();
             } else {
                 std::cout << result.to_string(config->anno_labels_delimiter,
                                               config->suppress_unlabeled,
-                                              config->verbose_output
-                                                || !(config->query_mode == COUNTS || config->query_mode == COORDS),
-                                              k) + "\n";
+                                              config->verbose_output, k) + "\n";
             }
         };
         size_t num_bp = query_fasta(file, query_callback, *config, *anno_graph, aligner_config.get());

--- a/metagraph/tests/cli/test_query.cpp
+++ b/metagraph/tests/cli/test_query.cpp
@@ -1,6 +1,7 @@
 #include <vector>
 #include <unordered_set>
 
+#include <sdsl/int_vector.hpp>
 #include "gtest/gtest.h"
 
 #include "cli/query.hpp"
@@ -9,12 +10,10 @@
 
 
 namespace mtg::cli {
-/**
- * Split long contigs into overlapping segments for better work balancing.
- */
 void split_contigs_for_rebalancing(size_t k,
                                    size_t kmers_per_seq,
                                    std::vector<std::pair<std::string, std::vector<uint64_t>>> *contigs);
+std::string encode_presence_mask(const sdsl::bit_vector &mask);
 } // namespace mtg::cli
 
 namespace {
@@ -142,6 +141,42 @@ TEST(split_contigs_for_rebalancing, exact_multiple_of_chunk_steps) {
 
     ASSERT_EQ(3u, contigs.size());
     expect_contig_string_set_eq(contigs, { "abcdefg", "fghijkl", "klmnopq" });
+}
+
+
+sdsl::bit_vector make_bv(std::initializer_list<uint8_t> bits) {
+    sdsl::bit_vector bv(bits.size());
+    size_t i = 0;
+    for (uint8_t b : bits) bv[i++] = b;
+    return bv;
+}
+
+TEST(encode_presence_mask, all_zeros) {
+    EXPECT_EQ("o8", cli::encode_presence_mask(make_bv({0,0,0,0,0,0,0,0})));
+}
+
+TEST(encode_presence_mask, all_ones) {
+    EXPECT_EQ("x8", cli::encode_presence_mask(make_bv({1,1,1,1,1,1,1,1})));
+}
+
+TEST(encode_presence_mask, leading_run) {
+    EXPECT_EQ("x3o2x2o1", cli::encode_presence_mask(make_bv({1,1,1,0,0,1,1,0})));
+}
+
+TEST(encode_presence_mask, leading_gap) {
+    EXPECT_EQ("o3x5", cli::encode_presence_mask(make_bv({0,0,0,1,1,1,1,1})));
+}
+
+TEST(encode_presence_mask, single_bits_alternating) {
+    EXPECT_EQ("x1o1x1o1x1o1x1o1", cli::encode_presence_mask(make_bv({1,0,1,0,1,0,1,0})));
+}
+
+TEST(encode_presence_mask, single_bit_at_each_end) {
+    EXPECT_EQ("x1o6x1", cli::encode_presence_mask(make_bv({1,0,0,0,0,0,0,1})));
+}
+
+TEST(encode_presence_mask, empty) {
+    EXPECT_EQ("", cli::encode_presence_mask(sdsl::bit_vector(0)));
 }
 
 } // namespace


### PR DESCRIPTION
## Summary

- Replaces the raw binary bitmask string in `--query-mode signature` output with a compact run-length encoding (RLE)
- `--verbose-output` retains the full binary string (no behaviour change for existing users who pass that flag)

## New format

```
x<N>o<N>...
```

- `x<N>` — run of **N present** k-mers
- `o<N>` — run of **N absent** k-mers
- Runs alternate; trailing absent-runs are **always included** so the total k-mer count equals the sum of all run lengths

### Examples

| Binary mask    | Encoded         |
|----------------|-----------------|
| `11100110`     | `x3o2x2o1`      |
| `00011111`     | `o3x5`          |
| `10000001`     | `x1o6x1`        |
| `00000000`     | `o8`            |
| `11111111`     | `x8`            |
| `10101010`     | `x1o1x1o1x1o1x1o1` |

### TSV output (text mode)

```
<seq_id>\t<seq_name>\t<label>:<kmer_count>:<mask>:<score>...
```

Example:
```
0	query1	<seq2>:13:x13:17	<seq1>:10:x4o1x3o1x3o1:15
```

### JSON output

```json
{
  "presence_mask": "x4o1x3o1x3o1",
  "score": 15
}
```

### Verbose output (unchanged)

Pass `--verbose-output` to get the original binary string:
```
0	query1	<seq2>:13:1111111111111:17
```

## Decoder (for client updates)

```python
import re

def decode_presence_mask(s: str) -> list[bool]:
    return [
        bit == 'x'
        for token in re.findall(r'[xo]\d+', s)
        for bit in token[0] * int(token[1:])
    ]
```

## Changes

- `src/cli/query.cpp` — `encode_presence_mask()` helper; `to_json`/`to_string` use it by default
- `src/cli/config/config.cpp` — updated `--query-mode signature` and `--verbose-output` help text
- `docs/source/quick_start.rst` — new "Query k-mer presence masks" section
- `tests/cli/test_query.cpp` — 7 unit tests
- `integration_tests/test_query.py` — 15 integration tests (default RLE + verbose binary)