### PR TITLE
Updated workflows: add count/coord modes, improved UX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ metagraph/**/build*
 *.un~
 tags
 **/cmake-build-debug
+**/.snakemake/
 .idea

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -132,7 +132,20 @@ For this use case, primary graph mode is usually not recommended.
 
 Count-aware and coordinate-aware modes are mutually exclusive in this workflow.
 
+Row-diff transform outputs
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The annotate step writes ``columns.<mode>/<basename>.column.annodbg`` for each input sequence
+file. Row-diff stages 0–2 then write under ``rd_cols.<mode>/`` (for example ``rd_cols.binary/``,
+``rd_cols.coords/``, or ``rd_cols.counts.w8/`` depending on configuration):
+
+* **Binary annotation mode** (no ``--with-counts`` / ``--with-coords``): stage 2 emits
+  ``<basename>.row_diff.annodbg`` per column—the ``RowDiffColumnAnnotator`` format.
+* **Count or coordinate mode**: stage 2 emits ``<basename>.column.annodbg`` and, when applicable,
+  ``<basename>.column.annodbg.counts`` and/or ``<basename>.column.annodbg.coords``.
+
 See ``metagraph-workflows build -h`` for more details.
+
 3. Once a MetaGraph index has been created, it can be queried either by using the command line
    ``metagraph`` tool or by starting the MetaGraph server directly on a laptop or on another suitable
    machine and querying it using the python :ref:`API` client.

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -53,7 +53,7 @@ Typically, the following steps would be performed:
 
    * k-mer length
    * basic vs. primary graph mode
-   * source of annotation labels: ``sequence_headers`` or ``sequence_file_names``
+   * source of annotation labels: ``sequence_headers`` or ``file_names``
    * count-aware annotation mode and format selection
 
    An example invocation:
@@ -62,9 +62,9 @@ Typically, the following steps would be performed:
 
      metagraph-workflows build -k 31 \
                                --seqs-dir-path [PATH_TO_FILES] \
-                               --annotation-labels-source sequence_headers \
-                               --build-primary-graph \
-                               [OUTPUT_DIR]
+                               --anno-source sequence_headers \
+                               --primary \
+                               -o [OUTPUT_DIR]
 
 Count-aware annotations
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -80,20 +80,20 @@ the default switches from ``relax.row_diff_brwt`` to ``row_diff_int_brwt``::
 
     metagraph-workflows build -k 31 \
                               --seqs-file-list-path transcript_paths.txt \
-                              --build-primary-graph \
+                              --primary \
                               --with-counts \
                               --count-width 12 \
-                              [OUTPUT_DIR]
+                              -o [OUTPUT_DIR]
 
 You can also select a count-aware format directly via ``--annotation-format``; this
 automatically enables count-aware mode::
 
     metagraph-workflows build -k 31 \
                               --seqs-file-list-path transcript_paths.txt \
-                              --build-primary-graph \
+                              --primary \
                               --annotation-format row_diff_int_brwt \
                               --count-width 12 \
-                              [OUTPUT_DIR]
+                              -o [OUTPUT_DIR]
 
 Use ``--count-width`` to control the stored numeric range for counts
 (valid range: ``2..32``, default: ``8``).
@@ -117,7 +117,7 @@ the default switches from ``relax.row_diff_brwt`` to ``row_diff_brwt_coord``::
     metagraph-workflows build -k 31 \
                               --seqs-file-list-path transcript_paths.txt \
                               --with-coords \
-                              [OUTPUT_DIR]
+                              -o [OUTPUT_DIR]
 
 You can also select a coordinate-aware format directly via ``--annotation-format``; this
 automatically enables coordinate-aware mode::
@@ -125,7 +125,7 @@ automatically enables coordinate-aware mode::
     metagraph-workflows build -k 31 \
                               --seqs-file-list-path transcript_paths.txt \
                               --annotation-format row_diff_brwt_coord \
-                              [OUTPUT_DIR]
+                              -o [OUTPUT_DIR]
 
 Coordinates are typically indexed for reference sequences, where preserving the original sequence context is important.
 For this use case, primary graph mode is usually not recommended.

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -80,6 +80,7 @@ the default switches from ``relax.row_diff_brwt`` to ``row_diff_int_brwt``::
 
     metagraph-workflows build -k 31 \
                               --seqs-file-list-path transcript_paths.txt \
+                              --build-primary-graph \
                               --with-counts \
                               --count-width 12 \
                               [OUTPUT_DIR]
@@ -89,6 +90,7 @@ automatically enables count-aware mode::
 
     metagraph-workflows build -k 31 \
                               --seqs-file-list-path transcript_paths.txt \
+                              --build-primary-graph \
                               --annotation-format row_diff_int_brwt \
                               --count-width 12 \
                               [OUTPUT_DIR]
@@ -98,6 +100,37 @@ Use ``--count-width`` to control the stored numeric range for counts
 
 When reusing an output directory, the workflow keeps count and non-count intermediates in
 separate mode-specific directories to avoid stale artifact reuse.
+
+Coordinate-aware annotations
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The workflow supports these coordinate-aware annotation formats:
+
+* ``brwt_coord``
+* ``row_diff_coord``
+* ``row_diff_brwt_coord``
+* ``row_diff_disk_coord``
+
+To enable coordinates explicitly, pass ``--with-coords``. If no annotation format is specified,
+the default switches from ``relax.row_diff_brwt`` to ``row_diff_brwt_coord``::
+
+    metagraph-workflows build -k 31 \
+                              --seqs-file-list-path transcript_paths.txt \
+                              --with-coords \
+                              [OUTPUT_DIR]
+
+You can also select a coordinate-aware format directly via ``--annotation-format``; this
+automatically enables coordinate-aware mode::
+
+    metagraph-workflows build -k 31 \
+                              --seqs-file-list-path transcript_paths.txt \
+                              --annotation-format row_diff_brwt_coord \
+                              [OUTPUT_DIR]
+
+Coordinates are typically indexed for reference sequences, where preserving the original sequence context is important.
+For this use case, primary graph mode is usually not recommended.
+
+Count-aware and coordinate-aware modes are mutually exclusive in this workflow.
 
 See ``metagraph-workflows build -h`` for more details.
 3. Once a MetaGraph index has been created, it can be queried either by using the command line

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -54,6 +54,7 @@ Typically, the following steps would be performed:
    * k-mer length
    * basic vs. primary graph mode
    * source of annotation labels: ``sequence_headers`` or ``sequence_file_names``
+   * count-aware annotation mode and format selection
 
    An example invocation:
 
@@ -65,7 +66,40 @@ Typically, the following steps would be performed:
                                --build-primary-graph \
                                [OUTPUT_DIR]
 
-   See ``metagraph-workflows build -h`` for more help.
+Count-aware annotations
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The workflow supports these count-aware annotation formats:
+
+* ``int_brwt``
+* ``row_diff_int_brwt``
+* ``row_diff_int_disk``
+
+To enable counts explicitly, pass ``--with-counts``. If no annotation format is specified,
+the default switches from ``relax.row_diff_brwt`` to ``row_diff_int_brwt``::
+
+    metagraph-workflows build -k 31 \
+                              --seqs-file-list-path transcript_paths.txt \
+                              --with-counts \
+                              --count-width 12 \
+                              [OUTPUT_DIR]
+
+You can also select a count-aware format directly via ``--annotation-format``; this
+automatically enables count-aware mode::
+
+    metagraph-workflows build -k 31 \
+                              --seqs-file-list-path transcript_paths.txt \
+                              --annotation-format row_diff_int_brwt \
+                              --count-width 12 \
+                              [OUTPUT_DIR]
+
+Use ``--count-width`` to control the stored numeric range for counts
+(valid range: ``2..32``, default: ``8``).
+
+When reusing an output directory, the workflow keeps count and non-count intermediates in
+separate mode-specific directories to avoid stale artifact reuse.
+
+See ``metagraph-workflows build -h`` for more details.
 3. Once a MetaGraph index has been created, it can be queried either by using the command line
    ``metagraph`` tool or by starting the MetaGraph server directly on a laptop or on another suitable
    machine and querying it using the python :ref:`API` client.

--- a/metagraph/src/annotation/binary_matrix/column_sparse/column_major.cpp
+++ b/metagraph/src/annotation/binary_matrix/column_sparse/column_major.cpp
@@ -10,7 +10,7 @@ namespace matrix {
 
 uint64_t ColumnMajor::num_rows() const {
     if (!columns_.size()) {
-        return 0;
+        return explicit_num_rows_if_empty_;
     } else {
         assert(columns_[0]);
         return columns_[0]->size();
@@ -89,6 +89,7 @@ bool ColumnMajor::load(std::istream &in) {
         return false;
 
     columns_.clear();
+    explicit_num_rows_if_empty_ = 0;
 
     try {
         columns_.resize(load_number(in));
@@ -100,6 +101,10 @@ bool ColumnMajor::load(std::istream &in) {
             c = std::make_unique<bit_vector_sd>();
             if (!c->load(in))
                 return false;
+        }
+        // optional trailing row count for empty matrices
+        if (columns_.empty() && in.good() && in.peek() != std::istream::traits_type::eof()) {
+            explicit_num_rows_if_empty_ = load_number(in);
         }
         return true;
     } catch (...) {
@@ -119,6 +124,9 @@ void ColumnMajor::serialize(std::ostream &out) const {
         } else {
             c->copy_to<bit_vector_sd>().serialize(out);
         }
+    }
+    if (columns_.empty() && explicit_num_rows_if_empty_ > 0) {
+        serialize_number(out, explicit_num_rows_if_empty_);
     }
 }
 

--- a/metagraph/src/annotation/binary_matrix/column_sparse/column_major.hpp
+++ b/metagraph/src/annotation/binary_matrix/column_sparse/column_major.hpp
@@ -14,8 +14,10 @@ namespace matrix {
 class ColumnMajor : public BinaryMatrix, public GetEntrySupport {
   public:
     ColumnMajor() {}
-    ColumnMajor(std::vector<std::unique_ptr<bit_vector>>&& columns)
-        : columns_(std::move(columns)) {}
+    ColumnMajor(std::vector<std::unique_ptr<bit_vector>>&& columns,
+                uint64_t num_rows_if_empty = 0)
+        : columns_(std::move(columns)),
+          explicit_num_rows_if_empty_(columns_.empty() ? num_rows_if_empty : 0) {}
 
     uint64_t num_columns() const override { return columns_.size(); }
     uint64_t num_rows() const override;
@@ -48,6 +50,8 @@ class ColumnMajor : public BinaryMatrix, public GetEntrySupport {
 
   private:
     std::vector<std::unique_ptr<bit_vector>> columns_;
+    // When |columns_| is empty, row dimension for serialization / num_objects (optional).
+    uint64_t explicit_num_rows_if_empty_ = 0;
 };
 
 } // namespace matrix

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.cpp
@@ -31,6 +31,7 @@ ColumnCompressed<Label>::ColumnCompressed(uint64_t num_rows,
                                           const std::string &swap_dir,
                                           uint64_t buffer_size_bytes,
                                           uint8_t count_width,
+                                          bool index_coordinates,
                                           size_t max_chunks_open)
       : num_rows_(num_rows),
         swap_dir_(swap_dir),
@@ -44,6 +45,7 @@ ColumnCompressed<Label>::ColumnCompressed(uint64_t num_rows,
                         }),
         count_width_(count_width),
         max_count_(sdsl::bits::lo_set[count_width]),
+        index_coordinates_(index_coordinates),
         max_chunks_open_(max_chunks_open) {}
 
 template <typename Label>
@@ -53,9 +55,11 @@ ColumnCompressed<Label>::ColumnCompressed(sdsl::bit_vector&& column,
                                           const std::string &swap_dir,
                                           uint64_t buffer_size_bytes,
                                           uint8_t count_width,
+                                          bool index_coordinates,
                                           size_t max_chunks_open)
       : ColumnCompressed(column.size(),
-                         num_columns_cached, swap_dir, buffer_size_bytes, count_width, max_chunks_open) {
+                         num_columns_cached, swap_dir, buffer_size_bytes,
+                         count_width, index_coordinates, max_chunks_open) {
     label_encoder_.insert_and_encode(column_label);
     bitmatrix_.resize(1);
     cached_columns_.Put(0, new bitmap_vector(std::move(column)));
@@ -69,9 +73,11 @@ ColumnCompressed<Label>::ColumnCompressed(std::vector<std::unique_ptr<bit_vector
                                           const std::string &swap_dir,
                                           uint64_t buffer_size_bytes,
                                           uint8_t count_width,
+                                          bool index_coordinates,
                                           size_t max_chunks_open)
       : ColumnCompressed(columns.at(0)->size(),
-                         num_columns_cached, swap_dir, buffer_size_bytes, count_width, max_chunks_open) {
+                         num_columns_cached, swap_dir, buffer_size_bytes,
+                         count_width, index_coordinates, max_chunks_open) {
     bitmatrix_ = std::move(columns);
     label_encoder_ = label_encoder;
     flushed_ = true;
@@ -197,10 +203,12 @@ void ColumnCompressed<Label>::serialize(const std::string &filename) const {
 
     out.close();
 
-    if (coords_.size())
+    // Emit .coords when coordinate mode is on, even if empty (no coords added).
+    if (index_coordinates_)
         serialize_coordinates(filename);
 
-    if (relation_counts_.size())
+    // Emit .counts when count_width > 0, even if empty (no counts added).
+    if (count_width_)
         serialize_counts(filename);
 }
 
@@ -437,6 +445,9 @@ bool ColumnCompressed<Label>::load(const std::string &filename) {
     // release the columns stored
     cached_columns_.Clear();
     bitmatrix_.clear();
+    coords_.clear();
+    max_coord_.clear();
+    relation_counts_.clear();
 
     label_encoder_.clear();
 
@@ -494,6 +505,9 @@ bool ColumnCompressed<Label>::merge_load(const std::vector<std::string> &filenam
     // release the columns stored
     cached_columns_.Clear();
     bitmatrix_.clear();
+    coords_.clear();
+    max_coord_.clear();
+    relation_counts_.clear();
 
     label_encoder_.clear();
 

--- a/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
+++ b/metagraph/src/annotation/representation/column_compressed/annotate_column_compressed.hpp
@@ -36,7 +36,8 @@ class ColumnCompressed : public MultiLabelAnnotation<Label> {
                      size_t num_columns_cached = 1,
                      const std::string &swap_dir = "",
                      uint64_t buffer_size_bytes = 1e7,
-                     uint8_t count_width = 8,
+                     uint8_t count_width = 0,
+                     bool index_coordinates = false,
                      size_t max_chunks_open = 2000);
 
     ColumnCompressed(sdsl::bit_vector&& column,
@@ -44,7 +45,8 @@ class ColumnCompressed : public MultiLabelAnnotation<Label> {
                      size_t num_columns_cached = 1,
                      const std::string &swap_dir = "",
                      uint64_t buffer_size_bytes = 1e7,
-                     uint8_t count_width = 8,
+                     uint8_t count_width = 0,
+                     bool index_coordinates = false,
                      size_t max_chunks_open = 2000);
 
     ColumnCompressed(std::vector<std::unique_ptr<bit_vector>>&& columns,
@@ -52,7 +54,8 @@ class ColumnCompressed : public MultiLabelAnnotation<Label> {
                      size_t num_columns_cached = 1,
                      const std::string &swap_dir = "",
                      uint64_t buffer_size_bytes = 1e7,
-                     uint8_t count_width = 8,
+                     uint8_t count_width = 0,
+                     bool index_coordinates = false,
                      size_t max_chunks_open = 2000);
 
     ColumnCompressed(const ColumnCompressed&) = delete;
@@ -174,6 +177,7 @@ class ColumnCompressed : public MultiLabelAnnotation<Label> {
     mutable std::mutex counts_mu_;
     uint8_t count_width_;
     uint64_t max_count_;
+    bool index_coordinates_;
     std::vector<sdsl::int_vector<>> relation_counts_;
     // depending on parameters, coords are stored in RAM or in chunks dumped to disk
     std::vector<common::SortedVector<std::pair<Index, uint64_t>>> coords_;

--- a/metagraph/src/annotation/row_diff_builder.cpp
+++ b/metagraph/src/annotation/row_diff_builder.cpp
@@ -49,14 +49,12 @@ load_columns(const std::vector<std::string> &source_files, uint64_t *num_rows) {
             std::exit(1);
         }
 
-        if (!sources[i].num_labels())
-            continue;
-
+        const uint64_t n = sources[i].num_objects();
         #pragma omp critical
         {
             if (!*num_rows) {
-                *num_rows = sources[i].num_objects();
-            } else if (*num_rows != sources[i].num_objects()) {
+                *num_rows = n;
+            } else if (*num_rows != n) {
                 logger->error("Annotations have different number of rows");
                 std::exit(1);
             }
@@ -1157,13 +1155,15 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
             diff_columns[l_idx] = std::move(columns);
 
         } else {
-            if (!columns.size())
-                continue;
-
             auto fpath = col_out_dir/fs::path(source_files[l_idx]).filename();
             if constexpr(with_values) {
                 fpath.replace_extension().replace_extension(ColumnCompressed<>::kExtension);
-                ColumnCompressed<>(std::move(columns), label_encoders[l_idx]).serialize(fpath);
+                if (columns.size()) {
+                    ColumnCompressed<>(std::move(columns), label_encoders[l_idx]).serialize(fpath);
+                } else {
+                    // serialize an empty annotation with counts
+                    ColumnCompressed<>(num_rows, 1, "", buf_size_bytes, 1).serialize(fpath);
+                }
                 logger->trace("Serialized {}", fpath);
 
                 fpath.replace_extension().replace_extension(ColumnCompressed<>::kCountExtension);
@@ -1177,7 +1177,7 @@ void convert_batch_to_row_diff(const std::string &pred_succ_fprefix,
             } else {
                 fpath.replace_extension().replace_extension(RowDiffColumnAnnotator::kExtension);
                 RowDiffColumnAnnotator(
-                        std::make_unique<RowDiff<ColumnMajor>>(nullptr, ColumnMajor(std::move(columns))),
+                        std::make_unique<RowDiff<ColumnMajor>>(nullptr, ColumnMajor(std::move(columns), num_rows)),
                         std::move(label_encoders[l_idx])).serialize(fpath);
                 logger->trace("Serialized {}", fpath);
             }
@@ -1524,9 +1524,6 @@ void convert_batch_to_row_diff_coord(const std::string &pred_succ_fprefix,
     logger->trace("Generating row_diff columns...");
     #pragma omp parallel for num_threads(num_threads) schedule(dynamic)
     for (uint32_t l_idx = 0; l_idx < label_encoders.size(); ++l_idx) {
-        if (!label_encoders[l_idx].size())
-            continue;
-
         std::vector<std::unique_ptr<bit_vector>> columns(label_encoders[l_idx].size());
 
         auto fpath_coord = col_out_dir/fs::path(source_files[l_idx]).filename();
@@ -1567,7 +1564,12 @@ void convert_batch_to_row_diff_coord(const std::string &pred_succ_fprefix,
         logger->trace("Serialized {}", fpath_coord);
         auto fpath = col_out_dir/fs::path(source_files[l_idx]).filename();
         fpath.replace_extension().replace_extension(ColumnCompressed<>::kExtension);
-        ColumnCompressed<>(std::move(columns), label_encoders[l_idx]).serialize(fpath);
+        if (columns.size()) {
+            ColumnCompressed<>(std::move(columns), label_encoders[l_idx]).serialize(fpath);
+        } else {
+            // serialize an empty annotation with coords
+            ColumnCompressed<>(num_rows, 1, "", buf_size_bytes, 0, true).serialize(fpath);
+        }
         logger->trace("Serialized {}", fpath);
     }
 

--- a/metagraph/src/cli/load/load_annotation.cpp
+++ b/metagraph/src/cli/load/load_annotation.cpp
@@ -96,7 +96,8 @@ initialize_annotation(Config::AnnotationType anno_type,
                       double memory_available_gb,
                       uint8_t count_width,
                       size_t max_chunks_open,
-                      size_t RA_ivbuffer_size) {
+                      size_t RA_ivbuffer_size,
+                      bool index_coordinates) {
     std::unique_ptr<annot::MultiLabelAnnotation<std::string>> annotation;
 
     switch (anno_type) {
@@ -104,7 +105,8 @@ initialize_annotation(Config::AnnotationType anno_type,
             annotation.reset(
                 new annot::ColumnCompressed<>(num_rows, column_compressed_num_columns_cached,
                                               swap_dir, memory_available_gb * kBytesInGigabyte,
-                                              count_width, max_chunks_open)
+                                              count_width, index_coordinates,
+                                              max_chunks_open)
             );
             break;
         }

--- a/metagraph/src/cli/load/load_annotation.hpp
+++ b/metagraph/src/cli/load/load_annotation.hpp
@@ -19,9 +19,10 @@ initialize_annotation(Config::AnnotationType anno_type,
                       uint64_t num_rows = 0,
                       const std::string &swap_dir = "",
                       double memory_available_gb = 1,
-                      uint8_t count_width = 8,
+                      uint8_t count_width = 0,
                       size_t max_chunks_open = 2000,
-                      size_t RA_ivbuffer_size = 16'384);
+                      size_t RA_ivbuffer_size = 16'384,
+                      bool index_coordinates = false);
 
 inline std::unique_ptr<annot::MultiLabelAnnotation<std::string>>
 initialize_annotation(Config::AnnotationType anno_type,
@@ -31,7 +32,8 @@ initialize_annotation(Config::AnnotationType anno_type,
     return initialize_annotation(anno_type, config.num_columns_cached, config.sparse,
                                  num_rows, config.tmp_dir, config.memory_available,
                                  config.count_width, max_chunks_open,
-                                 config.RA_ivbuffer_size);
+                                 config.RA_ivbuffer_size,
+                                 config.coordinates);
 }
 
 template <typename... Args>

--- a/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
+++ b/metagraph/tests/annotation/test_annotated_dbg_helpers.cpp
@@ -46,7 +46,8 @@ std::unique_ptr<AnnotatedDBG> build_anno_graph(uint64_t k,
 
     auto anno_graph = std::make_unique<AnnotatedDBG>(
         graph,
-        std::make_unique<ColumnCompressed<>>(max_index)
+        std::make_unique<ColumnCompressed<>>(max_index, 1, "", uint64_t(10'000'000), 0,
+                                             coordinates, 2000)
     );
 
     if (coordinates) {

--- a/metagraph/tests/annotation/test_column_compressed_sidecars.cpp
+++ b/metagraph/tests/annotation/test_column_compressed_sidecars.cpp
@@ -1,0 +1,180 @@
+#include <filesystem>
+
+#include "gtest/gtest.h"
+
+#include "../test_helpers.hpp"
+#include "annotation/representation/column_compressed/annotate_column_compressed.hpp"
+#include "common/utils/string_utils.hpp"
+
+namespace fs = std::filesystem;
+
+namespace {
+
+using namespace mtg;
+
+using AC = annot::ColumnCompressed<>;
+
+std::string sidecar_base(const char *suffix) {
+    return test_dump_dir() + "/cc_sidecars_" + suffix;
+}
+
+void remove_cc_files(const std::string &base_no_ext) {
+    std::error_code ec;
+    const std::string main = utils::make_suffix(base_no_ext, AC::kExtension);
+    const std::string stem = utils::remove_suffix(main, AC::kExtension);
+    fs::remove(main, ec);
+    fs::remove(stem + AC::kCoordExtension, ec);
+    fs::remove(stem + AC::kCountExtension, ec);
+}
+
+std::string coord_path_for_main(const std::string &base_no_ext) {
+    const std::string main = utils::make_suffix(base_no_ext, AC::kExtension);
+    return utils::remove_suffix(main, AC::kExtension) + AC::kCoordExtension;
+}
+
+std::string counts_path_for_main(const std::string &base_no_ext) {
+    const std::string main = utils::make_suffix(base_no_ext, AC::kExtension);
+    return utils::remove_suffix(main, AC::kExtension) + AC::kCountExtension;
+}
+
+TEST(ColumnCompressedSidecars, EmptyAnnotatorCoordinateModeWritesCoordsOnly) {
+    const std::string base = sidecar_base("empty_coord_only");
+    remove_cc_files(base);
+
+    // count_width 0 => no .counts; index_coordinates => empty .coords for Snakemake-style pipelines.
+    AC anno(16, 1, "", uint64_t(10'000'000), /*count_width=*/0, /*index_coordinates=*/true, 2000);
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(utils::make_suffix(base, AC::kExtension)));
+    EXPECT_TRUE(fs::exists(coord_path_for_main(base)));
+    EXPECT_FALSE(fs::exists(counts_path_for_main(base)));
+}
+
+TEST(ColumnCompressedSidecars, EmptyAnnotatorCountsModeWritesCountsOnly) {
+    const std::string base = sidecar_base("empty_counts_only");
+    remove_cc_files(base);
+
+    AC anno(16, 1, "", uint64_t(10'000'000), /*count_width=*/8, /*index_coordinates=*/false, 2000);
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(utils::make_suffix(base, AC::kExtension)));
+    EXPECT_FALSE(fs::exists(coord_path_for_main(base)));
+    EXPECT_TRUE(fs::exists(counts_path_for_main(base)));
+}
+
+TEST(ColumnCompressedSidecars, EmptyAnnotatorBothModesWriteBothSidecars) {
+    const std::string base = sidecar_base("empty_both");
+    remove_cc_files(base);
+
+    AC anno(16, 1, "", uint64_t(10'000'000), /*count_width=*/8, /*index_coordinates=*/true, 2000);
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(utils::make_suffix(base, AC::kExtension)));
+    EXPECT_TRUE(fs::exists(coord_path_for_main(base)));
+    EXPECT_TRUE(fs::exists(counts_path_for_main(base)));
+}
+
+TEST(ColumnCompressedSidecars, EmptyAnnotatorNeitherModeWritesNoSidecars) {
+    const std::string base = sidecar_base("empty_neither");
+    remove_cc_files(base);
+
+    AC anno(16, 1, "", uint64_t(10'000'000), /*count_width=*/0, /*index_coordinates=*/false, 2000);
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(utils::make_suffix(base, AC::kExtension)));
+    EXPECT_FALSE(fs::exists(coord_path_for_main(base)));
+    EXPECT_FALSE(fs::exists(counts_path_for_main(base)));
+}
+
+TEST(ColumnCompressedSidecars, ExplicitCountWidthWritesCountsSidecar) {
+    const std::string base = sidecar_base("explicit_counts_ctor");
+    remove_cc_files(base);
+
+    AC anno(12, 1, "", uint64_t(10'000'000), /*count_width=*/8, false, 2000);
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(utils::make_suffix(base, AC::kExtension)));
+    EXPECT_FALSE(fs::exists(coord_path_for_main(base)));
+    EXPECT_TRUE(fs::exists(counts_path_for_main(base)));
+}
+
+TEST(ColumnCompressedSidecars, DefaultCtorWritesNoCountsSidecar) {
+    const std::string base = sidecar_base("default_ctor_no_counts");
+    remove_cc_files(base);
+
+    AC anno(12);
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(utils::make_suffix(base, AC::kExtension)));
+    EXPECT_FALSE(fs::exists(coord_path_for_main(base)));
+    EXPECT_FALSE(fs::exists(counts_path_for_main(base)));
+}
+
+TEST(ColumnCompressedSidecars, CoordinateColumnSerializeAndBitmapRoundTrip) {
+    const std::string base = sidecar_base("coord_one_col");
+    remove_cc_files(base);
+
+    AC anno(8, 1, "", uint64_t(10'000'000), 0, true, 2000);
+    anno.add_labels({2}, {"colA"});
+    anno.add_label_coords({{2, 42}}, {"colA"});
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(coord_path_for_main(base)));
+
+    AC loaded(8, 1, "", uint64_t(10'000'000), 0, false, 2000);
+    ASSERT_TRUE(loaded.load(utils::make_suffix(base, AC::kExtension)));
+
+    EXPECT_EQ(1u, loaded.num_labels());
+    EXPECT_EQ(convert_to_set({"colA"}), convert_to_set(loaded.get_labels(2)));
+}
+
+TEST(ColumnCompressedSidecars, CountColumnSerializeAndRoundTrip) {
+    const std::string base = sidecar_base("counts_one_col");
+    remove_cc_files(base);
+
+    AC anno(8, 1, "", uint64_t(10'000'000), 8, false, 2000);
+    anno.add_labels({4}, {"gene"});
+    anno.add_label_counts({4}, {"gene"}, {5});
+    anno.serialize(base);
+
+    EXPECT_TRUE(fs::exists(counts_path_for_main(base)));
+
+    AC loaded(8);
+    ASSERT_TRUE(loaded.load(utils::make_suffix(base, AC::kExtension)));
+    EXPECT_EQ(convert_to_set({"gene"}), convert_to_set(loaded.get_labels(4)));
+}
+
+TEST(ColumnCompressedSidecars, LoadThenSerializeAgainCoordinateMode) {
+    const std::string base = sidecar_base("coord_reload_a");
+    const std::string base2 = sidecar_base("coord_reload_b");
+    remove_cc_files(base);
+    remove_cc_files(base2);
+
+    AC anno(8, 1, "", uint64_t(10'000'000), 0, true, 2000);
+    anno.add_labels({1}, {"x"});
+    anno.add_label_coords({{1, 7}}, {"x"});
+    anno.serialize(base);
+
+    ASSERT_TRUE(anno.load(utils::make_suffix(base, AC::kExtension)));
+    ASSERT_NO_THROW(anno.serialize(base2));
+
+    EXPECT_TRUE(fs::exists(utils::make_suffix(base2, AC::kExtension)));
+    EXPECT_TRUE(fs::exists(coord_path_for_main(base2)));
+}
+
+TEST(ColumnCompressedSidecars, LoadClearsThenSerializeCountsStillWritten) {
+    const std::string base = sidecar_base("counts_reload");
+    remove_cc_files(base);
+
+    AC anno(8, 1, "", uint64_t(10'000'000), 8, false, 2000);
+    anno.add_labels({5}, {"y"});
+    anno.add_label_counts({5}, {"y"}, {3});
+    anno.serialize(base);
+
+    ASSERT_TRUE(anno.load(utils::make_suffix(base, AC::kExtension)));
+    ASSERT_NO_THROW(anno.serialize(base)); // overwrite same stem; relation_counts cleared by load
+
+    EXPECT_TRUE(fs::exists(counts_path_for_main(base)));
+}
+
+} // namespace

--- a/metagraph/tests/annotation/test_converters.cpp
+++ b/metagraph/tests/annotation/test_converters.cpp
@@ -11,6 +11,7 @@
 #include "annotation/representation/annotation_matrix/static_annotators_def.hpp"
 #include "annotation/annotation_converters.hpp"
 #include "annotation/binary_matrix/base/binary_matrix.hpp"
+#include "common/utils/string_utils.hpp"
 
 
 namespace {
@@ -253,19 +254,142 @@ TEST(RowDiff, ConvertFromColumnCompressedEmpty) {
     std::filesystem::remove_all(dst_dir);
     std::filesystem::create_directories(dst_dir);
 
-    std::string annot_fname
-            = dst_dir/(std::string("ACGTCAG") + ColumnCompressed<>::kExtension);
-    ColumnCompressed<>(5).serialize(annot_fname);
-
     std::unique_ptr<graph::DBGSuccinct> graph = create_graph(3, { "ACGTCAG" });
     const std::string graph_fname = dst_dir/(std::string("ACGTCAG") + graph::DBGSuccinct::kExtension);
     graph->serialize(graph_fname);
+
+    const std::string annot_fname
+            = dst_dir/(std::string("ACGTCAG") + ColumnCompressed<>::kExtension);
+    ColumnCompressed<>(graph->max_index()).serialize(annot_fname);
 
     convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir, dst_dir, RowDiffStage::COMPUTE_REDUCTION);
     convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir, dst_dir, RowDiffStage::CONVERT);
 
     const std::string dest_fname = dst_dir/(std::string("ACGTCAG") + RowDiffColumnAnnotator::kExtension);
-    ASSERT_TRUE(!std::filesystem::exists(dest_fname));
+    ASSERT_TRUE(std::filesystem::exists(dest_fname));
+    RowDiffColumnAnnotator annotator({}, graph.get());
+    annotator.load(dest_fname);
+    const_cast<matrix::RowDiff<matrix::ColumnMajor> &>(annotator.get_matrix())
+            .load_anchor(graph_fname + matrix::kRowDiffAnchorExt);
+    EXPECT_EQ(0u, annotator.num_labels());
+    EXPECT_EQ(graph->max_index(), annotator.num_objects());
+    std::filesystem::remove_all(dst_dir);
+}
+
+TEST(RowDiff, ConvertFromColumnCompressedEmptyAlongsideNonEmpty) {
+    const auto dst_dir = std::filesystem::path(test_dump_basename)/"row_diff_empty_batch";
+    const std::string graph_fname
+            = dst_dir/(std::string("graph") + graph::DBGSuccinct::kExtension);
+    std::filesystem::remove_all(dst_dir);
+    std::filesystem::create_directories(dst_dir);
+
+    std::unique_ptr<graph::DBGSuccinct> graph = create_graph(3, { "ACGTCAC" });
+    graph->serialize(graph_fname);
+
+    const std::string empty_annot = dst_dir/(std::string("empty") + ColumnCompressed<>::kExtension);
+    ColumnCompressed<>(graph->max_index()).serialize(empty_annot);
+
+    uint64_t labeled_row = 0;
+    bool have_node = false;
+    graph->call_nodes([&](graph::DeBruijnGraph::node_index node_idx) {
+        if (!have_node) {
+            labeled_row = graph_to_anno_index(node_idx);
+            have_node = true;
+        }
+    });
+    ASSERT_TRUE(have_node);
+
+    const std::string full_annot = dst_dir/(std::string("full") + ColumnCompressed<>::kExtension);
+    ColumnCompressed full(graph->max_index());
+    full.add_labels({ labeled_row }, { "Label0" });
+    full.serialize(full_annot);
+
+    convert_to_row_diff({ empty_annot, full_annot }, graph_fname, 1e9, 1, dst_dir, dst_dir,
+                        RowDiffStage::COMPUTE_REDUCTION);
+    convert_to_row_diff({ empty_annot, full_annot }, graph_fname, 1e9, 1, dst_dir, dst_dir,
+                        RowDiffStage::CONVERT);
+
+    const std::string dest_empty = dst_dir/(std::string("empty") + RowDiffColumnAnnotator::kExtension);
+    const std::string dest_full = dst_dir/(std::string("full") + RowDiffColumnAnnotator::kExtension);
+    ASSERT_TRUE(std::filesystem::exists(dest_empty));
+    ASSERT_TRUE(std::filesystem::exists(dest_full));
+
+    RowDiffColumnAnnotator empty_rd({}, graph.get());
+    empty_rd.load(dest_empty);
+    const_cast<matrix::RowDiff<matrix::ColumnMajor> &>(empty_rd.get_matrix())
+            .load_anchor(graph_fname + matrix::kRowDiffAnchorExt);
+    EXPECT_EQ(0u, empty_rd.num_labels());
+    EXPECT_EQ(graph->max_index(), empty_rd.num_objects());
+
+    RowDiffColumnAnnotator full_rd({}, graph.get());
+    full_rd.load(dest_full);
+    const_cast<matrix::RowDiff<matrix::ColumnMajor> &>(full_rd.get_matrix())
+            .load_anchor(graph_fname + matrix::kRowDiffAnchorExt);
+    EXPECT_EQ(1u, full_rd.num_labels());
+    EXPECT_THAT(full_rd.get_labels(labeled_row), ElementsAre("Label0"));
+
+    std::filesystem::remove_all(dst_dir);
+}
+
+TEST(RowDiff, ConvertFromColumnCompressedEmptyCoordinatesMode) {
+    const auto dst_dir = std::filesystem::path(test_dump_basename)/"row_diff_empty_coord";
+    std::filesystem::remove_all(dst_dir);
+    std::filesystem::create_directories(dst_dir);
+
+    std::unique_ptr<graph::DBGSuccinct> graph = create_graph(3, { "ACGTCAG" });
+    const std::string graph_fname = dst_dir/(std::string("ACGTCAG") + graph::DBGSuccinct::kExtension);
+    graph->serialize(graph_fname);
+
+    const std::string annot_fname
+            = dst_dir/(std::string("ACGTCAG") + ColumnCompressed<>::kExtension);
+    ColumnCompressed<> coord_empty(graph->max_index(), 1, "", (uint64_t)1e7, 0, true, 2000);
+    coord_empty.serialize(annot_fname);
+
+    convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir, dst_dir,
+                        RowDiffStage::COMPUTE_REDUCTION, "", false, true, 0);
+    convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir, dst_dir,
+                        RowDiffStage::CONVERT, "", false, true, 0);
+
+    const std::string dest_col = dst_dir/(std::string("ACGTCAG") + ColumnCompressed<>::kExtension);
+    ASSERT_TRUE(std::filesystem::exists(dest_col));
+    const std::string dest_coords = utils::remove_suffix(dest_col, ColumnCompressed<>::kExtension)
+            + ColumnCompressed<>::kCoordExtension;
+    ASSERT_TRUE(std::filesystem::exists(dest_coords));
+    const std::string dest_counts = utils::remove_suffix(dest_col, ColumnCompressed<>::kExtension)
+            + ColumnCompressed<>::kCountExtension;
+    ASSERT_FALSE(std::filesystem::exists(dest_counts));
+    ColumnCompressed<> loaded;
+    ASSERT_TRUE(loaded.load(dest_col));
+    EXPECT_EQ(0u, loaded.num_labels());
+    EXPECT_EQ(graph->max_index(), loaded.num_objects());
+
+    std::filesystem::remove_all(dst_dir);
+}
+
+TEST(RowDiff, ConvertFromColumnCompressedEmptyCountsMode) {
+    const auto dst_dir = std::filesystem::path(test_dump_basename)/"row_diff_empty_counts";
+    std::filesystem::remove_all(dst_dir);
+    std::filesystem::create_directories(dst_dir);
+
+    std::unique_ptr<graph::DBGSuccinct> graph = create_graph(3, { "ACGTCAG" });
+    const std::string graph_fname = dst_dir/(std::string("ACGTCAG") + graph::DBGSuccinct::kExtension);
+    graph->serialize(graph_fname);
+
+    const std::string annot_fname
+            = dst_dir/(std::string("ACGTCAG") + ColumnCompressed<>::kExtension);
+    ColumnCompressed<>(graph->max_index()).serialize(annot_fname);
+
+    convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir, dst_dir,
+                        RowDiffStage::COMPUTE_REDUCTION, "", true, false, 0);
+    convert_to_row_diff({ annot_fname }, graph_fname, 1e9, 1, dst_dir, dst_dir,
+                        RowDiffStage::CONVERT, "", true, false, 0);
+
+    const std::string dest_col = dst_dir/(std::string("ACGTCAG") + ColumnCompressed<>::kExtension);
+    ASSERT_TRUE(std::filesystem::exists(dest_col));
+    const std::string dest_counts = utils::remove_suffix(dest_col, ColumnCompressed<>::kExtension)
+            + ColumnCompressed<>::kCountExtension;
+    ASSERT_TRUE(std::filesystem::exists(dest_counts));
+
     std::filesystem::remove_all(dst_dir);
 }
 

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -8,6 +8,7 @@ import shlex
 import shutil
 import sys
 import subprocess
+import time
 from pathlib import Path
 from typing import Iterable, Optional, Dict, Any
 
@@ -40,6 +41,171 @@ COORD_COMPATIBLE_FORMATS = {
 }
 
 
+def _format_bytes(size_bytes: int) -> str:
+    units = ["B", "KB", "MB", "GB", "TB"]
+    val = float(size_bytes)
+    for unit in units:
+        if val < 1024 or unit == units[-1]:
+            return f"{val:.1f}{unit}"
+        val /= 1024.0
+    return f"{size_bytes}B"
+
+
+def _format_seconds_human(value: str) -> str:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return "-"
+
+    if seconds < 1.0:
+        return f"{int(round(seconds * 1000))}ms"
+    if seconds < 60.0:
+        return f"{seconds:.1f}s"
+    mins, secs = divmod(seconds, 60.0)
+    if mins < 60:
+        return f"{int(mins)}m {int(round(secs))}s"
+    hours, mins = divmod(mins, 60.0)
+    return f"{int(hours)}h {int(mins)}m {int(round(secs))}s"
+
+
+def _parse_timing_line(line: str) -> Optional[Dict[str, str]]:
+    if "[timing]" not in line:
+        return None
+    parts = {}
+    for token in line.strip().split():
+        if "=" in token:
+            k, v = token.split("=", 1)
+            parts[k] = v
+    return parts if parts else None
+
+
+def _collect_stage_summaries(output_dir: Path) -> Iterable[Dict[str, str]]:
+    logs_root = output_dir / "logs"
+    if not logs_root.exists():
+        return []
+
+    rows = []
+    for log_path in logs_root.rglob("*.log"):
+        try:
+            text = log_path.read_text(errors='replace')
+        except OSError:
+            continue
+        timing = None
+        for line in reversed(text.splitlines()):
+            parsed = _parse_timing_line(line)
+            if parsed:
+                timing = parsed
+                break
+        if not timing:
+            continue
+
+        stage_name = str(log_path.relative_to(logs_root)).replace(".log", "")
+        rss_kb = timing.get("max_rss_kb", "-")
+        try:
+            rss_gb = f"{(float(rss_kb) / (1024.0 * 1024.0)):.3f}"
+        except (TypeError, ValueError):
+            rss_gb = "-"
+        rows.append({
+            "stage": stage_name,
+            "wall": _format_seconds_human(timing.get("wall_sec", "-")),
+            "user": _format_seconds_human(timing.get("user_sec", "-")),
+            "sys": _format_seconds_human(timing.get("sys_sec", "-")),
+            "rss": rss_gb,
+            "_mtime": str(log_path.stat().st_mtime),
+        })
+    rows.sort(key=lambda r: float(r.get("_mtime", "0")))
+    for r in rows:
+        r.pop("_mtime", None)
+    return rows
+
+
+def _directory_size(path: Path) -> int:
+    total = 0
+    for p in path.rglob("*"):
+        if p.is_file():
+            try:
+                total += p.stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def _print_run_summary(output_dir: Path, dryrun: bool) -> None:
+    print("\n=== Workflow summary ===")
+    if dryrun:
+        print("Mode: dry-run (no commands executed, no runtime metrics).")
+        return
+
+    rows = list(_collect_stage_summaries(output_dir))
+    if rows:
+        print("1) Executed steps (timing + memory):")
+        idx_w = max(2, len(str(len(rows))))
+        stage_w = max(12, min(56, max(len(r["stage"]) for r in rows)))
+        header = (
+            f"   {'#':>{idx_w}}  "
+            f"{'stage':<{stage_w}}  "
+            f"{'wall':>8}  {'user':>8}  {'sys':>8}  {'rss_gb':>8}"
+        )
+        print(header)
+        print("   " + "-" * (len(header) - 3))
+        for i, r in enumerate(rows, start=1):
+            print(
+                f"   {i:>{idx_w}}  "
+                f"{r['stage']:<{stage_w}}  "
+                f"{r['wall']:>8}  {r['user']:>8}  {r['sys']:>8}  {r['rss']:>8}"
+            )
+    else:
+        print("1) Executed steps: unavailable (no timing entries found).")
+
+    def _is_final_artifact(path: Path) -> bool:
+        name = path.name
+        return name == "graph.dbg" or (name.startswith("graph") and name.endswith(".annodbg"))
+
+    total_size = _directory_size(output_dir)
+    final_artifacts = []
+    intermediate_artifacts = []
+    for p in output_dir.rglob("*"):
+        if not p.is_file():
+            continue
+        if "/logs/" in str(p):
+            continue
+        try:
+            size = p.stat().st_size
+        except OSError:
+            continue
+        rel = p.relative_to(output_dir)
+        if _is_final_artifact(p):
+            final_artifacts.append((rel, size))
+        else:
+            intermediate_artifacts.append((rel, size))
+
+    final_total = sum(sz for _, sz in final_artifacts)
+    intermediate_total = sum(sz for _, sz in intermediate_artifacts)
+    final_artifacts.sort(key=lambda x: x[1], reverse=True)
+    intermediate_artifacts.sort(key=lambda x: x[1], reverse=True)
+
+    print(f"2) Output directory: {output_dir}")
+    print(f"3) Total output size: {_format_bytes(total_size)}")
+    print(f"4) Final artifacts total: {_format_bytes(final_total)}")
+    for rel, sz in final_artifacts:
+        print(f"   - {_format_bytes(sz):>8}  {rel}")
+    print(f"5) Intermediate artifacts total: {_format_bytes(intermediate_total)}")
+
+    if intermediate_artifacts:
+        print("6) Largest intermediate artifacts:")
+        top = intermediate_artifacts[:10]
+        idx_w = max(2, len(str(len(top))))
+        size_vals = [_format_bytes(sz) for _, sz in top]
+        size_w = max(8, max(len(s) for s in size_vals))
+        print(f"   {'#':>{idx_w}}  {'size':>{size_w}}  path")
+        print("   " + "-" * (idx_w + size_w + 8 + 20))
+        for i, ((rel, _), size_s) in enumerate(zip(top, size_vals), start=1):
+            rel_str = str(rel)
+            if sys.stdout.isatty():
+                rel_str = f"\033[90m{rel_str}\033[0m"
+            print(f"   {i:>{idx_w}}  {size_s:>{size_w}}  {rel_str}")
+
+
 def _parse_annotation_format_value(value: str) -> AnnotationFormats:
     try:
         return AnnotationFormats(value)
@@ -55,7 +221,29 @@ def _parse_annotation_format_value(value: str) -> AnnotationFormats:
 
 def _format_error(text: str) -> str:
     if sys.stderr.isatty():
-        return f"\033[31mError: {text}\033[0m"
+        red = "\033[31m"
+        pink = "\033[95m"
+        reset = "\033[0m"
+        lines = text.splitlines() or [text]
+
+        rendered = [f"{red}Error: {lines[0]}{reset}"]
+        in_metagraph = False
+        for line in lines[1:]:
+            stripped = line.strip()
+            if stripped == "metagraph output:":
+                in_metagraph = True
+                rendered.append(f"{red}{line}{reset}")
+                continue
+            if in_metagraph and stripped.startswith("[timing]"):
+                in_metagraph = False
+                rendered.append(f"{red}{line}{reset}")
+                continue
+            if in_metagraph:
+                rendered.append(f"{pink}{line}{reset}")
+            else:
+                rendered.append(f"{red}{line}{reset}")
+
+        return "\n".join(rendered)
     return f"Error: {text}"
 
 
@@ -86,66 +274,178 @@ def _validate_metagraph_cmd(cmd: str) -> None:
 
 
 def _extract_first_relevant_error_line(log_text: str) -> Optional[str]:
-    for line in reversed(log_text.splitlines()):
+    lines = log_text.splitlines()
+    for line in lines:
         s = line.strip()
         if not s:
             continue
-        if "failed_to_exec=" in s or "command not found" in s or "No such file or directory" in s:
+        lowered = s.lower()
+        if lowered.startswith("usage:") or "unrecognized option" in lowered or "unknown option" in lowered \
+                or lowered.startswith("error:") or "[error]" in lowered:
             return s
-        if "[error]" in s.lower():
+    for line in reversed(lines):
+        s = line.strip()
+        if not s:
+            continue
+        lowered = s.lower()
+        if "failed_to_exec=" in s or "command not found" in lowered or "no such file or directory" in lowered:
+            return s
+        if "[error]" in lowered or lowered.startswith("error:") or "invalid argument" in lowered:
+            return s
+    # Fallback: show last meaningful non-timing line to avoid empty/opaque summaries.
+    for line in reversed(lines):
+        s = line.strip()
+        if not s:
+            continue
+        lowered = s.lower()
+        if s.startswith("[timing]") or "[trace]" in lowered or "[debug]" in lowered or "[info]" in lowered:
+            continue
+        if "\t" in s and "%" in s:
+            continue
+        return s
+    return None
+
+
+def _latest_snakemake_log_for_run(run_started_at: float) -> Optional[Path]:
+    snakemake_log_dir = Path(".snakemake/log")
+    if not snakemake_log_dir.exists():
+        return None
+    candidates = [p for p in snakemake_log_dir.glob("*.snakemake.log") if p.is_file()]
+    current_run = [p for p in candidates if p.stat().st_mtime >= run_started_at - 1.0]
+    pool = current_run if current_run else candidates
+    if not pool:
+        return None
+    return max(pool, key=lambda p: p.stat().st_mtime)
+
+
+def _extract_failing_shell_command(cli_output: str) -> Optional[str]:
+    lines = cli_output.splitlines()
+    shell_idx = None
+    for i, line in enumerate(lines):
+        if line.strip() == "shell:":
+            shell_idx = i
+    if shell_idx is None:
+        return None
+
+    cmd_lines = []
+    for line in lines[shell_idx + 1:]:
+        s = line.rstrip()
+        if "(command exited with non-zero exit code)" in s:
+            break
+        if not s.strip():
+            continue
+        cmd_lines.append(s.strip())
+    if not cmd_lines:
+        return None
+    cmd = " ".join(cmd_lines)
+    return cmd if len(cmd) <= 500 else (cmd[:497] + "...")
+
+
+def _compact_command(cmd: str, max_len: int = 220) -> str:
+    # Show the most relevant subcommand when piped through wrappers.
+    metagraph_idx = cmd.find("metagraph ")
+    if metagraph_idx != -1:
+        cmd = cmd[metagraph_idx:]
+    cmd = " ".join(cmd.split())
+    return cmd if len(cmd) <= max_len else (cmd[:max_len - 3] + "...")
+
+
+def _extract_stage_log_block(log_text: str, head_lines: int = 20, tail_lines: int = 10) -> Iterable[str]:
+    lines = log_text.splitlines()
+    max_lines = head_lines + tail_lines
+    if len(lines) <= max_lines:
+        return lines
+    return (
+        lines[:head_lines]
+        + ["... (truncated; see failing stage log for full output)"]
+        + lines[-tail_lines:]
+    )
+
+
+def _extract_timing_exit_code(log_text: str) -> Optional[int]:
+    for line in reversed(log_text.splitlines()):
+        parsed = _parse_timing_line(line)
+        if not parsed:
+            continue
+        raw = parsed.get("exit_code")
+        if raw is None:
+            return None
+        try:
+            return int(raw)
+        except ValueError:
+            return None
+    return None
+
+
+def _extract_snakemake_failure_line(cli_output: str) -> Optional[str]:
+    for line in cli_output.splitlines():
+        s = line.strip()
+        if not s:
+            continue
+        if "MissingOutputException" in s or "RuleException" in s or s.endswith("WorkflowError:"):
             return s
     return None
 
 
-def _summarize_snakemake_failure(output_dir: Path) -> str:
-    stage_logs_dir = Path(output_dir) / "logs"
-    stage_log = None
-    if stage_logs_dir.exists():
-        candidates = sorted(stage_logs_dir.rglob("*.log"), key=lambda p: p.stat().st_mtime)
-        if candidates:
-            stage_log = candidates[-1]
+def _extract_failing_stage_log_from_snakemake_output(cli_output: str, output_dir: Path) -> Optional[Path]:
+    lines = cli_output.splitlines()
+    for line in reversed(lines):
+        if "log:" not in line:
+            continue
+        after = line.split("log:", 1)[1].strip()
+        if not after:
+            continue
+        candidate = after.split(" (", 1)[0].strip().rstrip(",")
+        if not candidate:
+            continue
+        p = Path(candidate)
+        if not p.is_absolute():
+            p = Path(output_dir).parent / p
+        return p
+    return None
+
+
+def _summarize_snakemake_failure_for_run(output_dir: Path, run_started_at: float) -> str:
     details = []
+    stage_log = None
+    snakemake_log = _latest_snakemake_log_for_run(run_started_at)
+    snakemake_output = None
+    if snakemake_log and snakemake_log.exists():
+        try:
+            snakemake_output = snakemake_log.read_text(errors='replace')
+        except OSError:
+            snakemake_output = None
+
+    if snakemake_output:
+        stage_log = _extract_failing_stage_log_from_snakemake_output(snakemake_output, Path(output_dir))
+
     if stage_log and stage_log.exists():
         try:
             stage_text = stage_log.read_text(errors='replace')
+            stage_block = list(_extract_stage_log_block(stage_text))
+            stage_exit_code = _extract_timing_exit_code(stage_text)
             root_line = _extract_first_relevant_error_line(stage_text)
+            if stage_block and stage_exit_code != 0:
+                details.append("metagraph output:")
+                details.extend(stage_block)
             if root_line:
-                details.append(f"Root cause: {root_line}")
+                if stage_exit_code == 0:
+                    details.append(
+                        "Root cause: metagraph command exited successfully, "
+                        "but Snakemake reported missing/incorrect output files."
+                    )
+                else:
+                    details.append(f"Root cause: {root_line}")
             details.append(f"Failing stage log: {stage_log}")
         except OSError:
             pass
-
-    details.append(f"Stage logs: {Path(output_dir) / 'logs'}")
-    details.append("Snakemake logs: .snakemake/log/")
-    return "Workflow execution failed.\n" + "\n".join(details)
-
-
-def _extract_failing_stage_log(cli_output: str) -> Optional[Path]:
-    # Snakemake typically prints:
-    #   log: <path> (check log file(s) for error details)
-    matches = re.findall(r"log:\s+(\S+)\s+\(check log file\(s\) for error details\)", cli_output)
-    if matches:
-        return Path(matches[-1])
-    return None
-
-
-def _summarize_snakemake_failure_from_output(output_dir: Path, cli_output: str) -> str:
-    stage_log = _extract_failing_stage_log(cli_output)
-    if stage_log is None:
-        return _summarize_snakemake_failure(output_dir)
-
-    details = []
-    if stage_log.exists():
-        try:
-            stage_text = stage_log.read_text(errors='replace')
-            root_line = _extract_first_relevant_error_line(stage_text)
-            if root_line:
-                details.append(f"Root cause: {root_line}")
-            details.append(f"Failing stage log: {stage_log}")
-        except OSError:
-            pass
-    else:
-        details.append(f"Failing stage log: {stage_log}")
+    if snakemake_output:
+        failure_line = _extract_snakemake_failure_line(snakemake_output)
+        if failure_line:
+            details.append(f"Snakemake failure: {failure_line}")
+        cmd = _extract_failing_shell_command(snakemake_output)
+        if cmd:
+            details.append(f"Failing command: {_compact_command(cmd)}")
 
     details.append(f"Stage logs: {Path(output_dir) / 'logs'}")
     details.append("Snakemake logs: .snakemake/log/")
@@ -290,22 +590,12 @@ def run_build_workflow(
 
     # Run snakemake
     # Keep stdout/stderr attached so Snakemake preserves colors and rich formatting.
+    run_started_at = time.time()
     result = subprocess.run([' '.join(cmd)], shell=True)
 
     if result.returncode != 0:
-        snakemake_log_dir = Path(".snakemake/log")
-        latest_snakemake_log = None
-        if snakemake_log_dir.exists():
-            logs = sorted(snakemake_log_dir.glob("*.snakemake.log"), key=lambda p: p.stat().st_mtime)
-            if logs:
-                latest_snakemake_log = logs[-1]
-        if latest_snakemake_log and latest_snakemake_log.exists():
-            try:
-                cli_output = latest_snakemake_log.read_text(errors='replace')
-                raise RuntimeError(_summarize_snakemake_failure_from_output(Path(output_dir), cli_output))
-            except OSError:
-                pass
-        raise RuntimeError(_summarize_snakemake_failure(Path(output_dir)))
+        raise RuntimeError(_summarize_snakemake_failure_for_run(Path(output_dir), run_started_at))
+    _print_run_summary(Path(output_dir), dryrun)
 
 
 def setup_build_parser(parser):

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -41,6 +41,34 @@ COORD_COMPATIBLE_FORMATS = {
 }
 
 
+def _help_formatter(prog: str):
+    return argparse.RawTextHelpFormatter(prog, width=100, max_help_position=34)
+
+
+def _help_color(text: str, color_code: str) -> str:
+    if not sys.stdout.isatty():
+        return text
+    return f"\033[{color_code}m{text}\033[0m"
+
+
+def _default_threads_auto() -> int:
+    try:
+        out = subprocess.check_output(["nproc"], text=True).strip()
+        n = int(out)
+        if n > 0:
+            return n
+    except Exception:
+        pass
+    try:
+        out = subprocess.check_output(["sysctl", "-n", "hw.logicalcpu"], text=True).strip()
+        n = int(out)
+        if n > 0:
+            return n
+    except Exception:
+        pass
+    return snakemake.utils.available_cpu_count()
+
+
 def _format_bytes(size_bytes: int) -> str:
     units = ["B", "KB", "MB", "GB", "TB"]
     val = float(size_bytes)
@@ -547,7 +575,7 @@ def run_build_workflow(
     config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
     if not dryrun:
         _validate_metagraph_cmd(config['metagraph_cmd'])
-    config['max_threads'] = threads if threads else snakemake.utils.available_cpu_count()
+    config['max_threads'] = threads if threads else _default_threads_auto()
 
     if verbose:
         importlib.reload(logging)
@@ -578,7 +606,7 @@ def run_build_workflow(
         cmd.extend(['--cores', str(threads)])
     else:
         # Add default cores if not specified
-        cmd.extend(['--cores', str(snakemake.utils.available_cpu_count())])
+        cmd.extend(['--cores', str(_default_threads_auto())])
 
     # Add additional arguments
     for key, value in additional_args.items():
@@ -599,57 +627,107 @@ def run_build_workflow(
 
 
 def setup_build_parser(parser):
-    parser.add_argument('output_dir', type=Path)
+    label_sources = [v.value for v in AnnotationLabelsSource]
+    count_formats = sorted([f.value for f in COUNT_COMPATIBLE_FORMATS])
+    count_formats_display = [_help_color(fmt, "33") for fmt in count_formats]
+    coord_formats = sorted([f.value for f in COORD_COMPATIBLE_FORMATS])
+    coord_formats_display = [_help_color(fmt, "35") for fmt in coord_formats]
+    classic_formats_display = [
+        _help_color(fmt, "36")
+        for fmt in [
+            "row", "bin_rel_wt", "flat", "rbfish", "brwt", "relax.brwt",
+            "rb_brwt", "row_diff_brwt", "relax.row_diff_brwt",
+        ]
+    ]
+    with_counts_label = _help_color("--with-counts", "33")
+    with_coords_label = _help_color("--with-coords", "35")
+    default_base_fmt = _help_color("relax.row_diff_brwt", "36")
+    default_count_fmt = _help_color("row_diff_int_brwt", "33")
+    default_coord_fmt = _help_color("row_diff_brwt_coord", "35")
+    default_count_width = _help_color("8", "33")
+    zero_count_width = _help_color("0", "36")
 
-    input_seq_group = parser.add_argument_group('input sequence paths', '')
+    parser.description = (
+        "Build a MetaGraph graph + annotation workflow from a sequence list or directory."
+    )
+    parser.epilog = (
+        "Examples:\n"
+        "  metagraph-workflows build --seqs-file-list-path files.txt -k 31 -o out/\n"
+        "  metagraph-workflows build --seqs-file-list-path files.txt --with-counts -o out/\n"
+        "  metagraph-workflows build --seqs-file-list-path files.txt --with-coords -o out/"
+    )
+
+    input_seq_group = parser.add_argument_group('input/output')
 
     input_seq_group_xor = input_seq_group.add_mutually_exclusive_group(required=True)
     input_seq_group_xor.add_argument('--seqs-file-list-path',
-                                     help='Path to text file containing paths of sequences files')
+                                     metavar='PATH',
+                                     help='Path to a text file with sample paths (one per line) []')
     input_seq_group_xor.add_argument('--seqs-dir-path',
-                                     help="Path to directory containing sequence files")
+                                     metavar='DIR',
+                                     help="Directory containing samples []")
+    input_seq_group.add_argument('-o', '--output_dir', type=Path, required=True,
+                                 help='Output directory [required]')
 
-    graph = parser.add_argument_group('graph', 'arguments for graph building')
-    graph.add_argument('-k', type=int, default=None)
-    graph.add_argument('--base-name', default=None)
-    graph.add_argument('--build-primary-graph', default=False,
-                       action='store_true')
+    graph = parser.add_argument_group('graph')
+    graph.add_argument('-k', type=int, default=31, metavar='K',
+                       help='k-mer length [31]')
+    graph.add_argument('--base-name', default='graph', metavar='NAME',
+                       help='Base output name [graph]')
+    graph.add_argument('--primary', dest='build_primary_graph', default=False,
+                       action='store_true',
+                       help='Build canonical graph first, then derive/build primary graph [False]')
 
-    annotation = parser.add_argument_group('annotation',
-                                           'arguments for annotations')
-    annotation.add_argument('--annotation-format', action='append',
-                            default=[],
-                            help=f"Annotation format (can be used multiple times). "
-                                 f"Possible values: {', '.join([v.value for v in AnnotationFormats])}. "
-                                 f"Default is relax.row_diff_brwt; with --with-counts and no explicit format, "
-                                 f"default is row_diff_int_brwt; with --with-coords and no explicit format, "
-                                 f"default is row_diff_brwt_coord.")
-    annotation.add_argument('--annotation-labels-source',
+    annotation = parser.add_argument_group('annotation')
+    all_formats_help = "\n".join([
+        f"    {classic_formats_display[0]}, {classic_formats_display[1]}, {classic_formats_display[2]}, {classic_formats_display[3]}, {classic_formats_display[4]}, {classic_formats_display[5]}, {classic_formats_display[6]},",
+        f"             {classic_formats_display[7]}, {classic_formats_display[8]}",
+        f"    {count_formats_display[0]}, {count_formats_display[1]}, {count_formats_display[2]}",
+        f"    {coord_formats_display[0]}, {coord_formats_display[2]}, {coord_formats_display[1]}, {coord_formats_display[3]}",
+    ])
+    annotation.add_argument('--anno-source',
+                            dest='annotation_labels_source',
                             type=AnnotationLabelsSource,
                             default=AnnotationLabelsSource.SEQUENCE_HEADERS,
-                            help=f"What should be used as column labels. Possible values: "
-                                 f"{', '.join([v.value for v in AnnotationLabelsSource])}")
+                            metavar='SOURCE',
+                            help=f"Column label source: {', '.join(label_sources)} [sequence_headers]\n"
+                                 "  ")
+    annotation.add_argument('--annotation-format', action='append',
+                            default=[],
+                            metavar='FORMAT',
+                            help=f"Annotation format (can be used multiple times).\n"
+                                 f"{all_formats_help}\n"
+                                 f"  [{default_base_fmt}/{default_count_fmt}/{default_coord_fmt}]\n"
+                                 "  ")
     annotation.add_argument('--with-counts', default=False, action='store_true',
-                            help="Enable count-aware annotation workflow. "
-                                 "If no --annotation-format is provided, defaults to row_diff_int_brwt. "
-                                 "Also enabled automatically when a count-capable annotation format is selected.")
-    annotation.add_argument('--with-coords', dest='with_coordinates', default=False, action='store_true',
-                            help="Enable coordinate-aware annotation workflow. "
-                                 "If no --annotation-format is provided, defaults to row_diff_brwt_coord. "
-                                 "Also enabled automatically when a coordinate-capable annotation format is selected.")
+                            help=f"Index with k-mer counts [False]\n"
+                                 f"  Supported for {', '.join(count_formats_display)}.")
     annotation.add_argument('--count-width', type=int, default=None,
-                            help="Bit width for count values (passed to annotate/transform_anno). "
-                                 "Default behavior is 8-bit when unset.")
+                            metavar='BITS',
+                            help=f"Bit width for count values (passed to annotate/transform_anno) [{zero_count_width}/{default_count_width}]\n"
+                                 "  ")
+    annotation.add_argument('--with-coords', dest='with_coordinates', default=False, action='store_true',
+                            help=f"Index with k-mer positions [False]\n"
+                                 f"  Supported for {coord_formats_display[0]}, {coord_formats_display[2]}, {coord_formats_display[1]},\n"
+                                 f"                     {coord_formats_display[3]}.")
 
-    workflow = parser.add_argument_group('workflow',
-                                         'arguments for the workflow')
-    workflow.add_argument('--threads', type=int, default=None)
-    workflow.add_argument('--force', default=False, action='store_true')
-    workflow.add_argument('--verbose', default=False, action='store_true')
-    workflow.add_argument('--dryrun', default=False, action='store_true')
-    workflow.add_argument('--metagraph-cmd', type=str, default=None)
-    workflow.add_argument('--additional-snakemake-args', type=str, default='',
-                          help='Additional arguments to pass to snakemake, e.g. --additional-snakemake-args="arg1=val1 arg2=val2"')
+    workflow = parser.add_argument_group('other')
+    workflow.add_argument('--threads', type=int, default=None, metavar='N',
+                          help='Max cores for Snakemake execution [num_cores]')
+    workflow.add_argument('--force', default=False, action='store_true',
+                          help='Force re-run all rules [False]')
+    workflow.add_argument('--verbose', default=False, action='store_true',
+                          help='Print verbose config/runtime logs [False]')
+    workflow.add_argument('--dryrun', default=False, action='store_true',
+                          help='Render DAG and config only; do not execute rules [False]')
+    workflow.add_argument('--metagraph-cmd', type=str, default=None, metavar='CMD',
+                          help='Path/command for metagraph executable [metagraph from PATH]')
+    workflow.add_argument('--extra-args', dest='additional_snakemake_args', metavar='ARGS', type=str, default='',
+                          help='Extra arguments to pass to snakemake [none]\n'
+                               '  Example: --extra-args="arg1=val1 arg2=val2"')
+    options = parser.add_argument_group('options')
+    options.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
+                         help='Show this help message and exit')
 
     parser.set_defaults(func=init_build)
 
@@ -698,17 +776,31 @@ def init_build(args):
         force=args.force,
         verbose=args.verbose,
         dryrun=args.dryrun,
-        additional_snakemake_args=_parse_additional_snakemake_args(args.additional_snakemake_args)
+        additional_snakemake_args=_parse_additional_snakemake_args(
+            getattr(args, "additional_snakemake_args", "")
+        )
     )
 
 
 def main(args=tuple(sys.argv[1:])):
-    parser = argparse.ArgumentParser(description='metagraph utils')
+    parser = argparse.ArgumentParser(
+        description='MetaGraph workflow utilities',
+        formatter_class=_help_formatter,
+    )
 
-    subparsers = parser.add_subparsers(help="Available subcommands", required=True,
-                                       dest="command")
+    subparsers = parser.add_subparsers(
+        help="Available subcommands",
+        required=True,
+        dest="command",
+        parser_class=argparse.ArgumentParser,
+    )
 
-    build_parser = subparsers.add_parser("build", help="Create index")
+    build_parser = subparsers.add_parser(
+        "build",
+        help="Build graph + annotation workflow",
+        formatter_class=_help_formatter,
+        add_help=False,
+    )
     setup_build_parser(build_parser)
 
     parsed_arguments = parser.parse_args(args)

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -1,7 +1,11 @@
 import argparse
+import difflib
 import importlib
 import logging
+import os
+import re
 import shlex
+import shutil
 import sys
 import subprocess
 from pathlib import Path
@@ -29,7 +33,119 @@ COUNT_COMPATIBLE_FORMATS = {
     AnnotationFormats.ROW_DIFF_INT_DISK,
 }
 
-# TODO: use custom config object? fluent config?
+
+def _parse_annotation_format_value(value: str) -> AnnotationFormats:
+    try:
+        return AnnotationFormats(value)
+    except ValueError:
+        valid_values = [v.value for v in AnnotationFormats]
+        suggestion = difflib.get_close_matches(value, valid_values, n=1)
+        suggestion_msg = f" Did you mean '{suggestion[0]}'?" if suggestion else ""
+        raise ValueError(
+            f"Unsupported annotation format '{value}'. "
+            f"Valid values: {', '.join(valid_values)}.{suggestion_msg}"
+        )
+
+
+def _format_error(text: str) -> str:
+    if sys.stderr.isatty():
+        return f"\033[31mError: {text}\033[0m"
+    return f"Error: {text}"
+
+
+def _validate_metagraph_cmd(cmd: str) -> None:
+    cmd_parts = shlex.split(cmd)
+    if not cmd_parts:
+        raise ValueError("--metagraph-cmd is empty. Provide a valid executable path or command name.")
+
+    executable = cmd_parts[0]
+    if "/" in executable:
+        exe_path = Path(executable).expanduser()
+        if not exe_path.exists():
+            raise ValueError(
+                f"MetaGraph executable not found at '{executable}'. "
+                "Provide a valid path via --metagraph-cmd or add 'metagraph' to PATH."
+            )
+        if not exe_path.is_file() or not os.access(exe_path, os.X_OK):
+            raise ValueError(
+                f"MetaGraph executable '{executable}' is not executable. "
+                "Fix permissions or use --metagraph-cmd with a valid executable."
+            )
+    else:
+        if shutil.which(executable) is None:
+            raise ValueError(
+                f"MetaGraph executable '{executable}' was not found in PATH. "
+                "Use --metagraph-cmd with an absolute path or add it to PATH."
+            )
+
+
+def _extract_first_relevant_error_line(log_text: str) -> Optional[str]:
+    for line in reversed(log_text.splitlines()):
+        s = line.strip()
+        if not s:
+            continue
+        if "failed_to_exec=" in s or "command not found" in s or "No such file or directory" in s:
+            return s
+        if "[error]" in s.lower():
+            return s
+    return None
+
+
+def _summarize_snakemake_failure(output_dir: Path) -> str:
+    stage_logs_dir = Path(output_dir) / "logs"
+    stage_log = None
+    if stage_logs_dir.exists():
+        candidates = sorted(stage_logs_dir.rglob("*.log"), key=lambda p: p.stat().st_mtime)
+        if candidates:
+            stage_log = candidates[-1]
+    details = []
+    if stage_log and stage_log.exists():
+        try:
+            stage_text = stage_log.read_text(errors='replace')
+            root_line = _extract_first_relevant_error_line(stage_text)
+            if root_line:
+                details.append(f"Root cause: {root_line}")
+            details.append(f"Failing stage log: {stage_log}")
+        except OSError:
+            pass
+
+    details.append(f"Stage logs: {Path(output_dir) / 'logs'}")
+    details.append("Snakemake logs: .snakemake/log/")
+    return "Workflow execution failed.\n" + "\n".join(details)
+
+
+def _extract_failing_stage_log(cli_output: str) -> Optional[Path]:
+    # Snakemake typically prints:
+    #   log: <path> (check log file(s) for error details)
+    matches = re.findall(r"log:\s+(\S+)\s+\(check log file\(s\) for error details\)", cli_output)
+    if matches:
+        return Path(matches[-1])
+    return None
+
+
+def _summarize_snakemake_failure_from_output(output_dir: Path, cli_output: str) -> str:
+    stage_log = _extract_failing_stage_log(cli_output)
+    if stage_log is None:
+        return _summarize_snakemake_failure(output_dir)
+
+    details = []
+    if stage_log.exists():
+        try:
+            stage_text = stage_log.read_text(errors='replace')
+            root_line = _extract_first_relevant_error_line(stage_text)
+            if root_line:
+                details.append(f"Root cause: {root_line}")
+            details.append(f"Failing stage log: {stage_log}")
+        except OSError:
+            pass
+    else:
+        details.append(f"Failing stage log: {stage_log}")
+
+    details.append(f"Stage logs: {Path(output_dir) / 'logs'}")
+    details.append("Snakemake logs: .snakemake/log/")
+    return "Workflow execution failed.\n" + "\n".join(details)
+
+
 def run_build_workflow(
         output_dir: Path,
         seqs_file_list_path: Optional[Path] = None,
@@ -99,6 +215,7 @@ def run_build_workflow(
         config['count_width'] = count_width
 
     config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
+    _validate_metagraph_cmd(config['metagraph_cmd'])
     config['max_threads'] = threads if threads else snakemake.utils.available_cpu_count()
 
     if verbose:
@@ -141,10 +258,23 @@ def run_build_workflow(
             cmd.extend([f'--{key}', str(value)])
 
     # Run snakemake
+    # Keep stdout/stderr attached so Snakemake preserves colors and rich formatting.
     result = subprocess.run([' '.join(cmd)], shell=True)
 
     if result.returncode != 0:
-        raise RuntimeError(f"The snakemake workflow did not terminate correctly")
+        snakemake_log_dir = Path(".snakemake/log")
+        latest_snakemake_log = None
+        if snakemake_log_dir.exists():
+            logs = sorted(snakemake_log_dir.glob("*.snakemake.log"), key=lambda p: p.stat().st_mtime)
+            if logs:
+                latest_snakemake_log = logs[-1]
+        if latest_snakemake_log and latest_snakemake_log.exists():
+            try:
+                cli_output = latest_snakemake_log.read_text(errors='replace')
+                raise RuntimeError(_summarize_snakemake_failure_from_output(Path(output_dir), cli_output))
+            except OSError:
+                pass
+        raise RuntimeError(_summarize_snakemake_failure(Path(output_dir)))
 
 
 def setup_build_parser(parser):
@@ -232,7 +362,7 @@ def init_build(args):
         k=args.k,
         base_name=args.base_name,
         build_primary_graph=args.build_primary_graph,
-        annotation_formats=[AnnotationFormats(af) for af in args.annotation_format],
+        annotation_formats=[_parse_annotation_format_value(af) for af in args.annotation_format],
         annotation_labels_source=args.annotation_labels_source,
         with_counts=args.with_counts,
         count_width=args.count_width,
@@ -256,10 +386,14 @@ def main(args=tuple(sys.argv[1:])):
 
     parsed_arguments = parser.parse_args(args)
 
-    if parsed_arguments.func:
-        parsed_arguments.func(parsed_arguments)
-    else:
-        sys.exit("Unknown function call")
+    try:
+        if parsed_arguments.func:
+            parsed_arguments.func(parsed_arguments)
+        else:
+            sys.exit("Unknown function call")
+    except (ValueError, RuntimeError) as e:
+        print(_format_error(str(e)), file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -23,6 +23,11 @@ logging.basicConfig(format=LOGGING_FORMAT, level=logging.WARNING)
 
 
 default_path = Path(WORKFLOW_ROOT / 'default.yml')
+COUNT_COMPATIBLE_FORMATS = {
+    AnnotationFormats.INT_BRWT,
+    AnnotationFormats.ROW_DIFF_INT_BRWT,
+    AnnotationFormats.ROW_DIFF_INT_DISK,
+}
 
 # TODO: use custom config object? fluent config?
 def run_build_workflow(
@@ -34,6 +39,8 @@ def run_build_workflow(
         build_primary_graph: bool = False,
         annotation_formats: Iterable[AnnotationFormats] = (),
         annotation_labels_source: Optional[AnnotationLabelsSource] = None,
+        with_counts: bool = False,
+        count_width: Optional[int] = None,
         metagraph_cmd: Optional[str] = None,
         threads: Optional[int] = None,
         force: bool = False,
@@ -66,8 +73,30 @@ def run_build_workflow(
     config['base_name'] = base_name if base_name else config['base_name']
     config['build_primary_graph'] = build_primary_graph
 
-    config['annotation_formats'] = [af.value for af in
-                                    annotation_formats] if annotation_formats else config['annotation_formats']
+    selected_formats = set(annotation_formats)
+    has_count_formats = any(af in COUNT_COMPATIBLE_FORMATS for af in selected_formats)
+    effective_with_counts = with_counts or has_count_formats
+
+    if effective_with_counts and not annotation_formats:
+        config['annotation_formats'] = [AnnotationFormats.ROW_DIFF_INT_BRWT.value]
+    else:
+        config['annotation_formats'] = [af.value for af in
+                                        annotation_formats] if annotation_formats else config['annotation_formats']
+
+    if effective_with_counts:
+        invalid_formats = [af.value for af in annotation_formats if af not in COUNT_COMPATIBLE_FORMATS]
+        if invalid_formats:
+            raise ValueError(
+                "Count-aware mode is enabled (--with-counts or count-capable --annotation-format), "
+                "--annotation-format must be one of: "
+                + ", ".join(sorted([f.value for f in COUNT_COMPATIBLE_FORMATS]))
+                + f". Got: {', '.join(invalid_formats)}"
+            )
+    config['with_counts'] = effective_with_counts
+    if count_width is not None and not (2 <= count_width <= 32):
+        raise ValueError(f"--count-width must be in range [2, 32], got {count_width}")
+    if count_width is not None:
+        config['count_width'] = count_width
 
     config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
     config['max_threads'] = threads if threads else snakemake.utils.available_cpu_count()
@@ -140,12 +169,21 @@ def setup_build_parser(parser):
     annotation.add_argument('--annotation-format', action='append',
                             default=[],
                             help=f"Annotation format (can be used multiple times). "
-                                 f"Possible values: {', '.join([v.value for v in AnnotationFormats])}")
+                                 f"Possible values: {', '.join([v.value for v in AnnotationFormats])}. "
+                                 f"Default is relax.row_diff_brwt; with --with-counts and no explicit format, "
+                                 f"default is row_diff_int_brwt.")
     annotation.add_argument('--annotation-labels-source',
                             type=AnnotationLabelsSource,
                             default=AnnotationLabelsSource.SEQUENCE_HEADERS,
                             help=f"What should be used as column labels. Possible values: "
                                  f"{', '.join([v.value for v in AnnotationLabelsSource])}")
+    annotation.add_argument('--with-counts', default=False, action='store_true',
+                            help="Enable count-aware annotation workflow. "
+                                 "If no --annotation-format is provided, defaults to row_diff_int_brwt. "
+                                 "Also enabled automatically when a count-capable annotation format is selected.")
+    annotation.add_argument('--count-width', type=int, default=None,
+                            help="Bit width for count values (passed to annotate/transform_anno). "
+                                 "Default behavior is 8-bit when unset.")
 
     workflow = parser.add_argument_group('workflow',
                                          'arguments for the workflow')
@@ -196,6 +234,8 @@ def init_build(args):
         build_primary_graph=args.build_primary_graph,
         annotation_formats=[AnnotationFormats(af) for af in args.annotation_format],
         annotation_labels_source=args.annotation_labels_source,
+        with_counts=args.with_counts,
+        count_width=args.count_width,
         metagraph_cmd=args.metagraph_cmd,
         threads=args.threads,
         force=args.force,

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -32,6 +32,12 @@ COUNT_COMPATIBLE_FORMATS = {
     AnnotationFormats.ROW_DIFF_INT_BRWT,
     AnnotationFormats.ROW_DIFF_INT_DISK,
 }
+COORD_COMPATIBLE_FORMATS = {
+    AnnotationFormats.BRWT_COORD,
+    AnnotationFormats.ROW_DIFF_COORD,
+    AnnotationFormats.ROW_DIFF_BRWT_COORD,
+    AnnotationFormats.ROW_DIFF_DISK_COORD,
+}
 
 
 def _parse_annotation_format_value(value: str) -> AnnotationFormats:
@@ -156,6 +162,7 @@ def run_build_workflow(
         annotation_formats: Iterable[AnnotationFormats] = (),
         annotation_labels_source: Optional[AnnotationLabelsSource] = None,
         with_counts: bool = False,
+        with_coordinates: bool = False,
         count_width: Optional[int] = None,
         metagraph_cmd: Optional[str] = None,
         threads: Optional[int] = None,
@@ -191,10 +198,21 @@ def run_build_workflow(
 
     selected_formats = set(annotation_formats)
     has_count_formats = any(af in COUNT_COMPATIBLE_FORMATS for af in selected_formats)
+    has_coord_formats = any(af in COORD_COMPATIBLE_FORMATS for af in selected_formats)
     effective_with_counts = with_counts or has_count_formats
+    effective_with_coordinates = with_coordinates or has_coord_formats
+
+    if effective_with_counts and effective_with_coordinates:
+        raise ValueError(
+            "Count-aware and coordinate-aware modes are mutually exclusive in this workflow. "
+            "Choose either count formats (--with-counts / int_* / row_diff_int_*) or "
+            "coordinate formats (--with-coords / *_coord)."
+        )
 
     if effective_with_counts and not annotation_formats:
         config['annotation_formats'] = [AnnotationFormats.ROW_DIFF_INT_BRWT.value]
+    elif effective_with_coordinates and not annotation_formats:
+        config['annotation_formats'] = [AnnotationFormats.ROW_DIFF_BRWT_COORD.value]
     else:
         config['annotation_formats'] = [af.value for af in
                                         annotation_formats] if annotation_formats else config['annotation_formats']
@@ -208,14 +226,27 @@ def run_build_workflow(
                 + ", ".join(sorted([f.value for f in COUNT_COMPATIBLE_FORMATS]))
                 + f". Got: {', '.join(invalid_formats)}"
             )
+    if effective_with_coordinates:
+        invalid_formats = [af.value for af in annotation_formats if af not in COORD_COMPATIBLE_FORMATS]
+        if invalid_formats:
+            raise ValueError(
+                "Coordinate-aware mode is enabled (--with-coords or *_coord --annotation-format), "
+                "--annotation-format must be one of: "
+                + ", ".join(sorted([f.value for f in COORD_COMPATIBLE_FORMATS]))
+                + f". Got: {', '.join(invalid_formats)}"
+            )
     config['with_counts'] = effective_with_counts
+    config['with_coordinates'] = effective_with_coordinates
     if count_width is not None and not (2 <= count_width <= 32):
         raise ValueError(f"--count-width must be in range [2, 32], got {count_width}")
+    if count_width is not None and not effective_with_counts:
+        raise ValueError("--count-width can only be used with count-aware mode (--with-counts or count formats).")
     if count_width is not None:
         config['count_width'] = count_width
 
     config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
-    _validate_metagraph_cmd(config['metagraph_cmd'])
+    if not dryrun:
+        _validate_metagraph_cmd(config['metagraph_cmd'])
     config['max_threads'] = threads if threads else snakemake.utils.available_cpu_count()
 
     if verbose:
@@ -301,7 +332,8 @@ def setup_build_parser(parser):
                             help=f"Annotation format (can be used multiple times). "
                                  f"Possible values: {', '.join([v.value for v in AnnotationFormats])}. "
                                  f"Default is relax.row_diff_brwt; with --with-counts and no explicit format, "
-                                 f"default is row_diff_int_brwt.")
+                                 f"default is row_diff_int_brwt; with --with-coords and no explicit format, "
+                                 f"default is row_diff_brwt_coord.")
     annotation.add_argument('--annotation-labels-source',
                             type=AnnotationLabelsSource,
                             default=AnnotationLabelsSource.SEQUENCE_HEADERS,
@@ -311,6 +343,10 @@ def setup_build_parser(parser):
                             help="Enable count-aware annotation workflow. "
                                  "If no --annotation-format is provided, defaults to row_diff_int_brwt. "
                                  "Also enabled automatically when a count-capable annotation format is selected.")
+    annotation.add_argument('--with-coords', dest='with_coordinates', default=False, action='store_true',
+                            help="Enable coordinate-aware annotation workflow. "
+                                 "If no --annotation-format is provided, defaults to row_diff_brwt_coord. "
+                                 "Also enabled automatically when a coordinate-capable annotation format is selected.")
     annotation.add_argument('--count-width', type=int, default=None,
                             help="Bit width for count values (passed to annotate/transform_anno). "
                                  "Default behavior is 8-bit when unset.")
@@ -365,6 +401,7 @@ def init_build(args):
         annotation_formats=[_parse_annotation_format_value(af) for af in args.annotation_format],
         annotation_labels_source=args.annotation_labels_source,
         with_counts=args.with_counts,
+        with_coordinates=args.with_coordinates,
         count_width=args.count_width,
         metagraph_cmd=args.metagraph_cmd,
         threads=args.threads,

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -229,7 +229,7 @@ rule transform_rd_stage0:
         dbg_graph=graph_path,
         columns_file=columns_file,
     output:
-        columns_rd_row_count=rd_cols_dir/'vector.row_count'
+        columns_rd_row_count=temp(rd_cols_dir/'vector.row_count')
     threads: max_threads
     resources:
         mem_mb=TransformRdStage0Resources(config).get_mem()
@@ -259,19 +259,20 @@ rule transform_rd_stage1:
     input:
         dbg_graph=graph_path,
         columns_file=columns_file,
-        columns_rd_row_count=rd_cols_dir/'vector.row_count'
+        columns_rd_row_count=rules.transform_rd_stage0.output.columns_rd_row_count
     output:
-        pred=wdir / f'{graph}.dbg.pred',
-        pred_boundary=wdir / f'{graph}.dbg.pred_boundary',
+        pred=temp(wdir / f'{graph}.dbg.pred'),
+        pred_boundary=temp(wdir / f'{graph}.dbg.pred_boundary'),
+        succ=temp(wdir / f'{graph}.dbg.succ'),
+        succ_boundary=temp(wdir / f'{graph}.dbg.succ_boundary'),
         rd_succ=wdir / f'{graph}.dbg.rd_succ',
-        succ=wdir / f'{graph}.dbg.succ',
-        succ_boundary=wdir / f'{graph}.dbg.succ_boundary',
-        cols_rd_vectors=rd_cols_dir / 'vectors.row_reduction'
+        stage1_done=touch(rd_cols_dir / 'stage1.DONE')
     threads: max_threads
     resources:
         mem_mb=TransformRdStage1Resources(config).get_mem()
     params:
         mem_buffer=TransformRdStage1Resources(config).get_mem_buffer_gib(),
+        rd_cols_dir=rd_cols_dir,
         tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(TRANSFORM_RD_STAGE1_RULE, config)
     shell:
@@ -285,7 +286,7 @@ rule transform_rd_stage1:
             {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
-            -o {output.cols_rd_vectors} {params.tempdir_opt} > {log} 2>&1
+            -o {params.rd_cols_dir}/out {params.tempdir_opt} > {log} 2>&1
         """
 
 
@@ -294,7 +295,11 @@ rule transform_rd_stage2:
     input:
         dbg_graph=graph_path,
         columns_file=columns_file,
-        cols_rd_vectors=rd_cols_dir / 'vectors.row_reduction'
+        pred=rules.transform_rd_stage1.output.pred,
+        pred_boundary=rules.transform_rd_stage1.output.pred_boundary,
+        succ=rules.transform_rd_stage1.output.succ,
+        succ_boundary=rules.transform_rd_stage1.output.succ_boundary,
+        stage1_done=rules.transform_rd_stage1.output.stage1_done
     output:
         anchors=wdir/f'{graph}.dbg.anchors',
         rd_cols_done=touch(rd_cols_dir/DONE)
@@ -323,12 +328,13 @@ rule transform_rd_stage2:
 ANNOTATE_ROW_DIFF_BRWT_RULE="annotate_row_diff_brwt"
 rule annotate_row_diff_brwt:
     input:
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
         anchors=rules.transform_rd_stage2.output.anchors,
         rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_brwt.annodbg',
-        linkage=wdir / f'{graph}.row_diff_brwt.annodbg.linkage',
+        linkage=temp(wdir / f'{graph}.row_diff_brwt.annodbg.linkage'),
     threads: max_threads
     resources:
         mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_BRWT_RULE, config).get_mem(),
@@ -381,6 +387,7 @@ rule annotate_row_diff_int_brwt:
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_int_brwt.annodbg',
+        linkage=temp(wdir/f'{graph}.row_diff_int_brwt.annodbg.linkage')
     threads: max_threads
     resources:
         mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_INT_BRWT_RULE, config).get_mem(),
@@ -432,6 +439,7 @@ rule annotate_row_diff_brwt_coord:
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_brwt_coord.annodbg',
+        linkage=temp(wdir/f'{graph}.row_diff_brwt_coord.annodbg.linkage')
     threads: max_threads
     resources:
         mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_BRWT_COORD_RULE, config).get_mem(),

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -19,8 +19,10 @@ for af in annotation_formats:
 
 annotation_labels_opt = AnnotationLabelsSource(config['annotation_labels_source']).to_annotation_cmd_option()
 with_counts = take_value_or_default(workflow_configs.WITH_COUNTS, False, config)
+with_coordinates = take_value_or_default(workflow_configs.WITH_COORDINATES, False, config)
 count_width = take_value_or_default(workflow_configs.COUNT_WIDTH, 8, config)
 count_kmers_opt = '--count-kmers' if with_counts else ''
+coordinates_opt = '--coordinates' if with_coordinates else ''
 count_width_opt = f'--count-width {count_width}' if with_counts else ''
 
 
@@ -38,7 +40,12 @@ DONE="DONE"
 
 ## Paths
 graph_path=wdir/f'{graph}.dbg'
-annotation_mode_suffix = f'counts.w{count_width}' if with_counts else 'binary'
+if with_counts:
+    annotation_mode_suffix = f'counts.w{count_width}'
+elif with_coordinates:
+    annotation_mode_suffix = 'coords'
+else:
+    annotation_mode_suffix = 'binary'
 annotation_cols_path=wdir/f'columns.{annotation_mode_suffix}'
 annotation_path_done=annotation_cols_path/DONE
 
@@ -94,6 +101,7 @@ rule annotate:
           -i {input.dbg_graph} \
           {annotation_labels_opt} \
           {count_kmers_opt} \
+          {coordinates_opt} \
           {count_width_opt} \
           --anno-type column \
           --separately \
@@ -138,6 +146,9 @@ ruleorder: relax_brwt > transform_annotation # more specific rule has priority
 ruleorder: annotate_row_diff_brwt > transform_annotation
 ruleorder: annotate_row_diff_int_brwt > transform_annotation
 ruleorder: annotate_row_diff_int_disk > transform_annotation
+ruleorder: annotate_row_diff_brwt_coord > transform_annotation
+ruleorder: annotate_row_diff_coord > transform_annotation
+ruleorder: annotate_row_diff_disk_coord > transform_annotation
 
 TRANSFORM_ANNOTATION_RULE="transform_annotation"
 rule transform_annotation:
@@ -237,6 +248,7 @@ rule transform_rd_stage0:
             -i {input.dbg_graph} \
             --parallel {threads} \
             {count_kmers_opt} \
+            {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
             -o {output.columns_rd_row_count} {params.tempdir_opt} > {log} 2>&1
@@ -270,6 +282,7 @@ rule transform_rd_stage1:
             -i {input.dbg_graph} \
             --parallel {threads} \
             {count_kmers_opt} \
+            {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
             -o {output.cols_rd_vectors} {params.tempdir_opt} > {log} 2>&1
@@ -300,6 +313,7 @@ rule transform_rd_stage2:
             -i {input.dbg_graph} \
             --parallel {threads} \
             {count_kmers_opt} \
+            {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
             -o {output.rd_cols_done} {params.tempdir_opt} > {log} 2>&1
@@ -404,6 +418,81 @@ rule annotate_row_diff_int_disk:
         r"""
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_int_disk \
+            --parallel {threads} \
+            -i {input.dbg_graph} \
+            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+        """
+
+
+ANNOTATE_ROW_DIFF_BRWT_COORD_RULE="annotate_row_diff_brwt_coord"
+rule annotate_row_diff_brwt_coord:
+    input:
+        anchors=rules.transform_rd_stage2.output.anchors,
+        rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        dbg_graph=graph_path
+    output:
+        annotations=wdir/f'{graph}.row_diff_brwt_coord.annodbg',
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_BRWT_COORD_RULE, config).get_mem(),
+    params:
+        parallel_nodes=config[workflow_configs.BRWT_PARALLEL_NODES],
+        tempdir_opt=utils.temp_dir_config(config),
+    log: utils.get_log_path(ANNOTATE_ROW_DIFF_BRWT_COORD_RULE, config)
+    shell:
+        r"""
+        find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
+            --anno-type row_diff_brwt_coord \
+            --greedy \
+            --parallel-nodes {params.parallel_nodes} \
+            --parallel {threads} \
+            -i {input.dbg_graph} \
+            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+        """
+
+
+ANNOTATE_ROW_DIFF_COORD_RULE="annotate_row_diff_coord"
+rule annotate_row_diff_coord:
+    input:
+        anchors=rules.transform_rd_stage2.output.anchors,
+        rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        dbg_graph=graph_path
+    output:
+        annotations=wdir/f'{graph}.row_diff_coord.annodbg',
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_COORD_RULE, config).get_mem(),
+    params:
+        tempdir_opt=utils.temp_dir_config(config),
+    log: utils.get_log_path(ANNOTATE_ROW_DIFF_COORD_RULE, config)
+    shell:
+        r"""
+        find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
+            --anno-type row_diff_coord \
+            --parallel {threads} \
+            -i {input.dbg_graph} \
+            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+        """
+
+
+ANNOTATE_ROW_DIFF_DISK_COORD_RULE="annotate_row_diff_disk_coord"
+rule annotate_row_diff_disk_coord:
+    input:
+        anchors=rules.transform_rd_stage2.output.anchors,
+        rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        dbg_graph=graph_path
+    output:
+        annotations=wdir/f'{graph}.row_diff_disk_coord.annodbg',
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_DISK_COORD_RULE, config).get_mem(),
+    params:
+        tempdir_opt=utils.temp_dir_config(config),
+    log: utils.get_log_path(ANNOTATE_ROW_DIFF_DISK_COORD_RULE, config)
+    shell:
+        r"""
+        find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
+            --anno-type row_diff_disk_coord \
             --parallel {threads} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -18,6 +18,10 @@ for af in annotation_formats:
     # TODO: make a nicer error
 
 annotation_labels_opt = AnnotationLabelsSource(config['annotation_labels_source']).to_annotation_cmd_option()
+with_counts = take_value_or_default(workflow_configs.WITH_COUNTS, False, config)
+count_width = take_value_or_default(workflow_configs.COUNT_WIDTH, 8, config)
+count_kmers_opt = '--count-kmers' if with_counts else ''
+count_width_opt = f'--count-width {count_width}' if with_counts else ''
 
 
 metagraph_cmd=config['metagraph_cmd']
@@ -34,10 +38,11 @@ DONE="DONE"
 
 ## Paths
 graph_path=wdir/f'{graph}.dbg'
-annotation_cols_path=wdir/'columns'
+annotation_mode_suffix = f'counts.w{count_width}' if with_counts else 'binary'
+annotation_cols_path=wdir/f'columns.{annotation_mode_suffix}'
 annotation_path_done=annotation_cols_path/DONE
 
-columns_file=wdir/'columns.txt'
+columns_file=wdir/f'columns.{annotation_mode_suffix}.txt'
 
 seqs_file_list_path=utils.get_seqs_file_list_path(wdir, config)
 
@@ -88,6 +93,8 @@ rule annotate:
           --parallel {threads} \
           -i {input.dbg_graph} \
           {annotation_labels_opt} \
+          {count_kmers_opt} \
+          {count_width_opt} \
           --anno-type column \
           --separately \
           -o $OUT_DIR {params.tempdir_opt} > {log} 2>&1
@@ -128,6 +135,9 @@ rule generate_brwt_linkage:
         """
 
 ruleorder: relax_brwt > transform_annotation # more specific rule has priority
+ruleorder: annotate_row_diff_brwt > transform_annotation
+ruleorder: annotate_row_diff_int_brwt > transform_annotation
+ruleorder: annotate_row_diff_int_disk > transform_annotation
 
 TRANSFORM_ANNOTATION_RULE="transform_annotation"
 rule transform_annotation:
@@ -198,7 +208,7 @@ rule relax_brwt:
             {input.brwt_annots} {params.tempdir_opt} > {log} 2>&1
         """
 
-rd_cols_dir = wdir/'rd_cols'
+rd_cols_dir = wdir/f'rd_cols.{annotation_mode_suffix}'
 
 from metagraph_workflows.resource_management import TransformRdStage0Resources
 
@@ -226,6 +236,8 @@ rule transform_rd_stage0:
             --row-diff-stage 0 \
             -i {input.dbg_graph} \
             --parallel {threads} \
+            {count_kmers_opt} \
+            {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
             -o {output.columns_rd_row_count} {params.tempdir_opt} > {log} 2>&1
         """
@@ -257,6 +269,8 @@ rule transform_rd_stage1:
             --row-diff-stage 1 \
             -i {input.dbg_graph} \
             --parallel {threads} \
+            {count_kmers_opt} \
+            {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
             -o {output.cols_rd_vectors} {params.tempdir_opt} > {log} 2>&1
         """
@@ -285,6 +299,8 @@ rule transform_rd_stage2:
             --row-diff-stage 2 \
             -i {input.dbg_graph} \
             --parallel {threads} \
+            {count_kmers_opt} \
+            {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
             -o {output.rd_cols_done} {params.tempdir_opt} > {log} 2>&1
         """
@@ -340,4 +356,55 @@ rule relax_row_diff_brwt:
             --relax-arity {params.relax_arity} \
             --parallel {threads} \
             {input.brwt_annots} {params.tempdir_opt} > {log} 2>&1
+        """
+
+
+ANNOTATE_ROW_DIFF_INT_BRWT_RULE="annotate_row_diff_int_brwt"
+rule annotate_row_diff_int_brwt:
+    input:
+        anchors=rules.transform_rd_stage2.output.anchors,
+        rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        dbg_graph=graph_path
+    output:
+        annotations=wdir/f'{graph}.row_diff_int_brwt.annodbg',
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_INT_BRWT_RULE, config).get_mem(),
+    params:
+        parallel_nodes=config[workflow_configs.BRWT_PARALLEL_NODES],
+        tempdir_opt=utils.temp_dir_config(config),
+    log: utils.get_log_path(ANNOTATE_ROW_DIFF_INT_BRWT_RULE, config)
+    shell:
+        r"""
+        find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
+            --anno-type row_diff_int_brwt \
+            --greedy \
+            --parallel-nodes {params.parallel_nodes} \
+            --parallel {threads} \
+            -i {input.dbg_graph} \
+            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+        """
+
+
+ANNOTATE_ROW_DIFF_INT_DISK_RULE="annotate_row_diff_int_disk"
+rule annotate_row_diff_int_disk:
+    input:
+        anchors=rules.transform_rd_stage2.output.anchors,
+        rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        dbg_graph=graph_path
+    output:
+        annotations=wdir/f'{graph}.row_diff_int_disk.annodbg',
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_INT_DISK_RULE, config).get_mem(),
+    params:
+        tempdir_opt=utils.temp_dir_config(config),
+    log: utils.get_log_path(ANNOTATE_ROW_DIFF_INT_DISK_RULE, config)
+    shell:
+        r"""
+        find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
+            --anno-type row_diff_int_disk \
+            --parallel {threads} \
+            -i {input.dbg_graph} \
+            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import metagraph_workflows.utils
 from metagraph_workflows import workflow_configs, utils
 from metagraph_workflows.utils import take_value_or_default
@@ -20,6 +22,9 @@ for af in annotation_formats:
 annotation_labels_opt = AnnotationLabelsSource(config['annotation_labels_source']).to_annotation_cmd_option()
 with_counts = take_value_or_default(workflow_configs.WITH_COUNTS, False, config)
 with_coordinates = take_value_or_default(workflow_configs.WITH_COORDINATES, False, config)
+if with_counts and with_coordinates:
+    raise RuntimeError(
+        'with_counts and with_coordinates cannot both be true (same constraint as metagraph row-diff).')
 count_width = take_value_or_default(workflow_configs.COUNT_WIDTH, 8, config)
 count_kmers_opt = '--count-kmers' if with_counts else ''
 coordinates_opt = '--coordinates' if with_coordinates else ''
@@ -53,6 +58,10 @@ columns_file=wdir/f'columns.{annotation_mode_suffix}.txt'
 
 seqs_file_list_path=utils.get_seqs_file_list_path(wdir, config)
 
+column_anno_paths = utils.generate_col_paths(annotation_cols_path, seqs_file_list_path, config)
+column_counts_paths = [Path(str(p) + '.counts') for p in column_anno_paths] if with_counts else []
+column_coords_paths = [Path(str(p) + '.coords') for p in column_anno_paths] if with_coordinates else []
+
 contigs_dir=wdir/'contigs'
 
 seq_ids_dict = {}
@@ -62,7 +71,7 @@ if not config[workflow_configs.SAMPLE_IDS_PATH]:
 localrules: generate_column_list
 
 rule all:
-     input:
+    input:
         graph_path,
         [wdir/f'{graph}.{anno_type}.annodbg' for anno_type in annotation_formats]
 
@@ -76,7 +85,9 @@ rule annotate:
         dbg_graph=graph_path,
     output:
         done=touch(annotation_path_done),
-        column_anno_files=utils.generate_col_paths(annotation_cols_path, seqs_file_list_path, config)
+        column_anno_files=temp(column_anno_paths),
+        column_count_files=(temp(column_counts_paths) if with_counts else []),
+        column_coord_files=(temp(column_coords_paths) if with_coordinates else []),
     threads: max_threads
     resources:
         mem_mb=ResourceConfig(ANNOTATE_RULE, config).get_mem(),
@@ -92,7 +103,7 @@ rule annotate:
         else
             SEQ_PATHS="{input.seqs}"
         fi
-        
+
         OUT_DIR=$(dirname {output.done})
         mkdir -p $OUT_DIR
         cat $SEQ_PATHS | {time_cmd} {metagraph_cmd} annotate \
@@ -111,7 +122,7 @@ rule annotate:
 GENERATE_COLUMN_LIST_RULE="generate_column_list"
 rule generate_column_list:
     input: rules.annotate.output.column_anno_files
-    output: columns_file
+    output: temp(columns_file)
     run:
         with open(output[0], 'w') as f:
             f.write('\n'.join([str(l) for l in input]))
@@ -123,6 +134,9 @@ GENERATE_BRWT_LINKAGE_RULE="generate_brwt_linkage"
 rule generate_brwt_linkage:
     input:
         columns_file=columns_file,
+        column_anno_files=rules.annotate.output.column_anno_files,
+        column_count_files=rules.annotate.output.column_count_files,
+        column_coord_files=rules.annotate.output.column_coord_files,
     output:
         linkage=wdir/f"{graph}.linkage.txt"
     threads: max_threads
@@ -154,6 +168,9 @@ TRANSFORM_ANNOTATION_RULE="transform_annotation"
 rule transform_annotation:
     input:
         columns_file=columns_file,
+        column_anno_files=rules.annotate.output.column_anno_files,
+        column_count_files=rules.annotate.output.column_count_files,
+        column_coord_files=rules.annotate.output.column_coord_files,
     output:
         annotations=wdir/f'{graph}.{{anno_type}}.annodbg',
     threads: max_threads
@@ -176,6 +193,9 @@ rule annotate_brwt:
     input:
         linkage=wdir/f"{graph}.linkage.txt",
         columns_file=columns_file,
+        column_anno_files=rules.annotate.output.column_anno_files,
+        column_count_files=rules.annotate.output.column_count_files,
+        column_coord_files=rules.annotate.output.column_coord_files,
     output:
         annotations=wdir/f'{graph}.brwt.annodbg',
     threads: max_threads
@@ -221,6 +241,12 @@ rule relax_brwt:
 
 rd_cols_dir = wdir/f'rd_cols.{annotation_mode_suffix}'
 
+# Stage 2: *.column.annodbg (counts/coords) vs *.row_diff.annodbg (binary row-diff only).
+rd_col_annodbg_suffix = '.column.annodbg' if (with_counts or with_coordinates) else '.row_diff.annodbg'
+rd_col_annodbg_paths = utils.generate_col_paths(rd_cols_dir, seqs_file_list_path, config, suffix=rd_col_annodbg_suffix)
+rd_col_counts_paths = [Path(str(p) + '.counts') for p in rd_col_annodbg_paths] if with_counts else []
+rd_col_coords_paths = [Path(str(p) + '.coords') for p in rd_col_annodbg_paths] if with_coordinates else []
+
 from metagraph_workflows.resource_management import TransformRdStage0Resources
 
 TRANSFORM_RD_STAGE0_RULE="transform_rd_stage0"
@@ -228,6 +254,9 @@ rule transform_rd_stage0:
     input:
         dbg_graph=graph_path,
         columns_file=columns_file,
+        column_anno_files=rules.annotate.output.column_anno_files,
+        column_count_files=rules.annotate.output.column_count_files,
+        column_coord_files=rules.annotate.output.column_coord_files,
     output:
         columns_rd_row_count=temp(rd_cols_dir/'vector.row_count')
     threads: max_threads
@@ -259,13 +288,16 @@ rule transform_rd_stage1:
     input:
         dbg_graph=graph_path,
         columns_file=columns_file,
+        column_anno_files=rules.annotate.output.column_anno_files,
+        column_count_files=rules.annotate.output.column_count_files,
+        column_coord_files=rules.annotate.output.column_coord_files,
         columns_rd_row_count=rules.transform_rd_stage0.output.columns_rd_row_count
     output:
         pred=temp(wdir / f'{graph}.dbg.pred'),
         pred_boundary=temp(wdir / f'{graph}.dbg.pred_boundary'),
         succ=temp(wdir / f'{graph}.dbg.succ'),
         succ_boundary=temp(wdir / f'{graph}.dbg.succ_boundary'),
-        rd_succ=wdir / f'{graph}.dbg.rd_succ',
+        rd_succ=temp(wdir / f'{graph}.dbg.rd_succ'),
         row_reduction=temp(rd_cols_dir / 'vector.row_reduction'),
         stage1_done=touch(rd_cols_dir / 'stage1.DONE')
     threads: max_threads
@@ -296,15 +328,22 @@ rule transform_rd_stage2:
     input:
         dbg_graph=graph_path,
         columns_file=columns_file,
+        column_anno_files=rules.annotate.output.column_anno_files,
+        column_count_files=rules.annotate.output.column_count_files,
+        column_coord_files=rules.annotate.output.column_coord_files,
         row_reduction=rules.transform_rd_stage1.output.row_reduction,
         pred=rules.transform_rd_stage1.output.pred,
         pred_boundary=rules.transform_rd_stage1.output.pred_boundary,
         succ=rules.transform_rd_stage1.output.succ,
         succ_boundary=rules.transform_rd_stage1.output.succ_boundary,
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
         stage1_done=rules.transform_rd_stage1.output.stage1_done
     output:
-        anchors=wdir/f'{graph}.dbg.anchors',
-        rd_cols_done=touch(rd_cols_dir/DONE)
+        anchors=temp(wdir/f'{graph}.dbg.anchors'),
+        rd_cols_done=touch(rd_cols_dir/DONE),
+        rd_col_annodbg_files=temp(rd_col_annodbg_paths),
+        rd_col_count_files=(temp(rd_col_counts_paths) if with_counts else []),
+        rd_col_coord_files=(temp(rd_col_coords_paths) if with_coordinates else []),
     threads: max_threads
     resources:
         mem_mb=TransformRdStage2Resources(config).get_mem(),
@@ -333,6 +372,9 @@ rule annotate_row_diff_brwt:
         rd_succ=rules.transform_rd_stage1.output.rd_succ,
         anchors=rules.transform_rd_stage2.output.anchors,
         rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        rd_col_annodbg_files=rules.transform_rd_stage2.output.rd_col_annodbg_files,
+        rd_col_count_files=rules.transform_rd_stage2.output.rd_col_count_files,
+        rd_col_coord_files=rules.transform_rd_stage2.output.rd_col_coord_files,
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_brwt.annodbg',
@@ -384,8 +426,12 @@ rule relax_row_diff_brwt:
 ANNOTATE_ROW_DIFF_INT_BRWT_RULE="annotate_row_diff_int_brwt"
 rule annotate_row_diff_int_brwt:
     input:
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
         anchors=rules.transform_rd_stage2.output.anchors,
         rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        rd_col_annodbg_files=rules.transform_rd_stage2.output.rd_col_annodbg_files,
+        rd_col_count_files=rules.transform_rd_stage2.output.rd_col_count_files,
+        rd_col_coord_files=rules.transform_rd_stage2.output.rd_col_coord_files,
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_int_brwt.annodbg',
@@ -412,8 +458,12 @@ rule annotate_row_diff_int_brwt:
 ANNOTATE_ROW_DIFF_INT_DISK_RULE="annotate_row_diff_int_disk"
 rule annotate_row_diff_int_disk:
     input:
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
         anchors=rules.transform_rd_stage2.output.anchors,
         rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        rd_col_annodbg_files=rules.transform_rd_stage2.output.rd_col_annodbg_files,
+        rd_col_count_files=rules.transform_rd_stage2.output.rd_col_count_files,
+        rd_col_coord_files=rules.transform_rd_stage2.output.rd_col_coord_files,
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_int_disk.annodbg',
@@ -436,8 +486,12 @@ rule annotate_row_diff_int_disk:
 ANNOTATE_ROW_DIFF_BRWT_COORD_RULE="annotate_row_diff_brwt_coord"
 rule annotate_row_diff_brwt_coord:
     input:
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
         anchors=rules.transform_rd_stage2.output.anchors,
         rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        rd_col_annodbg_files=rules.transform_rd_stage2.output.rd_col_annodbg_files,
+        rd_col_count_files=rules.transform_rd_stage2.output.rd_col_count_files,
+        rd_col_coord_files=rules.transform_rd_stage2.output.rd_col_coord_files,
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_brwt_coord.annodbg',
@@ -464,8 +518,12 @@ rule annotate_row_diff_brwt_coord:
 ANNOTATE_ROW_DIFF_COORD_RULE="annotate_row_diff_coord"
 rule annotate_row_diff_coord:
     input:
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
         anchors=rules.transform_rd_stage2.output.anchors,
         rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        rd_col_annodbg_files=rules.transform_rd_stage2.output.rd_col_annodbg_files,
+        rd_col_count_files=rules.transform_rd_stage2.output.rd_col_count_files,
+        rd_col_coord_files=rules.transform_rd_stage2.output.rd_col_coord_files,
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_coord.annodbg',
@@ -488,8 +546,12 @@ rule annotate_row_diff_coord:
 ANNOTATE_ROW_DIFF_DISK_COORD_RULE="annotate_row_diff_disk_coord"
 rule annotate_row_diff_disk_coord:
     input:
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
         anchors=rules.transform_rd_stage2.output.anchors,
         rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        rd_col_annodbg_files=rules.transform_rd_stage2.output.rd_col_annodbg_files,
+        rd_col_count_files=rules.transform_rd_stage2.output.rd_col_count_files,
+        rd_col_coord_files=rules.transform_rd_stage2.output.rd_col_coord_files,
         dbg_graph=graph_path
     output:
         annotations=wdir/f'{graph}.row_diff_disk_coord.annodbg',

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -266,6 +266,7 @@ rule transform_rd_stage1:
         succ=temp(wdir / f'{graph}.dbg.succ'),
         succ_boundary=temp(wdir / f'{graph}.dbg.succ_boundary'),
         rd_succ=wdir / f'{graph}.dbg.rd_succ',
+        row_reduction=temp(rd_cols_dir / 'vector.row_reduction'),
         stage1_done=touch(rd_cols_dir / 'stage1.DONE')
     threads: max_threads
     resources:
@@ -286,7 +287,7 @@ rule transform_rd_stage1:
             {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
-            -o {params.rd_cols_dir}/out {params.tempdir_opt} > {log} 2>&1
+            -o {output.row_reduction} {params.tempdir_opt} > {log} 2>&1
         """
 
 
@@ -295,6 +296,7 @@ rule transform_rd_stage2:
     input:
         dbg_graph=graph_path,
         columns_file=columns_file,
+        row_reduction=rules.transform_rd_stage1.output.row_reduction,
         pred=rules.transform_rd_stage1.output.pred,
         pred_boundary=rules.transform_rd_stage1.output.pred_boundary,
         succ=rules.transform_rd_stage1.output.succ,

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -12,6 +12,8 @@ kmc_mem_overhead_factor: 1.1
 # annotation options
 annotation_formats: ['relax.row_diff_brwt']
 annotation_labels_source: 'sequence_headers'
+with_counts: false
+count_width: 8
 
 brwt_relax_arity: 32
 brwt_parallel_nodes: 5

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -13,6 +13,7 @@ kmc_mem_overhead_factor: 1.1
 annotation_formats: ['relax.row_diff_brwt']
 annotation_labels_source: 'sequence_headers'
 with_counts: false
+with_coordinates: false
 count_width: 8
 
 brwt_relax_arity: 32

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -20,7 +20,6 @@ brwt_parallel_nodes: 5
 brwt_linkage_subsample: 100000
 
 metagraph_cmd: 'metagraph'
-gnu_time_cmd: '/usr/bin/time'
 
 default_disk_mb: 10000
 max_memory_mb: 4048

--- a/metagraph/workflows/metagraph_workflows/snakemake/test_workflow/test.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/test_workflow/test.yml
@@ -6,7 +6,7 @@ primarize_samples_separately: True
 output_directory: 'output_dir_test'
 seqs_file_list_path: '' # using dummy_staging_script.sh staging script, to "stage" data
 
-annotation_labels_source: 'sequence_file_names'
+annotation_labels_source: 'file_names'
 
 sample_ids_path: 'test_workflow/sample_ids.txt'
 sample_staging_script_path: 'test_workflow/dummy_staging_script.sh'

--- a/metagraph/workflows/metagraph_workflows/time_wrapper.py
+++ b/metagraph/workflows/metagraph_workflows/time_wrapper.py
@@ -1,0 +1,54 @@
+"""Portable subprocess timing wrapper for workflow shell commands."""
+
+import argparse
+import resource
+import subprocess
+import sys
+import time
+
+
+def _rss_kb(ru_maxrss: int) -> int:
+    # On Linux ru_maxrss is in KB, on macOS it's in bytes.
+    if sys.platform == "darwin":
+        return int(ru_maxrss / 1024)
+    return int(ru_maxrss)
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("command", nargs=argparse.REMAINDER)
+    ns = parser.parse_args(argv)
+
+    cmd = ns.command
+    if cmd and cmd[0] == "--":
+        cmd = cmd[1:]
+    if not cmd:
+        print("time_wrapper: missing command", file=sys.stderr)
+        return 2
+
+    start = time.perf_counter()
+    try:
+        child = subprocess.Popen(cmd)
+    except OSError as e:
+        print(f"[timing] failed_to_exec={e}", file=sys.stderr)
+        return 127
+    exit_code = child.wait()
+    elapsed = time.perf_counter() - start
+    usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+
+    # Print concise, portable metrics footer.
+    print(
+        "[timing] wall_sec={:.3f} user_sec={:.3f} sys_sec={:.3f} max_rss_kb={} exit_code={}".format(
+            elapsed,
+            usage.ru_utime,
+            usage.ru_stime,
+            _rss_kb(usage.ru_maxrss),
+            exit_code,
+        ),
+        file=sys.stderr,
+    )
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/metagraph/workflows/metagraph_workflows/utils.py
+++ b/metagraph/workflows/metagraph_workflows/utils.py
@@ -82,7 +82,12 @@ def get_build_joint_input(config, contigs_dir, seq_ids_dict, seqs_file_list_path
     return _get_build_graph_input
 
 
-def generate_col_paths(annotation_cols_path, seqs_file_list_path, config):
+def generate_col_paths(annotation_cols_path, seqs_file_list_path, config,
+                       suffix=".column.annodbg"):
+    """Per-sample paths under ``annotation_cols_path`` (default: ``*.column.annodbg``).
+
+    Row-diff stage 2 binary mode emits ``*.row_diff.annodbg``; pass ``suffix='.row_diff.annodbg'``.
+    """
     sample_names = set()
 
     if workflow_configs.SAMPLE_IDS_PATH in config and config[workflow_configs.SAMPLE_IDS_PATH]:
@@ -105,8 +110,7 @@ def generate_col_paths(annotation_cols_path, seqs_file_list_path, config):
             else:
                 sample_names = set(column_names)
 
-    return [annotation_cols_path / f"{c}.column.annodbg" for c in
-            sample_names]
+    return [annotation_cols_path / f"{c}{suffix}" for c in sample_names]
 
 
 def get_wdir(config):

--- a/metagraph/workflows/metagraph_workflows/utils.py
+++ b/metagraph/workflows/metagraph_workflows/utils.py
@@ -1,12 +1,13 @@
 import itertools
 import logging
+import os
 import re
-import subprocess
+import shlex
 from pathlib import Path
 from typing import Union
 
 from metagraph_workflows import workflow_configs, utils
-from metagraph_workflows.workflow_configs import GNU_TIME_CMD, TMP_DIR, \
+from metagraph_workflows.workflow_configs import TMP_DIR, \
     RULE_CONFIGS_KEY, SEQS_FILE_LIST_PATH, SEQS_DIR_PATH
 
 logger = logging.getLogger("metagraph_workflow")
@@ -112,22 +113,16 @@ def get_wdir(config):
     return Path(config['output_directory'])
 
 
+def get_time_wrapper_command(config):
+    """Return a portable Python timing wrapper command."""
+    del config
+    module_call = [shlex.quote(os.environ.get("PYTHON", "python")), "-m", "metagraph_workflows.time_wrapper"]
+    return " ".join(module_call)
+
+
 def get_gnu_time_command(config):
-    EMTPY_CMD = ''
-    cmd = config.get(GNU_TIME_CMD, EMTPY_CMD)
-
-    if cmd:
-        test_cmd=[cmd, '--version']
-        proc = subprocess.run(test_cmd, capture_output=True)
-        if proc.returncode == 0:
-            return f"{cmd} --verbose"
-        else:
-            logger.warning(f"Command {' '.join(test_cmd)} for GNU time could not be executed successfully: {proc.stderr}."
-                           f" No timing information collected")
-    else:
-        logger.warning("No GNU Time command provided.")
-
-    return EMTPY_CMD
+    """Backward-compatible alias for old Snakefiles."""
+    return get_time_wrapper_command(config)
 
 
 def get_log_path(rule_name, config, wildcards=None):

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -40,6 +40,7 @@ DISK_CAP_MB_KEY = 'disk_cap_mb'
 
 WITH_COUNTS = 'with_counts'
 COUNT_WIDTH = 'count_width'
+WITH_COORDINATES = 'with_coordinates'
 
 
 class AnnotationLabelsSource(Enum):
@@ -70,3 +71,7 @@ class AnnotationFormats(Enum):
     INT_BRWT = 'int_brwt'
     ROW_DIFF_INT_BRWT = 'row_diff_int_brwt'
     ROW_DIFF_INT_DISK = 'row_diff_int_disk'
+    BRWT_COORD = 'brwt_coord'
+    ROW_DIFF_COORD = 'row_diff_coord'
+    ROW_DIFF_BRWT_COORD = 'row_diff_brwt_coord'
+    ROW_DIFF_DISK_COORD = 'row_diff_disk_coord'

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -45,10 +45,10 @@ WITH_COORDINATES = 'with_coordinates'
 
 class AnnotationLabelsSource(Enum):
     SEQUENCE_HEADERS = 'sequence_headers'
-    SEQUENCE_FILE_NAMES = 'sequence_file_names'
+    FILE_NAMES = 'file_names'
 
     def to_annotation_cmd_option(self):
-        if self == self.SEQUENCE_FILE_NAMES:
+        if self == self.FILE_NAMES:
             return '--anno-filename'
         elif self == self.SEQUENCE_HEADERS:
             return '--anno-header'

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -39,6 +39,8 @@ MEM_BUFFER_MB_KEY = 'mem_buffer_mb'
 DISK_CAP_MB_KEY = 'disk_cap_mb'
 
 GNU_TIME_CMD = 'gnu_time_cmd'
+WITH_COUNTS = 'with_counts'
+COUNT_WIDTH = 'count_width'
 
 
 class AnnotationLabelsSource(Enum):
@@ -66,3 +68,6 @@ class AnnotationFormats(Enum):
     #RELAXED_RB_BRWT = 'relax.rb_brwt' # not possible
     ROW_DIFF_BRWT = 'row_diff_brwt'
     RELAXED_ROW_DIFF_BRWT = 'relax.row_diff_brwt'
+    INT_BRWT = 'int_brwt'
+    ROW_DIFF_INT_BRWT = 'row_diff_int_brwt'
+    ROW_DIFF_INT_DISK = 'row_diff_int_disk'

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -38,7 +38,6 @@ DISK_MB_KEY = 'disk_mb'
 MEM_BUFFER_MB_KEY = 'mem_buffer_mb'
 DISK_CAP_MB_KEY = 'disk_cap_mb'
 
-GNU_TIME_CMD = 'gnu_time_cmd'
 WITH_COUNTS = 'with_counts'
 COUNT_WIDTH = 'count_width'
 

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -9,6 +9,12 @@ import metagraph_workflows
 from metagraph_workflows import cli, utils
 from metagraph_workflows.workflow_configs import AnnotationLabelsSource, \
     AnnotationFormats
+COUNT_FORMATS = {
+    AnnotationFormats.INT_BRWT,
+    AnnotationFormats.ROW_DIFF_INT_BRWT,
+    AnnotationFormats.ROW_DIFF_INT_DISK,
+}
+
 
 WORKFLOW_ROOT = Path(metagraph_workflows.__file__).parent / 'snakemake'
 
@@ -45,6 +51,8 @@ def test_build_workflow(primary, annotation_format, annotation_label_src, sample
                  '-k', 5,
                  '--annotation-format', annotation_format.value,
                  '--annotation-labels-source', annotation_label_src.value]
+    if annotation_format in COUNT_FORMATS:
+        base_args += ['--with-counts']
 
     base_args += ['--build-primary-graph'] if primary else []
 
@@ -75,3 +83,104 @@ def test_workflow_invocation_additional_args(sample_list_path, output_dir):
     assert output_dir.exists()
     assert (output_dir / "config.yaml").exists()
     assert len([f for f in output_dir.listdir() if f.check(file=1)]) == 1
+
+
+def test_with_counts_defaults_to_row_diff_int_brwt(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--with-counts',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "with_counts: true" in cfg
+    assert "annotation_formats:" in cfg
+    assert "- row_diff_int_brwt" in cfg
+
+
+def test_with_counts_rejects_incompatible_annotation_format(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--with-counts',
+        '--annotation-format', AnnotationFormats.BRWT.value,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "Count-aware mode is enabled" in proc.stdout.decode()
+
+
+def test_with_counts_respects_explicit_annotation_format(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--with-counts',
+        '--annotation-format', AnnotationFormats.INT_BRWT.value,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "- int_brwt" in cfg
+    assert "- row_diff_int_brwt" not in cfg
+
+
+def test_count_capable_format_auto_enables_with_counts(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_DISK.value,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "with_counts: true" in cfg
+    assert "- row_diff_int_disk" in cfg
+
+
+def test_build_help_mentions_defaults():
+    proc = run_wrapper(['build', '-h'])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "Default is relax.row_diff_brwt" in out
+    assert "row_diff_int_brwt" in out
+
+
+@pytest.mark.parametrize("count_width", [2, 12, 32])
+def test_count_width_is_propagated_to_count_build_steps(sample_list_path, output_dir, count_width):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
+        '--count-width', str(count_width),
+        '--dryrun',
+        '--additional-snakemake-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+
+    out = proc.stdout.decode()
+    assert "--count-kmers" in out
+    assert f"--count-width {count_width}" in out
+
+    cfg = (output_dir / "config.yaml").read()
+    assert f"count_width: {count_width}" in cfg
+    assert "with_counts: true" in cfg
+
+
+@pytest.mark.parametrize("invalid_count_width", [1, 64])
+def test_count_width_out_of_range_fails(sample_list_path, output_dir, invalid_count_width):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
+        '--count-width', str(invalid_count_width),
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "--count-width must be in range [2, 32]" in proc.stdout.decode()

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -47,27 +47,28 @@ def _resolve_metagraph_cmd() -> str | None:
 
 def run_wrapper(args_list):
     code_base = Path(os.path.realpath(__file__)).parent.parent
-    process_args = ['python', '-m', 'metagraph_workflows.cli'] + args_list
+    normalized_args = list(args_list)
+    if normalized_args and normalized_args[0] == "build":
+        has_output_flag = any(arg in ("-o", "--output_dir") for arg in normalized_args)
+        if not has_output_flag and len(normalized_args) > 1:
+            last = normalized_args[-1]
+            last_str = str(last)
+            if not last_str.startswith("-"):
+                normalized_args = normalized_args[:-1] + ["--output_dir", last]
+
+    process_args = ['python', '-m', 'metagraph_workflows.cli'] + normalized_args
 
     # If tests are running without `metagraph` on PATH, inject `--metagraph-cmd`
     # pointing to the locally built binary (when available).
-    if "--metagraph-cmd" not in args_list:
+    if "--metagraph-cmd" not in normalized_args:
         metagraph_cmd = _resolve_metagraph_cmd()
         if metagraph_cmd is None:
             pytest.skip("metagraph executable not found in PATH and local build/metagraph missing")
-        if not args_list:
+        if not normalized_args:
             pytest.skip("empty args_list passed to run_wrapper")
-        # If the last arg is an option (e.g. "-h"), don't attempt to treat it
-        # as the output_dir positional argument.
-        last = args_list[-1]
-        if isinstance(last, str) and last.startswith("-"):
-            process_args = ['python', '-m', 'metagraph_workflows.cli'] + args_list
-        else:
-            output_dir = args_list[-1]
-            base_args = args_list[:-1]
-            process_args = ['python', '-m', 'metagraph_workflows.cli'] + base_args + [
-                "--metagraph-cmd", metagraph_cmd, output_dir
-            ]
+        process_args = ['python', '-m', 'metagraph_workflows.cli'] + normalized_args + [
+            "--metagraph-cmd", metagraph_cmd
+        ]
 
     proc = subprocess.run(
         [str(a) for a in process_args],
@@ -92,20 +93,20 @@ def sample_list_path(tmpdir):
 
 
 @pytest.mark.parametrize('primary,annotation_format,annotation_label_src', list(product([False], [AnnotationFormats.ROW_DIFF_BRWT], [AnnotationLabelsSource.SEQUENCE_HEADERS])) +
-    list(product([False, True], AnnotationFormats, [AnnotationLabelsSource.SEQUENCE_FILE_NAMES])))
+    list(product([False, True], AnnotationFormats, [AnnotationLabelsSource.FILE_NAMES])))
 def test_build_workflow(primary, annotation_format, annotation_label_src, sample_list_path, output_dir):
 
     base_args = ['build',
                  '--seqs-file-list-path', sample_list_path,
                  '-k', 5,
                  '--annotation-format', annotation_format.value,
-                 '--annotation-labels-source', annotation_label_src.value]
+                 '--anno-source', annotation_label_src.value]
     if annotation_format in COUNT_FORMATS:
         base_args += ['--with-counts']
     if annotation_format in COORD_FORMATS:
         base_args += ['--with-coords']
 
-    base_args += ['--build-primary-graph'] if primary else []
+    base_args += ['--primary'] if primary else []
 
     ret = run_wrapper(base_args + [output_dir])
 
@@ -134,7 +135,7 @@ def test_workflow_invocation_additional_args(sample_list_path, output_dir):
     base_args = ['build',
                  '--seqs-file-list-path', sample_list_path,
                  '-k', 5,
-                 '--additional-snakemake-args="summary=True"']
+                 '--extra-args="summary=True"']
 
     proc = run_wrapper(base_args + [output_dir])
 
@@ -276,7 +277,7 @@ def test_build_help_mentions_defaults():
     # Argparse may insert newlines + indentation into long help strings;
     # normalize all whitespace so substring checks are stable.
     out_norm = re.sub(r'\s+', ' ', out).strip()
-    assert "Default is relax.row_diff_brwt" in out_norm
+    assert "[relax.row_diff_brwt/row_diff_int_brwt/row_diff_brwt_coord]" in out_norm
     assert "row_diff_int_brwt" in out
     assert "row_diff_brwt_coord" in out
 
@@ -299,7 +300,7 @@ def test_missing_metagraph_executable_fails_fast(sample_list_path, output_dir):
         'build',
         '--seqs-file-list-path', sample_list_path,
         '--metagraph-cmd', 'definitely_missing_metagraph_binary_12345',
-        '--additional-snakemake-args=printshellcmds=True',
+        '--extra-args=printshellcmds=True',
         output_dir,
     ])
     assert proc.returncode != 0
@@ -342,7 +343,7 @@ def test_count_width_is_propagated_to_count_build_steps(sample_list_path, output
         '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
         '--count-width', str(count_width),
         '--dryrun',
-        '--additional-snakemake-args=printshellcmds=True',
+        '--extra-args=printshellcmds=True',
         output_dir,
     ])
     assert proc.returncode == 0

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -14,6 +14,12 @@ COUNT_FORMATS = {
     AnnotationFormats.ROW_DIFF_INT_BRWT,
     AnnotationFormats.ROW_DIFF_INT_DISK,
 }
+COORD_FORMATS = {
+    AnnotationFormats.BRWT_COORD,
+    AnnotationFormats.ROW_DIFF_COORD,
+    AnnotationFormats.ROW_DIFF_BRWT_COORD,
+    AnnotationFormats.ROW_DIFF_DISK_COORD,
+}
 
 
 WORKFLOW_ROOT = Path(metagraph_workflows.__file__).parent / 'snakemake'
@@ -53,6 +59,8 @@ def test_build_workflow(primary, annotation_format, annotation_label_src, sample
                  '--annotation-labels-source', annotation_label_src.value]
     if annotation_format in COUNT_FORMATS:
         base_args += ['--with-counts']
+    if annotation_format in COORD_FORMATS:
+        base_args += ['--with-coords']
 
     base_args += ['--build-primary-graph'] if primary else []
 
@@ -113,6 +121,34 @@ def test_with_counts_rejects_incompatible_annotation_format(sample_list_path, ou
     assert "Count-aware mode is enabled" in proc.stdout.decode()
 
 
+def test_with_coordinates_defaults_to_row_diff_brwt_coord(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--with-coords',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "with_coordinates: true" in cfg
+    assert "annotation_formats:" in cfg
+    assert "- row_diff_brwt_coord" in cfg
+
+
+def test_with_coordinates_rejects_incompatible_annotation_format(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--with-coords',
+        '--annotation-format', AnnotationFormats.BRWT.value,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "Coordinate-aware mode is enabled" in proc.stdout.decode()
+
+
 def test_with_counts_respects_explicit_annotation_format(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
@@ -142,12 +178,53 @@ def test_count_capable_format_auto_enables_with_counts(sample_list_path, output_
     assert "- row_diff_int_disk" in cfg
 
 
+def test_coord_capable_format_auto_enables_with_coordinates(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "with_coordinates: true" in cfg
+    assert "- row_diff_brwt_coord" in cfg
+
+
+def test_with_counts_and_with_coordinates_are_mutually_exclusive(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--with-counts',
+        '--with-coords',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "mutually exclusive" in proc.stdout.decode()
+
+
+def test_mixed_count_and_coord_formats_are_mutually_exclusive(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
+        '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "mutually exclusive" in proc.stdout.decode()
+
+
 def test_build_help_mentions_defaults():
     proc = run_wrapper(['build', '-h'])
     assert proc.returncode == 0
     out = proc.stdout.decode()
     assert "Default is relax.row_diff_brwt" in out
     assert "row_diff_int_brwt" in out
+    assert "row_diff_brwt_coord" in out
 
 
 def test_missing_metagraph_executable_fails_fast(sample_list_path, output_dir):
@@ -155,7 +232,7 @@ def test_missing_metagraph_executable_fails_fast(sample_list_path, output_dir):
         'build',
         '--seqs-file-list-path', sample_list_path,
         '--metagraph-cmd', 'definitely_missing_metagraph_binary_12345',
-        '--dryrun',
+        '--additional-snakemake-args=printshellcmds=True',
         output_dir,
     ])
     assert proc.returncode != 0
@@ -174,6 +251,20 @@ def test_invalid_annotation_format_shows_suggestion(sample_list_path, output_dir
     out = proc.stdout.decode()
     assert "Unsupported annotation format 'row_diff_int_brwt1'" in out
     assert "Did you mean 'row_diff_int_brwt'" in out
+
+
+def test_invalid_coord_annotation_format_shows_suggestion(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotation-format', 'row_diff_brwt_coord1',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    out = proc.stdout.decode()
+    assert "Unsupported annotation format 'row_diff_brwt_coord1'" in out
+    assert "Did you mean 'row_diff_brwt_coord'" in out
 
 
 @pytest.mark.parametrize("count_width", [2, 12, 32])

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -150,6 +150,32 @@ def test_build_help_mentions_defaults():
     assert "row_diff_int_brwt" in out
 
 
+def test_missing_metagraph_executable_fails_fast(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--metagraph-cmd', 'definitely_missing_metagraph_binary_12345',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "was not found in PATH" in proc.stdout.decode()
+
+
+def test_invalid_annotation_format_shows_suggestion(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotation-format', 'row_diff_int_brwt1',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    out = proc.stdout.decode()
+    assert "Unsupported annotation format 'row_diff_int_brwt1'" in out
+    assert "Did you mean 'row_diff_int_brwt'" in out
+
+
 @pytest.mark.parametrize("count_width", [2, 12, 32])
 def test_count_width_is_propagated_to_count_build_steps(sample_list_path, output_dir, count_width):
     proc = run_wrapper([

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -1,5 +1,7 @@
 import os
 import subprocess
+import shutil
+import re
 from itertools import product
 from pathlib import Path
 
@@ -25,13 +27,54 @@ COORD_FORMATS = {
 WORKFLOW_ROOT = Path(metagraph_workflows.__file__).parent / 'snakemake'
 
 
+def _resolve_metagraph_cmd() -> str | None:
+    """Best-effort resolution of the local `metagraph` binary for tests.
+
+    Tests should normally run with a `metagraph` executable available on `PATH`.
+    When that's not the case (e.g. fresh dev environments), we fall back to
+    `../build/metagraph` if it exists.
+    """
+    if shutil.which("metagraph") is not None:
+        return None
+
+    code_base = Path(os.path.realpath(__file__)).parent.parent  # metagraph/workflows
+    repo_root = code_base.parent  # metagraph/
+    candidate = repo_root / "build" / "metagraph"
+    if candidate.exists() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
+
+
 def run_wrapper(args_list):
     code_base = Path(os.path.realpath(__file__)).parent.parent
-
     process_args = ['python', '-m', 'metagraph_workflows.cli'] + args_list
 
-    proc = subprocess.run([str(a) for a in process_args],
-                          cwd=code_base, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    # If tests are running without `metagraph` on PATH, inject `--metagraph-cmd`
+    # pointing to the locally built binary (when available).
+    if "--metagraph-cmd" not in args_list:
+        metagraph_cmd = _resolve_metagraph_cmd()
+        if metagraph_cmd is None:
+            pytest.skip("metagraph executable not found in PATH and local build/metagraph missing")
+        if not args_list:
+            pytest.skip("empty args_list passed to run_wrapper")
+        # If the last arg is an option (e.g. "-h"), don't attempt to treat it
+        # as the output_dir positional argument.
+        last = args_list[-1]
+        if isinstance(last, str) and last.startswith("-"):
+            process_args = ['python', '-m', 'metagraph_workflows.cli'] + args_list
+        else:
+            output_dir = args_list[-1]
+            base_args = args_list[:-1]
+            process_args = ['python', '-m', 'metagraph_workflows.cli'] + base_args + [
+                "--metagraph-cmd", metagraph_cmd, output_dir
+            ]
+
+    proc = subprocess.run(
+        [str(a) for a in process_args],
+        cwd=code_base,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
 
     return proc
 
@@ -76,7 +119,15 @@ def test_build_workflow(primary, annotation_format, annotation_label_src, sample
 
 
 def test_workflow_invocation_via_python(sample_list_path, output_dir):
-    assert cli.run_build_workflow(output_dir, seqs_file_list_path=sample_list_path) is None
+    metagraph_cmd = _resolve_metagraph_cmd()
+    if metagraph_cmd is None and shutil.which("metagraph") is None:
+        pytest.skip("metagraph executable not found in PATH and local build/metagraph missing")
+
+    assert cli.run_build_workflow(
+        output_dir,
+        seqs_file_list_path=sample_list_path,
+        metagraph_cmd=metagraph_cmd,
+    ) is None
 
 
 def test_workflow_invocation_additional_args(sample_list_path, output_dir):
@@ -222,9 +273,25 @@ def test_build_help_mentions_defaults():
     proc = run_wrapper(['build', '-h'])
     assert proc.returncode == 0
     out = proc.stdout.decode()
-    assert "Default is relax.row_diff_brwt" in out
+    # Argparse may insert newlines + indentation into long help strings;
+    # normalize all whitespace so substring checks are stable.
+    out_norm = re.sub(r'\s+', ' ', out).strip()
+    assert "Default is relax.row_diff_brwt" in out_norm
     assert "row_diff_int_brwt" in out
     assert "row_diff_brwt_coord" in out
+
+
+def test_dryrun_prints_summary(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "=== Workflow summary ===" in out
+    assert "Mode: dry-run" in out
 
 
 def test_missing_metagraph_executable_fails_fast(sample_list_path, output_dir):

--- a/metagraph/workflows/tests/test_utils.py
+++ b/metagraph/workflows/tests/test_utils.py
@@ -1,4 +1,6 @@
 import pytest
+import sys
+import subprocess
 
 import metagraph_workflows.utils
 
@@ -13,3 +15,38 @@ import metagraph_workflows.utils
 )
 def test_get_sample_name(case, expected):
     assert metagraph_workflows.utils.get_sample_name(case) == expected
+
+
+def test_get_gnu_time_command_uses_python_wrapper():
+    cmd = metagraph_workflows.utils.get_gnu_time_command({})
+    assert "metagraph_workflows.time_wrapper" in cmd
+
+
+def test_get_time_wrapper_command_uses_python_wrapper():
+    cmd = metagraph_workflows.utils.get_time_wrapper_command({})
+    assert "metagraph_workflows.time_wrapper" in cmd
+
+
+def test_time_wrapper_success_prints_timing():
+    proc = subprocess.run(
+        [sys.executable, "-m", "metagraph_workflows.time_wrapper", "--", sys.executable, "-c", "print('ok')"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 0
+    assert "ok" in proc.stdout
+    assert "[timing] wall_sec=" in proc.stderr
+
+
+def test_time_wrapper_missing_command_returns_127():
+    proc = subprocess.run(
+        [sys.executable, "-m", "metagraph_workflows.time_wrapper", "--", "definitely_missing_binary_12345"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    assert proc.returncode == 127
+    assert "[timing] failed_to_exec=" in proc.stderr


### PR DESCRIPTION
**Full index in one shot** — `metagraph-workflows build` alone drives graph construction, per-sample column annotations, optional row-diff with counts or coordinates, and the final merged annotation format. The workflow DAG wires intermediate artifacts (including row-diff sidecars) so you don’t have to chain separate scripts or patch holes between stages.


## Summary

- Adds count-aware and coordinate-aware workflow modes to `metagraph-workflows build` with proper defaults, validation, and mutual-exclusion checks.
- Improves failure UX by showing concise root cause, failing command, and relevant metagraph stderr.
- Replaces GNU `time` usage with a portable Python timing wrapper.
- Improves run summary output (human-readable times, RAM in GB, final vs intermediate artifacts).
- Tightens row-diff stage dependency/cleanup handling in Snakemake.
- Updates docs and tests accordingly.