### PR TITLE
metagraph-workflows: unify pipeline under a single build command

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Useful switches:
 - `--mem-gb GB` — approximate RAM budget per rule (default 16)
 - `--disk-swap-dir DIR` — directory for on-disk spill buffers
 - `--primary` — build a primary graph (recommended for most workloads)
-- `--annotation-format FMT` — request a specific annotation format
+- `--anno-type FMT` — request a specific annotation format
   (repeat for multiple outputs); the default is `relax.row_diff_brwt`
 - `--with-counts` / `--with-coords` — count- or coordinate-aware
   annotation (mutually exclusive)

--- a/README.md
+++ b/README.md
@@ -103,6 +103,50 @@ All different versions of the container image are listed [here](https://github.c
 To compile from source (e.g., for builds with custom alphabet or other configurations), see [documentation online](https://metagraph.ethz.ch/static/docs/installation.html#install-from-source).
 
 
+## Quick start: build an index in one command
+
+For most users, the easiest entry point is the Snakemake wrapper, which
+runs the full indexing pipeline — graph construction, annotation, and
+all row-diff / BRWT transforms — as a single command:
+
+```bash
+metagraph-workflows build samples.txt -o out/ --primary
+```
+
+`samples.txt` is a text file listing your input sample paths (one per
+line); a directory of sample files works just as well. `out/` will
+contain `graph.dbg`, `graph_small.dbg`, and the requested annotation
+artifacts. You can also feed a list inline with process substitution:
+
+```bash
+metagraph-workflows build <(ls /data/samples/*.fa) -o out/ --primary
+```
+
+Tell the workflow how much hardware to use; everything else (memory
+caps per stage, per-column buffer sizing, BRWT clustering parameters)
+is derived automatically:
+
+```bash
+metagraph-workflows build samples.txt -o out/ --primary \
+  --threads 34 --mem-gb 70 --disk-swap-dir /scratch/swap
+```
+
+Useful switches:
+- `--threads N` — maximum CPU cores to use (defaults to all cores)
+- `--mem-gb GB` — approximate RAM budget per rule (default 16)
+- `--disk-swap-dir DIR` — directory for on-disk spill buffers
+- `--primary` — build a primary graph (recommended for most workloads)
+- `--annotation-format FMT` — request a specific annotation format
+  (repeat for multiple outputs); the default is `relax.row_diff_brwt`
+- `--with-counts` / `--with-coords` — count- or coordinate-aware
+  annotation (mutually exclusive)
+- `--graph EXISTING.dbg` — reuse an already-built graph and only run
+  the annotation + transforms
+
+See `metagraph/workflows/README.rst` for setup and the full option
+list (`metagraph-workflows build --help`).
+
+
 ## Typical workflow
 1. Build de Bruijn graph from Fasta files, FastQ files, or [KMC k-mer counters](https://github.com/refresh-bio/KMC/):\
 `./metagraph build`

--- a/README.md
+++ b/README.md
@@ -107,7 +107,18 @@ To compile from source (e.g., for builds with custom alphabet or other configura
 
 For most users, the easiest entry point is the Snakemake wrapper, which
 runs the full indexing pipeline — graph construction, annotation, and
-all row-diff / BRWT transforms — as a single command:
+all row-diff / BRWT transforms — as a single command.
+
+The wrapper ships as a separate Python package; the `metagraph` conda
+recipe only installs the C++ binary, so the workflow CLI needs an extra
+`pip install` step:
+
+```bash
+conda install -c bioconda -c conda-forge metagraph     # the metagraph binary
+pip install -U "git+https://github.com/ratschlab/metagraph.git#subdirectory=metagraph/workflows"
+```
+
+Then run the full pipeline as:
 
 ```bash
 metagraph-workflows build samples.txt -o out/ --primary

--- a/README.md
+++ b/README.md
@@ -139,11 +139,11 @@ is derived automatically:
 
 ```bash
 metagraph-workflows build samples.txt -o out/ --primary \
-  --threads 34 --mem-gb 70 --disk-swap-dir /scratch/swap
+  -p 34 --mem-gb 70 --disk-swap-dir /scratch/swap
 ```
 
 Useful switches:
-- `--threads N` — maximum CPU cores to use (defaults to all cores)
+- `-p N` — maximum CPU cores to use (defaults to all cores)
 - `--mem-gb GB` — approximate RAM budget per rule (default 16)
 - `--disk-swap-dir DIR` — directory for on-disk spill buffers
 - `--primary` — build a primary graph (recommended for most workloads)

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -24,20 +24,25 @@ Set up a conda environment and install the necessary packages using:
 Creating graphs and annotations
 -------------------------------
 
-Given some raw sequencing data and a few options like the k-mer length, graphs and annotations
-are automatically built::
+A single command runs the full pipeline — graph construction,
+annotation, and all row-diff / BRWT transforms — for a set of samples::
 
-    metagraph-workflows build -k 5 transcript_paths.txt /tmp/mygraph
+    metagraph-workflows build samples.txt -o /tmp/mygraph --primary
+
+``samples.txt`` is a text file listing input paths (one per line); a
+directory of sample files also works. Process substitution is supported
+too, so you can pipe a glob inline::
+
+    metagraph-workflows build <(ls /data/samples/*.fa) -o /tmp/mygraph --primary
 
 
-The same pipeline can be invoked from within a python script:
+The same pipeline can be invoked from a Python script:
 
 .. code-block:: python
 
-    from metagraph_workflows import workflows
+    from metagraph_workflows import cli
 
-    workflows.run_build_workflow('/tmp/mygraph', seqs_file_list_path='transcript_paths.txt', k=5)
-
+    cli.run_workflow('/tmp/mygraph', samples='samples.txt', k=31, build_primary_graph=True)
 
 
 The pipelines are written in the `Snakemake <https://snakemake.readthedocs.io/>`__ workflow management system and can also be directly invoked using the ``snakemake`` command line tool (see below).
@@ -48,23 +53,32 @@ Usage
 
 Typically, the following steps would be performed:
 
-1. Prepare a list of files for indexing.
-2. Construct a MetaGraph index: invoke a workflow using ``metagraph-workflows build``. Important parameters you may consider tuning are:
+1. Prepare a list of input files (or a directory).
+2. Construct a MetaGraph index: invoke ``metagraph-workflows build``.
+   Tell the workflow how much hardware is available and what kind of
+   index you want; the per-stage memory caps, thread packing, and
+   BRWT clustering parameters are derived automatically.
 
-   * k-mer length
-   * basic vs. primary graph mode
-   * source of annotation labels: ``sequence_headers`` or ``file_names``
-   * count-aware annotation mode and format selection
+   Important parameters you may want to set:
+
+   * ``--threads N`` and ``--mem-gb GB`` for the hardware budget
+   * ``-k`` for k-mer length (default 31)
+   * ``--primary`` for primary graph mode (recommended for most workloads)
+   * ``--disk-swap-dir DIR`` to enable on-disk spill buffers
+   * ``--anno-source`` (``sequence_headers`` or ``file_names``)
+   * ``--annotation-format FMT`` to choose / add output annotation formats
+   * ``--with-counts`` or ``--with-coords`` for count- / coordinate-aware
+     annotation (mutually exclusive)
+   * ``--graph EXISTING.dbg`` to reuse an already-built graph and run
+     only the annotation + transform stages
 
    An example invocation:
 
    .. code-block:: bash
 
-     metagraph-workflows build -k 31 \
-                               --seqs-dir-path [PATH_TO_FILES] \
-                               --anno-source sequence_headers \
-                               --primary \
-                               -o [OUTPUT_DIR]
+     metagraph-workflows build samples.txt -o /tmp/mygraph \
+         -k 31 --primary --anno-source sequence_headers \
+         --threads 34 --mem-gb 70 --disk-swap-dir /scratch/swap
 
 Count-aware annotations
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -78,22 +92,14 @@ The workflow supports these count-aware annotation formats:
 To enable counts explicitly, pass ``--with-counts``. If no annotation format is specified,
 the default switches from ``relax.row_diff_brwt`` to ``row_diff_int_brwt``::
 
-    metagraph-workflows build -k 31 \
-                              --seqs-file-list-path transcript_paths.txt \
-                              --primary \
-                              --with-counts \
-                              --count-width 12 \
-                              -o [OUTPUT_DIR]
+    metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
+        -k 31 --primary --with-counts --count-width 12
 
 You can also select a count-aware format directly via ``--annotation-format``; this
 automatically enables count-aware mode::
 
-    metagraph-workflows build -k 31 \
-                              --seqs-file-list-path transcript_paths.txt \
-                              --primary \
-                              --annotation-format row_diff_int_brwt \
-                              --count-width 12 \
-                              -o [OUTPUT_DIR]
+    metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
+        -k 31 --primary --annotation-format row_diff_int_brwt --count-width 12
 
 Use ``--count-width`` to control the stored numeric range for counts
 (valid range: ``2..32``, default: ``8``).
@@ -114,18 +120,14 @@ The workflow supports these coordinate-aware annotation formats:
 To enable coordinates explicitly, pass ``--with-coords``. If no annotation format is specified,
 the default switches from ``relax.row_diff_brwt`` to ``row_diff_brwt_coord``::
 
-    metagraph-workflows build -k 31 \
-                              --seqs-file-list-path transcript_paths.txt \
-                              --with-coords \
-                              -o [OUTPUT_DIR]
+    metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
+        -k 31 --with-coords
 
 You can also select a coordinate-aware format directly via ``--annotation-format``; this
 automatically enables coordinate-aware mode::
 
-    metagraph-workflows build -k 31 \
-                              --seqs-file-list-path transcript_paths.txt \
-                              --annotation-format row_diff_brwt_coord \
-                              -o [OUTPUT_DIR]
+    metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
+        -k 31 --annotation-format row_diff_brwt_coord
 
 Coordinates are typically indexed for reference sequences, where preserving the original sequence context is important.
 For this use case, primary graph mode is usually not recommended.

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -10,15 +10,19 @@ for the most common scenarios.
 Installation
 ------------
 
-
-Set up a conda environment and install the necessary packages using:
+The ``metagraph-workflows`` CLI ships as a separate Python package. The
+``metagraph`` conda recipe only installs the C++ binary, so the workflow
+wrapper needs an extra ``pip install`` step alongside it:
 
 .. code-block:: bash
 
    conda create -n metagraph-workflows python=3.8
    conda activate metagraph-workflows
-   conda install -c bioconda -c conda-forge metagraph
+   conda install -c bioconda -c conda-forge metagraph       # the metagraph binary
    pip install -U "git+https://github.com/ratschlab/metagraph.git#subdirectory=metagraph/workflows"
+
+After this, the ``metagraph`` binary and the ``metagraph-workflows``
+command are both available on ``PATH``.
 
 
 Creating graphs and annotations

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -138,16 +138,21 @@ For this use case, primary graph mode is usually not recommended.
 
 When coordinate-aware annotation is built with ``--anno-source filename``
 (the default; one column per input file), the workflow additionally builds
-a ``CoordToHeader`` sidecar (``<graph>.<format>.seqs``) for each requested
-coord format. This is a second ``metagraph annotate --index-header-coords``
-pass over the input fastas; the pass uses the column order recovered from
-the final annotation via ``metagraph stats --print-col-names`` so that file
-labels and coord offsets stay aligned even after BRWT clustering reorders
-columns. The sidecar lets ``metagraph query --query-mode coords`` and
-``metagraph align`` report hits as ``<header>/<N>:<positions>`` instead of
-file-based coordinates. In ``--anno-source header`` mode each sequence
-already has its own column, so no sidecar is needed and the rule is
-skipped.
+a ``CoordToHeader`` sidecar at ``<graph>.seqs``. This is a second
+``metagraph annotate --index-header-coords`` pass over the input fastas;
+the pass uses the column order recovered from the final annotation via
+``metagraph stats --print-col-names`` so that file labels and coord
+offsets stay aligned even after BRWT clustering reorders columns. The
+sidecar lets ``metagraph query --query-mode coords`` and ``metagraph
+align`` report hits as ``<header>/<N>:<positions>`` instead of file-based
+coordinates. In ``--anno-source header`` mode each sequence already has
+its own column, so no sidecar is needed and the rule is skipped.
+
+The loader always looks at ``<graph>.seqs`` (it strips the full
+annotation extension and appends ``.seqs``), so a single sidecar is
+emitted regardless of how many coord formats are requested. When
+multiple are requested, the sidecar is derived from the first one in
+the list -- pick that format when querying with coords.
 
 Count-aware and coordinate-aware modes are mutually exclusive in this workflow.
 

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -65,7 +65,7 @@ Typically, the following steps would be performed:
 
    Important parameters you may want to set:
 
-   * ``--threads N`` and ``--mem-gb GB`` for the hardware budget
+   * ``-p N`` and ``--mem-gb GB`` for the hardware budget
    * ``-k`` for k-mer length (default 31)
    * ``--primary`` for primary graph mode (recommended for most workloads)
    * ``--disk-swap-dir DIR`` to enable on-disk spill buffers
@@ -82,7 +82,7 @@ Typically, the following steps would be performed:
 
      metagraph-workflows build samples.txt -o /tmp/mygraph \
          -k 31 --primary \
-         --threads 34 --mem-gb 70 --disk-swap-dir /scratch/swap
+         -p 34 --mem-gb 70 --disk-swap-dir /scratch/swap
 
 Count-aware annotations
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -69,7 +69,7 @@ Typically, the following steps would be performed:
    * ``-k`` for k-mer length (default 31)
    * ``--primary`` for primary graph mode (recommended for most workloads)
    * ``--disk-swap-dir DIR`` to enable on-disk spill buffers
-   * ``--anno-source`` (``sequence_headers`` or ``file_names``)
+   * ``--anno-source`` (``header`` or ``filename``; default ``filename``)
    * ``--annotation-format FMT`` to choose / add output annotation formats
    * ``--with-counts`` or ``--with-coords`` for count- / coordinate-aware
      annotation (mutually exclusive)
@@ -81,7 +81,7 @@ Typically, the following steps would be performed:
    .. code-block:: bash
 
      metagraph-workflows build samples.txt -o /tmp/mygraph \
-         -k 31 --primary --anno-source sequence_headers \
+         -k 31 --primary \
          --threads 34 --mem-gb 70 --disk-swap-dir /scratch/swap
 
 Count-aware annotations
@@ -136,18 +136,18 @@ automatically enables coordinate-aware mode::
 Coordinates are typically indexed for reference sequences, where preserving the original sequence context is important.
 For this use case, primary graph mode is usually not recommended.
 
-When coordinate-aware annotation is built with ``--anno-source file_names``
-(i.e. one column per input file), the workflow additionally builds a
-``CoordToHeader`` sidecar (``<graph>.<format>.seqs``) for each requested
+When coordinate-aware annotation is built with ``--anno-source filename``
+(the default; one column per input file), the workflow additionally builds
+a ``CoordToHeader`` sidecar (``<graph>.<format>.seqs``) for each requested
 coord format. This is a second ``metagraph annotate --index-header-coords``
 pass over the input fastas; the pass uses the column order recovered from
 the final annotation via ``metagraph stats --print-col-names`` so that file
 labels and coord offsets stay aligned even after BRWT clustering reorders
 columns. The sidecar lets ``metagraph query --query-mode coords`` and
 ``metagraph align`` report hits as ``<header>/<N>:<positions>`` instead of
-file-based coordinates. In ``--anno-source sequence_headers`` mode each
-sequence already has its own column, so no sidecar is needed and the rule
-is skipped.
+file-based coordinates. In ``--anno-source header`` mode each sequence
+already has its own column, so no sidecar is needed and the rule is
+skipped.
 
 Count-aware and coordinate-aware modes are mutually exclusive in this workflow.
 
@@ -194,4 +194,4 @@ directly invoke the snakemake workflow (assuming you checked out the `metagraph 
     cd metagraph/workflows
     snakemake --forceall --configfile default.yml \
         --config k=5 seqs_file_list_path='transcript_paths.txt' output_directory=/tmp/mygraph \
-        annotation_labels_source=sequence_headers --cores 2
+        annotation_labels_source=header --cores 2

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -70,7 +70,7 @@ Typically, the following steps would be performed:
    * ``--primary`` for primary graph mode (recommended for most workloads)
    * ``--disk-swap-dir DIR`` to enable on-disk spill buffers
    * ``--anno-source`` (``header`` or ``filename``; default ``filename``)
-   * ``--annotation-format FMT`` to choose / add output annotation formats
+   * ``--anno-type FMT`` to choose / add output annotation formats
    * ``--with-counts`` or ``--with-coords`` for count- / coordinate-aware
      annotation (mutually exclusive)
    * ``--graph EXISTING.dbg`` to reuse an already-built graph and run
@@ -99,11 +99,11 @@ the default switches from ``relax.row_diff_brwt`` to ``row_diff_int_brwt``::
     metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
         -k 31 --primary --with-counts --count-width 12
 
-You can also select a count-aware format directly via ``--annotation-format``; this
+You can also select a count-aware format directly via ``--anno-type``; this
 automatically enables count-aware mode::
 
     metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
-        -k 31 --primary --annotation-format row_diff_int_brwt --count-width 12
+        -k 31 --primary --anno-type row_diff_int_brwt --count-width 12
 
 Use ``--count-width`` to control the stored numeric range for counts
 (valid range: ``2..32``, default: ``8``).
@@ -127,11 +127,11 @@ the default switches from ``relax.row_diff_brwt`` to ``row_diff_brwt_coord``::
     metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
         -k 31 --with-coords
 
-You can also select a coordinate-aware format directly via ``--annotation-format``; this
+You can also select a coordinate-aware format directly via ``--anno-type``; this
 automatically enables coordinate-aware mode::
 
     metagraph-workflows build transcript_paths.txt -o [OUTPUT_DIR] \
-        -k 31 --annotation-format row_diff_brwt_coord
+        -k 31 --anno-type row_diff_brwt_coord
 
 Coordinates are typically indexed for reference sequences, where preserving the original sequence context is important.
 For this use case, primary graph mode is usually not recommended.

--- a/metagraph/docs/source/workflows.rst
+++ b/metagraph/docs/source/workflows.rst
@@ -136,6 +136,19 @@ automatically enables coordinate-aware mode::
 Coordinates are typically indexed for reference sequences, where preserving the original sequence context is important.
 For this use case, primary graph mode is usually not recommended.
 
+When coordinate-aware annotation is built with ``--anno-source file_names``
+(i.e. one column per input file), the workflow additionally builds a
+``CoordToHeader`` sidecar (``<graph>.<format>.seqs``) for each requested
+coord format. This is a second ``metagraph annotate --index-header-coords``
+pass over the input fastas; the pass uses the column order recovered from
+the final annotation via ``metagraph stats --print-col-names`` so that file
+labels and coord offsets stay aligned even after BRWT clustering reorders
+columns. The sidecar lets ``metagraph query --query-mode coords`` and
+``metagraph align`` report hits as ``<header>/<N>:<positions>`` instead of
+file-based coordinates. In ``--anno-source sequence_headers`` mode each
+sequence already has its own column, so no sidecar is needed and the rule
+is skipped.
+
 Count-aware and coordinate-aware modes are mutually exclusive in this workflow.
 
 Row-diff transform outputs

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -976,62 +976,6 @@ def init_build(args):
     )
 
 
-def setup_annotate_parser(parser):
-    parser.description = (
-        "Annotate an existing MetaGraph graph: run column annotation and the\n"
-        "row-diff / BRWT transforms against a caller-supplied .dbg file. Skips\n"
-        "the build pipeline.\n"
-        "\n"
-        "Inputs are assumed to be contigs with deduplicated k-mers (one fasta.gz\n"
-        "per sample); when --graph is a primary graph, they must be primary\n"
-        "contigs. For --with-coords, inputs must instead be the full,\n"
-        "non-deduplicated samples."
-    )
-    parser.epilog = (
-        "Examples:\n"
-        "  metagraph-workflows annotate --graph mouse.dbg files.txt -o out/"
-    )
-
-    io_group = parser.add_argument_group('input/output')
-    io_group.add_argument('--graph', type=Path, required=True, metavar='PATH',
-                          help='Existing .dbg graph to annotate (must already be built) [required]')
-    _add_seq_input_args(io_group)
-    io_group.add_argument('--base-name', default='graph', metavar='NAME',
-                          help='Base output name (annotations are <NAME>.<fmt>.annodbg) [graph]')
-
-    _add_annotation_args(parser.add_argument_group('annotation'))
-    _add_workflow_args(parser.add_argument_group('other'))
-    _add_help_arg(parser)
-
-    parser.set_defaults(func=init_annotate)
-
-
-def init_annotate(args):
-    run_annotate_workflow(
-        args.output_dir,
-        graph=args.graph,
-        samples=args.samples,
-        base_name=args.base_name,
-        annotation_formats=[_parse_annotation_format_value(af) for af in args.annotation_format],
-        annotation_labels_source=args.annotation_labels_source,
-        with_counts=args.with_counts,
-        with_coordinates=args.with_coordinates,
-        count_width=args.count_width,
-        annotate_threads_each=args.annotate_threads_each,
-        disk_swap_dir=args.disk_swap_dir,
-        mem_gb=args.mem_gb,
-        brwt_subsample=args.brwt_subsample,
-        metagraph_cmd=args.metagraph_cmd,
-        threads=args.threads,
-        force=args.force,
-        verbose=args.verbose,
-        dryrun=args.dryrun,
-        additional_snakemake_args=_parse_additional_snakemake_args(
-            getattr(args, "additional_snakemake_args", "")
-        )
-    )
-
-
 def main(args=tuple(sys.argv[1:])):
     parser = argparse.ArgumentParser(
         description='MetaGraph workflow utilities',
@@ -1052,14 +996,6 @@ def main(args=tuple(sys.argv[1:])):
         add_help=False,
     )
     setup_build_parser(build_parser)
-
-    annotate_parser = subparsers.add_parser(
-        "annotate",
-        help="Annotate an existing graph (skip the build pipeline)",
-        formatter_class=_help_formatter,
-        add_help=False,
-    )
-    setup_annotate_parser(annotate_parser)
 
     parsed_arguments = parser.parse_args(args)
 

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -658,6 +658,8 @@ def run_workflow(
         force: bool = False,
         verbose: bool = False,
         dryrun: bool = False,
+        keep_columns: bool = False,
+        keep_rd_columns: bool = False,
         additional_snakemake_args: Optional[Dict[str, Any]] = None,
 ) -> None:
     """Run the metagraph-workflows pipeline.
@@ -690,6 +692,8 @@ def run_workflow(
                               with_counts, with_coordinates, count_width)
     _apply_runtime_options(config, output_dir, threads, annotate_threads_each, metagraph_cmd,
                            disk_swap_dir, mem_gb, brwt_subsample, dryrun)
+    config['keep_columns'] = keep_columns
+    config['keep_rd_columns'] = keep_rd_columns
 
     if graph is not None:
         # Symlink the user's graph as <base_name>.dbg so downstream
@@ -855,6 +859,13 @@ def _add_workflow_args(workflow):
     workflow.add_argument('--brwt-subsample', type=_int_or_sci, default=None, metavar='N',
                           help='Number of bits subsampled for distance estimation when clustering BRWT\n'
                                '  columns (passed as --subsample to transform_anno --anno-type *_brwt*) [1e6]')
+    workflow.add_argument('--keep-columns', default=False, action='store_true',
+                          help='Keep per-sample column annotations (columns.<mode>/) after the\n'
+                               '  final annotation is built [False]')
+    workflow.add_argument('--keep-rd-columns', default=False, action='store_true',
+                          help='Keep per-sample row-diff column annotations (rd_cols.<mode>/) and\n'
+                               '  the rd_succ / anchors graph sidecars, so the BRWT clustering\n'
+                               '  step can be re-run with different parameters [False]')
 
 
 def _add_help_arg(parser):
@@ -978,6 +989,8 @@ def init_build(args):
         force=args.force,
         verbose=args.verbose,
         dryrun=args.dryrun,
+        keep_columns=args.keep_columns,
+        keep_rd_columns=args.keep_rd_columns,
         additional_snakemake_args=_parse_additional_snakemake_args(args.additional_snakemake_args),
     )
 

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -830,7 +830,7 @@ def _add_workflow_args(workflow):
                           help='Directory for on-disk buffers; omit to stay in RAM [none]')
     workflow.add_argument('--mem-gb', type=float, default=None,
                           metavar='GB',
-                          help='Approximate RAM budget in GB [16]')
+                          help='Approximate RAM budget in GB; used to derive --mem-cap-gb for each stage [16]')
     workflow.add_argument('--anno-threads-each', dest='annotate_threads_each',
                           type=int, default=None, metavar='N',
                           help='Threads used to annotate each input file. Parallel columns = ceil(--threads / N);\n'

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -615,8 +615,8 @@ def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd
             raise ValueError(f"--mem-gb must be > 0, got {mem_gb}")
         config['max_memory_mb'] = int(mem_gb * 1024)
     if brwt_subsample is not None:
-        if brwt_subsample < 1:
-            raise ValueError(f"--brwt-subsample must be >= 1, got {brwt_subsample}")
+        if brwt_subsample < 1000:
+            raise ValueError(f"--brwt-subsample must be >= 1000, got {brwt_subsample}")
         config['brwt_linkage_subsample'] = brwt_subsample
 
 

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -796,7 +796,7 @@ def _add_workflow_args(workflow):
                           help='Approximate RAM budget per rule (in GB); drives the auto --mem-cap-gb\n'
                                '  passed to each metagraph stage. [16]')
     workflow.add_argument('--annotate-threads-each', type=int, default=None, metavar='N',
-                          help='Threads used to annotate each input file. Parallel columns = --threads // N;\n'
+                          help='Threads used to annotate each input file. Parallel columns = ceil(--threads / N);\n'
                                '  raise N to give each column more --mem-cap-gb buffer.\n'
                                '  [8 for binary/counts, 16 for coords]')
     workflow.add_argument('--brwt-subsample', type=int, default=None, metavar='N',

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -830,8 +830,7 @@ def _add_workflow_args(workflow):
                           help='Directory for on-disk buffers; omit to stay in RAM [none]')
     workflow.add_argument('--mem-gb', type=float, default=None,
                           metavar='GB',
-                          help='Approximate RAM budget per rule (in GB); drives the auto --mem-cap-gb\n'
-                               '  passed to each metagraph stage. [16]')
+                          help='Approximate RAM budget in GB [16]')
     workflow.add_argument('--anno-threads-each', dest='annotate_threads_each',
                           type=int, default=None, metavar='N',
                           help='Threads used to annotate each input file. Parallel columns = ceil(--threads / N);\n'

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -480,6 +480,83 @@ def _summarize_snakemake_failure_for_run(output_dir: Path, run_started_at: float
     return "Workflow execution failed.\n" + "\n".join(details)
 
 
+def _apply_annotation_options(config, annotation_formats, annotation_labels_source,
+                              with_counts, with_coordinates, count_width):
+    """Apply annotation-related fields to config; raise on incompatible options."""
+    if annotation_labels_source:
+        config['annotation_labels_source'] = annotation_labels_source.value
+
+    selected = set(annotation_formats)
+    has_count = any(af in COUNT_COMPATIBLE_FORMATS for af in selected)
+    has_coord = any(af in COORD_COMPATIBLE_FORMATS for af in selected)
+    effective_counts = with_counts or has_count
+    effective_coords = with_coordinates or has_coord
+
+    if effective_counts and effective_coords:
+        raise ValueError(
+            "Count-aware and coordinate-aware modes are mutually exclusive in this workflow. "
+            "Choose either count formats (--with-counts / int_* / row_diff_int_*) or "
+            "coordinate formats (--with-coords / *_coord)."
+        )
+
+    if effective_counts and not annotation_formats:
+        config['annotation_formats'] = [AnnotationFormats.ROW_DIFF_INT_BRWT.value]
+    elif effective_coords and not annotation_formats:
+        config['annotation_formats'] = [AnnotationFormats.ROW_DIFF_BRWT_COORD.value]
+    elif annotation_formats:
+        config['annotation_formats'] = [af.value for af in annotation_formats]
+    # else: keep whatever default.yml provided.
+
+    if effective_counts:
+        invalid = [af.value for af in annotation_formats if af not in COUNT_COMPATIBLE_FORMATS]
+        if invalid:
+            raise ValueError(
+                "Count-aware mode is enabled (--with-counts or count-capable --annotation-format), "
+                "--annotation-format must be one of: "
+                + ", ".join(sorted([f.value for f in COUNT_COMPATIBLE_FORMATS]))
+                + f". Got: {', '.join(invalid)}"
+            )
+    if effective_coords:
+        invalid = [af.value for af in annotation_formats if af not in COORD_COMPATIBLE_FORMATS]
+        if invalid:
+            raise ValueError(
+                "Coordinate-aware mode is enabled (--with-coords or *_coord --annotation-format), "
+                "--annotation-format must be one of: "
+                + ", ".join(sorted([f.value for f in COORD_COMPATIBLE_FORMATS]))
+                + f". Got: {', '.join(invalid)}"
+            )
+
+    config['with_counts'] = effective_counts
+    config['with_coordinates'] = effective_coords
+    if count_width is not None:
+        if not (2 <= count_width <= 32):
+            raise ValueError(f"--count-width must be in range [2, 32], got {count_width}")
+        if not effective_counts:
+            raise ValueError(
+                "--count-width can only be used with count-aware mode (--with-counts or count formats).")
+        config['count_width'] = count_width
+
+
+def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
+                           disk_swap_dir, mem_cap_gb, dryrun):
+    """Apply runtime / resource fields to config; raise on invalid values."""
+    config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
+    if not dryrun:
+        _validate_metagraph_cmd(config['metagraph_cmd'])
+    config['max_threads'] = threads if threads else _default_threads_auto()
+    if annotate_threads_each is not None:
+        if annotate_threads_each < 1:
+            raise ValueError(
+                f"--annotate-threads-each must be >= 1, got {annotate_threads_each}")
+        config['annotate_threads_each'] = annotate_threads_each
+    if disk_swap_dir is not None:
+        config['tmpdir'] = str(disk_swap_dir)
+    if mem_cap_gb is not None:
+        if mem_cap_gb <= 0:
+            raise ValueError(f"--mem-cap-gb must be > 0, got {mem_cap_gb}")
+        config['max_memory_mb'] = int(mem_cap_gb * 1024)
+
+
 def run_build_workflow(
         output_dir: Path,
         seqs_file_list_path: Optional[Path] = None,
@@ -502,10 +579,6 @@ def run_build_workflow(
         dryrun: bool = False,
         additional_snakemake_args: Optional[Dict[str, Any]] = None
 ) -> None:
-    # TODO: support str argumt?
-
-    snakefile_path = Path(WORKFLOW_ROOT / 'Snakefile')
-
     with open(default_path, 'r') as f:
         config = yaml.safe_load(f)
 
@@ -518,80 +591,26 @@ def run_build_workflow(
         config[SEQS_DIR_PATH] = str(seqs_dir_path)
 
     config['output_directory'] = str(output_dir)
-
     config['k'] = k if k else config['k']
-
-    if annotation_labels_source:
-        config['annotation_labels_source'] = annotation_labels_source.value
-
     config['base_name'] = base_name if base_name else config['base_name']
     config['build_primary_graph'] = build_primary_graph
 
-    selected_formats = set(annotation_formats)
-    has_count_formats = any(af in COUNT_COMPATIBLE_FORMATS for af in selected_formats)
-    has_coord_formats = any(af in COORD_COMPATIBLE_FORMATS for af in selected_formats)
-    effective_with_counts = with_counts or has_count_formats
-    effective_with_coordinates = with_coordinates or has_coord_formats
+    _apply_annotation_options(config, annotation_formats, annotation_labels_source,
+                              with_counts, with_coordinates, count_width)
+    _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
+                           disk_swap_dir, mem_cap_gb, dryrun)
 
-    if effective_with_counts and effective_with_coordinates:
-        raise ValueError(
-            "Count-aware and coordinate-aware modes are mutually exclusive in this workflow. "
-            "Choose either count formats (--with-counts / int_* / row_diff_int_*) or "
-            "coordinate formats (--with-coords / *_coord)."
-        )
+    _invoke_snakemake(config, output_dir, threads=threads, force=force,
+                      dryrun=dryrun, verbose=verbose,
+                      additional_snakemake_args=additional_snakemake_args)
 
-    if effective_with_counts and not annotation_formats:
-        config['annotation_formats'] = [AnnotationFormats.ROW_DIFF_INT_BRWT.value]
-    elif effective_with_coordinates and not annotation_formats:
-        config['annotation_formats'] = [AnnotationFormats.ROW_DIFF_BRWT_COORD.value]
-    else:
-        config['annotation_formats'] = [af.value for af in
-                                        annotation_formats] if annotation_formats else config['annotation_formats']
 
-    if effective_with_counts:
-        invalid_formats = [af.value for af in annotation_formats if af not in COUNT_COMPATIBLE_FORMATS]
-        if invalid_formats:
-            raise ValueError(
-                "Count-aware mode is enabled (--with-counts or count-capable --annotation-format), "
-                "--annotation-format must be one of: "
-                + ", ".join(sorted([f.value for f in COUNT_COMPATIBLE_FORMATS]))
-                + f". Got: {', '.join(invalid_formats)}"
-            )
-    if effective_with_coordinates:
-        invalid_formats = [af.value for af in annotation_formats if af not in COORD_COMPATIBLE_FORMATS]
-        if invalid_formats:
-            raise ValueError(
-                "Coordinate-aware mode is enabled (--with-coords or *_coord --annotation-format), "
-                "--annotation-format must be one of: "
-                + ", ".join(sorted([f.value for f in COORD_COMPATIBLE_FORMATS]))
-                + f". Got: {', '.join(invalid_formats)}"
-            )
-    config['with_counts'] = effective_with_counts
-    config['with_coordinates'] = effective_with_coordinates
-    if count_width is not None and not (2 <= count_width <= 32):
-        raise ValueError(f"--count-width must be in range [2, 32], got {count_width}")
-    if count_width is not None and not effective_with_counts:
-        raise ValueError("--count-width can only be used with count-aware mode (--with-counts or count formats).")
-    if count_width is not None:
-        config['count_width'] = count_width
-
-    config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
-    if not dryrun:
-        _validate_metagraph_cmd(config['metagraph_cmd'])
-    config['max_threads'] = threads if threads else _default_threads_auto()
-    if annotate_threads_each is not None:
-        if annotate_threads_each < 1:
-            raise ValueError(
-                f"--annotate-threads-each must be >= 1, got {annotate_threads_each}")
-        config['annotate_threads_each'] = annotate_threads_each
-
-    if disk_swap_dir is not None:
-        config['tmpdir'] = str(disk_swap_dir)
-
-    if mem_cap_gb is not None:
-        if mem_cap_gb <= 0:
-            raise ValueError(f"--mem-cap-gb must be > 0, got {mem_cap_gb}")
-        config['max_memory_mb'] = int(mem_cap_gb * 1024)
+def _invoke_snakemake(config, output_dir, threads, force, dryrun, verbose,
+                      additional_snakemake_args):
+    """Write the merged config to <output_dir>/config.yaml, run snakemake,
+    and emit the run summary. Raises RuntimeError on snakemake failure."""
+    snakefile_path = Path(WORKFLOW_ROOT / 'Snakefile')
+    output_dir_path = Path(output_dir)
 
     if verbose:
         importlib.reload(logging)
@@ -600,31 +619,20 @@ def run_build_workflow(
         for k, v in sorted(config.items(), key=lambda t: t[0]):
             logging.info(f"\t{k}: {v}")
 
-    additional_args = additional_snakemake_args if additional_snakemake_args else {}
-
-    # Build snakemake command
-    cmd = ['python', '-m', 'snakemake', '--snakefile', str(snakefile_path)]
-
-    # Add config file
-    output_dir_path = Path(output_dir)
     config_file = output_dir_path / 'config.yaml'
     config_file.parent.mkdir(parents=True, exist_ok=True)
     with open(config_file, 'w') as f:
         yaml.dump(config, f)
-    cmd.extend(['--configfile', str(config_file)])
 
-    # Add other arguments
+    cmd = ['python', '-m', 'snakemake', '--snakefile', str(snakefile_path),
+           '--configfile', str(config_file)]
     if force:
         cmd.append('--forceall')
     if dryrun:
         cmd.append('--dry-run')
-    if threads:
-        cmd.extend(['--cores', str(threads)])
-    else:
-        # Add default cores if not specified
-        cmd.extend(['--cores', str(_default_threads_auto())])
+    cmd.extend(['--cores', str(threads if threads else _default_threads_auto())])
 
-    # Add additional arguments
+    additional_args = additional_snakemake_args if additional_snakemake_args else {}
     for key, value in additional_args.items():
         if isinstance(value, bool):
             if value:
@@ -632,85 +640,134 @@ def run_build_workflow(
         else:
             cmd.extend([f'--{key}', str(value)])
 
-    # Run snakemake
     # Keep stdout/stderr attached so Snakemake preserves colors and rich formatting.
     run_started_at = time.time()
     result = subprocess.run([' '.join(cmd)], shell=True)
 
     if result.returncode != 0:
-        raise RuntimeError(_summarize_snakemake_failure_for_run(Path(output_dir), run_started_at))
-    _print_run_summary(Path(output_dir), dryrun)
+        raise RuntimeError(_summarize_snakemake_failure_for_run(output_dir_path, run_started_at))
+    _print_run_summary(output_dir_path, dryrun)
 
 
-def setup_build_parser(parser):
+def run_annotate_workflow(
+        output_dir: Path,
+        graph: Path,
+        seqs_file_list_path: Optional[Path] = None,
+        seqs_dir_path: Optional[Path] = None,
+        base_name: Optional[str] = None,
+        annotation_formats: Iterable[AnnotationFormats] = (),
+        annotation_labels_source: Optional[AnnotationLabelsSource] = None,
+        with_counts: bool = False,
+        with_coordinates: bool = False,
+        count_width: Optional[int] = None,
+        annotate_threads_each: Optional[int] = None,
+        disk_swap_dir: Optional[Path] = None,
+        mem_cap_gb: Optional[float] = None,
+        metagraph_cmd: Optional[str] = None,
+        threads: Optional[int] = None,
+        force: bool = False,
+        verbose: bool = False,
+        dryrun: bool = False,
+        additional_snakemake_args: Optional[Dict[str, Any]] = None
+) -> None:
+    """Annotation + row-diff pipeline on a pre-existing graph (no build).
+
+    The user-provided graph is symlinked into the workflow output dir as
+    ``<base_name>.dbg`` so the existing rules can pick it up as input
+    without rebuilding. The build pipeline (build.smk) is skipped via
+    ``config[external_graph] = True``.
+    """
+    with open(default_path, 'r') as f:
+        config = yaml.safe_load(f)
+
+    if not seqs_file_list_path and not seqs_dir_path:
+        raise ValueError("seqs_file_list_path and seqs_dir_path cannot both be None")
+
+    graph_path = Path(graph).expanduser().resolve()
+    if not graph_path.exists():
+        raise ValueError(f"Graph file not found: {graph_path}")
+
+    if seqs_file_list_path:
+        config[SEQS_FILE_LIST_PATH] = str(seqs_file_list_path)
+    if seqs_dir_path:
+        config[SEQS_DIR_PATH] = str(seqs_dir_path)
+
+    config['output_directory'] = str(output_dir)
+    config['base_name'] = base_name if base_name else config['base_name']
+    config['external_graph'] = True
+    # Per-sample primarization depends on build.smk rules; it can't run
+    # without the build pipeline.
+    config['primarize_samples_separately'] = False
+    config['build_primary_graph'] = False  # irrelevant without build
+
+    _apply_annotation_options(config, annotation_formats, annotation_labels_source,
+                              with_counts, with_coordinates, count_width)
+    _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
+                           disk_swap_dir, mem_cap_gb, dryrun)
+
+    # Symlink the user's graph as <base_name>.dbg so downstream rules
+    # see it as a satisfied input and snakemake doesn't try to rebuild.
+    output_dir_path = Path(output_dir)
+    output_dir_path.mkdir(parents=True, exist_ok=True)
+    target = output_dir_path / f"{config['base_name']}.dbg"
+    if target.is_symlink() or target.exists():
+        target.unlink()
+    target.symlink_to(graph_path)
+
+    _invoke_snakemake(config, output_dir, threads=threads, force=force,
+                      dryrun=dryrun, verbose=verbose,
+                      additional_snakemake_args=additional_snakemake_args)
+
+
+def _add_seq_input_args(group, required=True):
+    """Add --seqs-file-list-path / --seqs-dir-path / -o / --output_dir.
+
+    Returns the mutually-exclusive group so callers can attach more
+    members before the parse, if needed.
+    """
+    xor = group.add_mutually_exclusive_group(required=required)
+    xor.add_argument('--seqs-file-list-path',
+                     metavar='PATH',
+                     help='Path to a text file with sample paths (one per line) []')
+    xor.add_argument('--seqs-dir-path',
+                     metavar='DIR',
+                     help="Directory containing samples []")
+    group.add_argument('-o', '--output_dir', type=Path, required=True,
+                       help='Output directory [required]')
+    return xor
+
+
+def _add_annotation_args(annotation):
+    """Add the shared annotation argument group (anno-source, annotation-format,
+    with-counts, count-width, with-coords) with help text that highlights the
+    per-mode default formats inline."""
     label_sources = [v.value for v in AnnotationLabelsSource]
     count_formats = sorted([f.value for f in COUNT_COMPATIBLE_FORMATS])
-    count_formats_display = [_help_color(fmt, "33") for fmt in count_formats]
     coord_formats = sorted([f.value for f in COORD_COMPATIBLE_FORMATS])
+    count_formats_display = [_help_color(fmt, "33") for fmt in count_formats]
     coord_formats_display = [_help_color(fmt, "35") for fmt in coord_formats]
     classic_fmt_names = [
         "row", "bin_rel_wt", "flat", "rbfish", "brwt", "relax.brwt",
         "rb_brwt", "row_diff_brwt", "relax.row_diff_brwt",
     ]
-    classic_formats_display = [_help_color(fmt, "36") for fmt in classic_fmt_names]
 
     def _with_default(name: str, color: str, default_name: str) -> str:
-        """Colored format name, with `[<name>]` suffix if it's the default."""
         colored = _help_color(name, color)
-        if name == default_name:
-            return f"[{colored}]"
-        return colored
+        return f"[{colored}]" if name == default_name else colored
 
-    # Variants used only in the --annotation-format help block: each format
-    # carries its own `[<name>]` suffix when it is the default for that
-    # mode (binary / counts / coordinates).
     classic_fmt_help = [_with_default(f, "36", "relax.row_diff_brwt") for f in classic_fmt_names]
     count_fmt_help = [_with_default(f, "33", "row_diff_int_brwt") for f in count_formats]
     coord_fmt_help = [_with_default(f, "35", "row_diff_brwt_coord") for f in coord_formats]
-
-    with_counts_label = _help_color("--with-counts", "33")
-    with_coords_label = _help_color("--with-coords", "35")
     default_count_width = _help_color("8", "33")
     zero_count_width = _help_color("0", "36")
 
-    parser.description = (
-        "Build a MetaGraph graph + annotation workflow from a sequence list or directory."
-    )
-    parser.epilog = (
-        "Examples:\n"
-        "  metagraph-workflows build --seqs-file-list-path files.txt -k 31 -o out/\n"
-        "  metagraph-workflows build --seqs-file-list-path files.txt --with-counts -o out/\n"
-        "  metagraph-workflows build --seqs-file-list-path files.txt --with-coords -o out/"
-    )
-
-    input_seq_group = parser.add_argument_group('input/output')
-
-    input_seq_group_xor = input_seq_group.add_mutually_exclusive_group(required=True)
-    input_seq_group_xor.add_argument('--seqs-file-list-path',
-                                     metavar='PATH',
-                                     help='Path to a text file with sample paths (one per line) []')
-    input_seq_group_xor.add_argument('--seqs-dir-path',
-                                     metavar='DIR',
-                                     help="Directory containing samples []")
-    input_seq_group.add_argument('-o', '--output_dir', type=Path, required=True,
-                                 help='Output directory [required]')
-
-    graph = parser.add_argument_group('graph')
-    graph.add_argument('-k', type=int, default=31, metavar='K',
-                       help='k-mer length [31]')
-    graph.add_argument('--base-name', default='graph', metavar='NAME',
-                       help='Base output name [graph]')
-    graph.add_argument('--primary', dest='build_primary_graph', default=False,
-                       action='store_true',
-                       help='Build canonical graph first, then derive/build primary graph [False]')
-
-    annotation = parser.add_argument_group('annotation')
     all_formats_help = "\n".join([
         f"    {classic_fmt_help[0]}, {classic_fmt_help[1]}, {classic_fmt_help[2]}, {classic_fmt_help[3]}, {classic_fmt_help[4]}, {classic_fmt_help[5]}, {classic_fmt_help[6]},",
         f"             {classic_fmt_help[7]}, {classic_fmt_help[8]}",
         f"    {count_fmt_help[0]}, {count_fmt_help[1]}, {count_fmt_help[2]}",
         f"    {coord_fmt_help[0]}, {coord_fmt_help[2]}, {coord_fmt_help[1]}, {coord_fmt_help[3]}",
     ])
+
     annotation.add_argument('--anno-source',
                             dest='annotation_labels_source',
                             type=AnnotationLabelsSource,
@@ -733,10 +790,12 @@ def setup_build_parser(parser):
                                  "  ")
     annotation.add_argument('--with-coords', dest='with_coordinates', default=False, action='store_true',
                             help=f"Index with k-mer positions [False]\n"
-                                 f"  Supported for {coord_formats_display[0]}, {coord_formats_display[2]}, {coord_formats_display[1]},\n"
-                                 f"             {coord_formats_display[3]}")
+                                 f"  Supported for {coord_formats_display[0]}, {coord_formats_display[2]}, {coord_formats_display[1]}, {coord_formats_display[3]}")
 
-    workflow = parser.add_argument_group('other')
+
+def _add_workflow_args(workflow):
+    """Add the shared `other` argument group (threads, disk/mem, force,
+    verbose, dryrun, metagraph-cmd, extra-args)."""
     workflow.add_argument('--threads', type=int, default=None, metavar='N',
                           help='Max cores for Snakemake execution [num_cores]')
     workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir', type=Path, default=None,
@@ -759,9 +818,44 @@ def setup_build_parser(parser):
     workflow.add_argument('--extra-args', dest='additional_snakemake_args', metavar='ARGS', type=str, default='',
                           help='Extra arguments to pass to snakemake [none]\n'
                                '  Example: --extra-args="arg1=val1 arg2=val2"')
+
+
+def _add_help_arg(parser):
     options = parser.add_argument_group('options')
     options.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
                          help='Show this help message and exit')
+
+
+def setup_build_parser(parser):
+    parser.description = (
+        "Build a MetaGraph graph + annotation workflow from a sequence list or directory.\n"
+        "\n"
+        "Inputs are assumed to be contigs with deduplicated k-mers (one fasta.gz\n"
+        "per sample). When building a primary graph (--primary), they must be\n"
+        "primary contigs. For --with-coords, inputs must instead be the full,\n"
+        "non-deduplicated samples."
+    )
+    parser.epilog = (
+        "Examples:\n"
+        "  metagraph-workflows build --seqs-file-list-path files.txt -k 31 -o out/\n"
+        "  metagraph-workflows build --seqs-file-list-path files.txt --with-counts -o out/\n"
+        "  metagraph-workflows build --seqs-file-list-path files.txt --with-coords -o out/"
+    )
+
+    _add_seq_input_args(parser.add_argument_group('input/output'))
+
+    graph = parser.add_argument_group('graph')
+    graph.add_argument('-k', type=int, default=31, metavar='K',
+                       help='k-mer length [31]')
+    graph.add_argument('--base-name', default='graph', metavar='NAME',
+                       help='Base output name [graph]')
+    graph.add_argument('--primary', dest='build_primary_graph', default=False,
+                       action='store_true',
+                       help='Build canonical graph first, then derive/build primary graph [False]')
+
+    _add_annotation_args(parser.add_argument_group('annotation'))
+    _add_workflow_args(parser.add_argument_group('other'))
+    _add_help_arg(parser)
 
     parser.set_defaults(func=init_build)
 
@@ -819,6 +913,63 @@ def init_build(args):
     )
 
 
+def setup_annotate_parser(parser):
+    parser.description = (
+        "Annotate an existing MetaGraph graph: run column annotation and the\n"
+        "row-diff / BRWT transforms against a caller-supplied .dbg file. Skips\n"
+        "the build pipeline.\n"
+        "\n"
+        "Inputs are assumed to be contigs with deduplicated k-mers (one fasta.gz\n"
+        "per sample); when --graph is a primary graph, they must be primary\n"
+        "contigs. For --with-coords, inputs must instead be the full,\n"
+        "non-deduplicated samples."
+    )
+    parser.epilog = (
+        "Examples:\n"
+        "  metagraph-workflows annotate --graph mouse.dbg \\\n"
+        "      --seqs-file-list-path files.txt -o out/"
+    )
+
+    io_group = parser.add_argument_group('input/output')
+    io_group.add_argument('--graph', type=Path, required=True, metavar='PATH',
+                          help='Existing .dbg graph to annotate (must already be built) [required]')
+    _add_seq_input_args(io_group)
+    io_group.add_argument('--base-name', default='graph', metavar='NAME',
+                          help='Base output name (annotations are <NAME>.<fmt>.annodbg) [graph]')
+
+    _add_annotation_args(parser.add_argument_group('annotation'))
+    _add_workflow_args(parser.add_argument_group('other'))
+    _add_help_arg(parser)
+
+    parser.set_defaults(func=init_annotate)
+
+
+def init_annotate(args):
+    run_annotate_workflow(
+        args.output_dir,
+        graph=args.graph,
+        seqs_file_list_path=args.seqs_file_list_path,
+        seqs_dir_path=args.seqs_dir_path,
+        base_name=args.base_name,
+        annotation_formats=[_parse_annotation_format_value(af) for af in args.annotation_format],
+        annotation_labels_source=args.annotation_labels_source,
+        with_counts=args.with_counts,
+        with_coordinates=args.with_coordinates,
+        count_width=args.count_width,
+        annotate_threads_each=args.annotate_threads_each,
+        disk_swap_dir=args.disk_swap_dir,
+        mem_cap_gb=args.mem_cap_gb,
+        metagraph_cmd=args.metagraph_cmd,
+        threads=args.threads,
+        force=args.force,
+        verbose=args.verbose,
+        dryrun=args.dryrun,
+        additional_snakemake_args=_parse_additional_snakemake_args(
+            getattr(args, "additional_snakemake_args", "")
+        )
+    )
+
+
 def main(args=tuple(sys.argv[1:])):
     parser = argparse.ArgumentParser(
         description='MetaGraph workflow utilities',
@@ -839,6 +990,14 @@ def main(args=tuple(sys.argv[1:])):
         add_help=False,
     )
     setup_build_parser(build_parser)
+
+    annotate_parser = subparsers.add_parser(
+        "annotate",
+        help="Annotate an existing graph (skip the build pipeline)",
+        formatter_class=_help_formatter,
+        add_help=False,
+    )
+    setup_annotate_parser(annotate_parser)
 
     parsed_arguments = parser.parse_args(args)
 

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -38,8 +38,37 @@ COORD_COMPATIBLE_FORMATS = {
 }
 
 
+# Colorize a few flag names in --help so users can see at a glance which
+# flags belong to count-aware (yellow, 33) vs coord-aware (purple, 35)
+# modes. Matches the colors already used for the format-name lists in
+# `_add_annotation_args`.
+_FLAG_COLORS = {
+    '--with-counts': '33',
+    '--count-width': '33',
+    '--with-coords': '35',
+}
+
+
+class _ColorHelpFormatter(argparse.RawTextHelpFormatter):
+    """RawTextHelpFormatter that colorizes specific option strings.
+
+    We wrap the flag in ANSI codes after argparse has already computed
+    its column widths, so the alignment of the help text is unaffected
+    (ANSI escape codes render at zero width in the terminal).
+    """
+
+    def _format_action(self, action):
+        text = super()._format_action(action)
+        if not sys.stdout.isatty():
+            return text
+        for flag, code in _FLAG_COLORS.items():
+            if flag in action.option_strings:
+                return text.replace(flag, f"\033[{code}m{flag}\033[0m", 1)
+        return text
+
+
 def _help_formatter(prog: str):
-    return argparse.RawTextHelpFormatter(prog, width=120, max_help_position=34)
+    return _ColorHelpFormatter(prog, width=120, max_help_position=34)
 
 
 def _help_color(text: str, color_code: str) -> str:

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -3,7 +3,6 @@ import difflib
 import importlib
 import logging
 import os
-import re
 import shlex
 import shutil
 import sys
@@ -12,8 +11,6 @@ import time
 from pathlib import Path
 from typing import Iterable, Optional, Dict, Any
 
-import snakemake
-import snakemake.io
 import snakemake.utils
 import yaml
 
@@ -573,10 +570,10 @@ def _set_samples_config(config, samples, output_dir):
 def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
                            disk_swap_dir, mem_gb, brwt_subsample, dryrun):
     """Apply runtime / resource fields to config; raise on invalid values."""
-    config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
+    config['metagraph_cmd'] = metagraph_cmd or config['metagraph_cmd']
     if not dryrun:
         _validate_metagraph_cmd(config['metagraph_cmd'])
-    config['max_threads'] = threads if threads else _default_threads_auto()
+    config['max_threads'] = threads or _default_threads_auto()
     if annotate_threads_each is not None:
         if annotate_threads_each < 1:
             raise ValueError(
@@ -594,9 +591,11 @@ def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd
         config['brwt_linkage_subsample'] = brwt_subsample
 
 
-def run_build_workflow(
+def run_workflow(
         output_dir: Path,
         samples: Path,
+        *,
+        graph: Optional[Path] = None,
         k: Optional[int] = None,
         base_name: Optional[str] = None,
         build_primary_graph: bool = False,
@@ -614,22 +613,49 @@ def run_build_workflow(
         force: bool = False,
         verbose: bool = False,
         dryrun: bool = False,
-        additional_snakemake_args: Optional[Dict[str, Any]] = None
+        additional_snakemake_args: Optional[Dict[str, Any]] = None,
 ) -> None:
+    """Run the metagraph-workflows pipeline.
+
+    With ``graph=None`` (default), build a fresh graph + annotation
+    from ``samples``. With ``graph`` pointing at an existing .dbg file,
+    skip the build pipeline and run annotation-only against that graph
+    (the file is symlinked into the output dir as ``<base_name>.dbg``).
+    """
     with open(default_path, 'r') as f:
         config = yaml.safe_load(f)
 
     _set_samples_config(config, samples, output_dir)
-
     config['output_directory'] = str(output_dir)
-    config['k'] = k if k else config['k']
-    config['base_name'] = base_name if base_name else config['base_name']
-    config['build_primary_graph'] = build_primary_graph
+    config['base_name'] = base_name or config['base_name']
+
+    if graph is not None:
+        graph_path = Path(graph).expanduser().resolve()
+        if not graph_path.exists():
+            raise ValueError(f"Graph file not found: {graph_path}")
+        config['external_graph'] = True
+        # Per-sample primarization needs build.smk rules; not available.
+        config['primarize_samples_separately'] = False
+        config['build_primary_graph'] = False  # irrelevant without build
+    else:
+        config['k'] = k or config['k']
+        config['build_primary_graph'] = build_primary_graph
 
     _apply_annotation_options(config, annotation_formats, annotation_labels_source,
                               with_counts, with_coordinates, count_width)
     _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
                            disk_swap_dir, mem_gb, brwt_subsample, dryrun)
+
+    if graph is not None:
+        # Symlink the user's graph as <base_name>.dbg so downstream
+        # rules see it as a satisfied input and snakemake doesn't try
+        # to rebuild it.
+        output_dir_path = Path(output_dir)
+        output_dir_path.mkdir(parents=True, exist_ok=True)
+        target = output_dir_path / f"{config['base_name']}.dbg"
+        if target.is_symlink() or target.exists():
+            target.unlink()
+        target.symlink_to(graph_path)
 
     _invoke_snakemake(config, output_dir, threads=threads, force=force,
                       dryrun=dryrun, verbose=verbose,
@@ -679,69 +705,6 @@ def _invoke_snakemake(config, output_dir, threads, force, dryrun, verbose,
         raise RuntimeError(_summarize_snakemake_failure_for_run(output_dir_path, run_started_at))
     _print_run_summary(output_dir_path, dryrun)
 
-
-def run_annotate_workflow(
-        output_dir: Path,
-        graph: Path,
-        samples: Path,
-        base_name: Optional[str] = None,
-        annotation_formats: Iterable[AnnotationFormats] = (),
-        annotation_labels_source: Optional[AnnotationLabelsSource] = None,
-        with_counts: bool = False,
-        with_coordinates: bool = False,
-        count_width: Optional[int] = None,
-        annotate_threads_each: Optional[int] = None,
-        disk_swap_dir: Optional[Path] = None,
-        mem_gb: Optional[float] = None,
-        brwt_subsample: Optional[int] = None,
-        metagraph_cmd: Optional[str] = None,
-        threads: Optional[int] = None,
-        force: bool = False,
-        verbose: bool = False,
-        dryrun: bool = False,
-        additional_snakemake_args: Optional[Dict[str, Any]] = None
-) -> None:
-    """Annotation + row-diff pipeline on a pre-existing graph (no build).
-
-    The user-provided graph is symlinked into the workflow output dir as
-    ``<base_name>.dbg`` so the existing rules can pick it up as input
-    without rebuilding. The build pipeline (build.smk) is skipped via
-    ``config[external_graph] = True``.
-    """
-    with open(default_path, 'r') as f:
-        config = yaml.safe_load(f)
-
-    graph_path = Path(graph).expanduser().resolve()
-    if not graph_path.exists():
-        raise ValueError(f"Graph file not found: {graph_path}")
-
-    _set_samples_config(config, samples, output_dir)
-
-    config['output_directory'] = str(output_dir)
-    config['base_name'] = base_name if base_name else config['base_name']
-    config['external_graph'] = True
-    # Per-sample primarization depends on build.smk rules; it can't run
-    # without the build pipeline.
-    config['primarize_samples_separately'] = False
-    config['build_primary_graph'] = False  # irrelevant without build
-
-    _apply_annotation_options(config, annotation_formats, annotation_labels_source,
-                              with_counts, with_coordinates, count_width)
-    _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
-                           disk_swap_dir, mem_gb, brwt_subsample, dryrun)
-
-    # Symlink the user's graph as <base_name>.dbg so downstream rules
-    # see it as a satisfied input and snakemake doesn't try to rebuild.
-    output_dir_path = Path(output_dir)
-    output_dir_path.mkdir(parents=True, exist_ok=True)
-    target = output_dir_path / f"{config['base_name']}.dbg"
-    if target.is_symlink() or target.exists():
-        target.unlink()
-    target.symlink_to(graph_path)
-
-    _invoke_snakemake(config, output_dir, threads=threads, force=force,
-                      dryrun=dryrun, verbose=verbose,
-                      additional_snakemake_args=additional_snakemake_args)
 
 
 def _add_seq_input_args(group):
@@ -899,60 +862,32 @@ def setup_build_parser(parser):
 def _convert_type(v: str) -> Any:
     if v.lower() == 'true' or v == '1':
         return True
-    elif v.lower() == 'false' or v == '0':
+    if v.lower() == 'false' or v == '0':
         return False
-
     try:
         return float(v)
-    except:
-        pass
-
-    return v
+    except ValueError:
+        return v
 
 
 def _parse_additional_snakemake_args(arg: str) -> Dict[str, Any]:
     ret = {}
     for a in shlex.split(arg):
         if '=' not in a:
-            raise ValueError("ex")
-
-        k, v = a.split('=')
+            raise ValueError(
+                f"--extra-args expects key=value tokens; got {a!r}. "
+                f"Example: --extra-args=\"keep-going=True jobs=4\""
+            )
+        k, v = a.split('=', 1)
         ret[k] = _convert_type(v)
-
     return ret
 
 
 def init_build(args):
-    # If the user supplied --graph, bypass the build pipeline and run
-    # annotation-only against that graph. Otherwise build from samples.
-    if args.graph is not None:
-        run_annotate_workflow(
-            args.output_dir,
-            graph=args.graph,
-            samples=args.samples,
-            base_name=args.base_name,
-            annotation_formats=[_parse_annotation_format_value(af) for af in args.annotation_format],
-            annotation_labels_source=args.annotation_labels_source,
-            with_counts=args.with_counts,
-            with_coordinates=args.with_coordinates,
-            count_width=args.count_width,
-            annotate_threads_each=args.annotate_threads_each,
-            disk_swap_dir=args.disk_swap_dir,
-            mem_gb=args.mem_gb,
-            brwt_subsample=args.brwt_subsample,
-            metagraph_cmd=args.metagraph_cmd,
-            threads=args.threads,
-            force=args.force,
-            verbose=args.verbose,
-            dryrun=args.dryrun,
-            additional_snakemake_args=_parse_additional_snakemake_args(
-                getattr(args, "additional_snakemake_args", "")
-            )
-        )
-        return
-    run_build_workflow(
-        args.output_dir,
+    run_workflow(
+        output_dir=args.output_dir,
         samples=args.samples,
+        graph=args.graph,
         k=args.k,
         base_name=args.base_name,
         build_primary_graph=args.build_primary_graph,
@@ -970,9 +905,7 @@ def init_build(args):
         force=args.force,
         verbose=args.verbose,
         dryrun=args.dryrun,
-        additional_snakemake_args=_parse_additional_snakemake_args(
-            getattr(args, "additional_snakemake_args", "")
-        )
+        additional_snakemake_args=_parse_additional_snakemake_args(args.additional_snakemake_args),
     )
 
 

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -492,6 +492,7 @@ def run_build_workflow(
         with_counts: bool = False,
         with_coordinates: bool = False,
         count_width: Optional[int] = None,
+        annotate_threads_each: Optional[int] = None,
         metagraph_cmd: Optional[str] = None,
         threads: Optional[int] = None,
         force: bool = False,
@@ -576,6 +577,11 @@ def run_build_workflow(
     if not dryrun:
         _validate_metagraph_cmd(config['metagraph_cmd'])
     config['max_threads'] = threads if threads else _default_threads_auto()
+    if annotate_threads_each is not None:
+        if annotate_threads_each < 1:
+            raise ValueError(
+                f"--annotate-threads-each must be >= 1, got {annotate_threads_each}")
+        config['annotate_threads_each'] = annotate_threads_each
 
     if verbose:
         importlib.reload(logging)
@@ -714,6 +720,12 @@ def setup_build_parser(parser):
     workflow = parser.add_argument_group('other')
     workflow.add_argument('--threads', type=int, default=None, metavar='N',
                           help='Max cores for Snakemake execution [num_cores]')
+    workflow.add_argument('--annotate-threads-each', type=int, default=None, metavar='N',
+                          help='Threads per file in `metagraph annotate --separately`.\n'
+                               '  Parallel columns built at once = --threads // N. The\n'
+                               '  per-column --mem-cap-gb buffer scales as\n'
+                               '  mem_budget / parallel_cols, so raise N to give each\n'
+                               '  column more buffer (and disk-swap less). [8]')
     workflow.add_argument('--force', default=False, action='store_true',
                           help='Force re-run all rules [False]')
     workflow.add_argument('--verbose', default=False, action='store_true',
@@ -771,6 +783,7 @@ def init_build(args):
         with_counts=args.with_counts,
         with_coordinates=args.with_coordinates,
         count_width=args.count_width,
+        annotate_threads_each=args.annotate_threads_each,
         metagraph_cmd=args.metagraph_cmd,
         threads=args.threads,
         force=args.force,

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -42,7 +42,7 @@ COORD_COMPATIBLE_FORMATS = {
 
 
 def _help_formatter(prog: str):
-    return argparse.RawTextHelpFormatter(prog, width=100, max_help_position=34)
+    return argparse.RawTextHelpFormatter(prog, width=120, max_help_position=34)
 
 
 def _help_color(text: str, color_code: str) -> str:
@@ -493,6 +493,8 @@ def run_build_workflow(
         with_coordinates: bool = False,
         count_width: Optional[int] = None,
         annotate_threads_each: Optional[int] = None,
+        disk_swap_dir: Optional[Path] = None,
+        mem_cap_gb: Optional[float] = None,
         metagraph_cmd: Optional[str] = None,
         threads: Optional[int] = None,
         force: bool = False,
@@ -583,6 +585,14 @@ def run_build_workflow(
                 f"--annotate-threads-each must be >= 1, got {annotate_threads_each}")
         config['annotate_threads_each'] = annotate_threads_each
 
+    if disk_swap_dir is not None:
+        config['tmpdir'] = str(disk_swap_dir)
+
+    if mem_cap_gb is not None:
+        if mem_cap_gb <= 0:
+            raise ValueError(f"--mem-cap-gb must be > 0, got {mem_cap_gb}")
+        config['max_memory_mb'] = int(mem_cap_gb * 1024)
+
     if verbose:
         importlib.reload(logging)
         logging.basicConfig(format=LOGGING_FORMAT, level=logging.INFO)
@@ -638,18 +648,28 @@ def setup_build_parser(parser):
     count_formats_display = [_help_color(fmt, "33") for fmt in count_formats]
     coord_formats = sorted([f.value for f in COORD_COMPATIBLE_FORMATS])
     coord_formats_display = [_help_color(fmt, "35") for fmt in coord_formats]
-    classic_formats_display = [
-        _help_color(fmt, "36")
-        for fmt in [
-            "row", "bin_rel_wt", "flat", "rbfish", "brwt", "relax.brwt",
-            "rb_brwt", "row_diff_brwt", "relax.row_diff_brwt",
-        ]
+    classic_fmt_names = [
+        "row", "bin_rel_wt", "flat", "rbfish", "brwt", "relax.brwt",
+        "rb_brwt", "row_diff_brwt", "relax.row_diff_brwt",
     ]
+    classic_formats_display = [_help_color(fmt, "36") for fmt in classic_fmt_names]
+
+    def _with_default(name: str, color: str, default_name: str) -> str:
+        """Colored format name, with `[<name>]` suffix if it's the default."""
+        colored = _help_color(name, color)
+        if name == default_name:
+            return f"[{colored}]"
+        return colored
+
+    # Variants used only in the --annotation-format help block: each format
+    # carries its own `[<name>]` suffix when it is the default for that
+    # mode (binary / counts / coordinates).
+    classic_fmt_help = [_with_default(f, "36", "relax.row_diff_brwt") for f in classic_fmt_names]
+    count_fmt_help = [_with_default(f, "33", "row_diff_int_brwt") for f in count_formats]
+    coord_fmt_help = [_with_default(f, "35", "row_diff_brwt_coord") for f in coord_formats]
+
     with_counts_label = _help_color("--with-counts", "33")
     with_coords_label = _help_color("--with-coords", "35")
-    default_base_fmt = _help_color("relax.row_diff_brwt", "36")
-    default_count_fmt = _help_color("row_diff_int_brwt", "33")
-    default_coord_fmt = _help_color("row_diff_brwt_coord", "35")
     default_count_width = _help_color("8", "33")
     zero_count_width = _help_color("0", "36")
 
@@ -686,10 +706,10 @@ def setup_build_parser(parser):
 
     annotation = parser.add_argument_group('annotation')
     all_formats_help = "\n".join([
-        f"    {classic_formats_display[0]}, {classic_formats_display[1]}, {classic_formats_display[2]}, {classic_formats_display[3]}, {classic_formats_display[4]}, {classic_formats_display[5]}, {classic_formats_display[6]},",
-        f"             {classic_formats_display[7]}, {classic_formats_display[8]}",
-        f"    {count_formats_display[0]}, {count_formats_display[1]}, {count_formats_display[2]}",
-        f"    {coord_formats_display[0]}, {coord_formats_display[2]}, {coord_formats_display[1]}, {coord_formats_display[3]}",
+        f"    {classic_fmt_help[0]}, {classic_fmt_help[1]}, {classic_fmt_help[2]}, {classic_fmt_help[3]}, {classic_fmt_help[4]}, {classic_fmt_help[5]}, {classic_fmt_help[6]},",
+        f"             {classic_fmt_help[7]}, {classic_fmt_help[8]}",
+        f"    {count_fmt_help[0]}, {count_fmt_help[1]}, {count_fmt_help[2]}",
+        f"    {coord_fmt_help[0]}, {coord_fmt_help[2]}, {coord_fmt_help[1]}, {coord_fmt_help[3]}",
     ])
     annotation.add_argument('--anno-source',
                             dest='annotation_labels_source',
@@ -703,7 +723,6 @@ def setup_build_parser(parser):
                             metavar='FORMAT',
                             help=f"Annotation format (can be used multiple times).\n"
                                  f"{all_formats_help}\n"
-                                 f"  [{default_base_fmt}/{default_count_fmt}/{default_coord_fmt}]\n"
                                  "  ")
     annotation.add_argument('--with-counts', default=False, action='store_true',
                             help=f"Index with k-mer counts [False]\n"
@@ -715,17 +734,20 @@ def setup_build_parser(parser):
     annotation.add_argument('--with-coords', dest='with_coordinates', default=False, action='store_true',
                             help=f"Index with k-mer positions [False]\n"
                                  f"  Supported for {coord_formats_display[0]}, {coord_formats_display[2]}, {coord_formats_display[1]},\n"
-                                 f"                     {coord_formats_display[3]}.")
+                                 f"             {coord_formats_display[3]}")
 
     workflow = parser.add_argument_group('other')
     workflow.add_argument('--threads', type=int, default=None, metavar='N',
                           help='Max cores for Snakemake execution [num_cores]')
+    workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir', type=Path, default=None,
+                          metavar='DIR',
+                          help='Directory for on-disk buffers (passed as --disk-swap). Omit to keep everything in RAM. [none]')
+    workflow.add_argument('--mem-cap-gb', dest='mem_cap_gb', type=float, default=None,
+                          metavar='GB',
+                          help='Per-rule memory budget; drives the auto --mem-cap-gb of each metagraph stage. [4]')
     workflow.add_argument('--annotate-threads-each', type=int, default=None, metavar='N',
-                          help='Threads per file in `metagraph annotate --separately`.\n'
-                               '  Parallel columns built at once = --threads // N. The\n'
-                               '  per-column --mem-cap-gb buffer scales as\n'
-                               '  mem_budget / parallel_cols, so raise N to give each\n'
-                               '  column more buffer (and disk-swap less). [8]')
+                          help='Threads per file in `annotate --separately`. Parallel columns = --threads // N;\n'
+                               '  raise N to give each column more --mem-cap-gb buffer. [8]')
     workflow.add_argument('--force', default=False, action='store_true',
                           help='Force re-run all rules [False]')
     workflow.add_argument('--verbose', default=False, action='store_true',
@@ -784,6 +806,8 @@ def init_build(args):
         with_coordinates=args.with_coordinates,
         count_width=args.count_width,
         annotate_threads_each=args.annotate_threads_each,
+        disk_swap_dir=args.disk_swap_dir,
+        mem_cap_gb=args.mem_cap_gb,
         metagraph_cmd=args.metagraph_cmd,
         threads=args.threads,
         force=args.force,

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -613,7 +613,7 @@ def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd
     if mem_gb is not None:
         if mem_gb <= 0:
             raise ValueError(f"--mem-gb must be > 0, got {mem_gb}")
-        config['max_memory_mb'] = int(mem_gb * 1024)
+        config['memory_mb'] = int(mem_gb * 1024)
     if brwt_subsample is not None:
         if brwt_subsample < 1000:
             raise ValueError(f"--brwt-subsample must be >= 1000, got {brwt_subsample}")

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -186,8 +186,14 @@ def _print_run_summary(output_dir: Path, dryrun: bool) -> None:
         print("1) Executed steps: unavailable (no timing entries found).")
 
     def _is_final_artifact(path: Path) -> bool:
-        name = path.name
-        return name == "graph.dbg" or (name.startswith("graph") and name.endswith(".annodbg"))
+        # Final .dbg / .annodbg files live at the top of output_dir;
+        # per-column intermediates live in subdirectories
+        # (columns.<mode>/, rd_cols.<mode>/). Build sidecars like
+        # graph.dbg.pred / .succ / .anchors have a different suffix
+        # so they're naturally excluded.
+        if path.parent != output_dir:
+            return False
+        return path.suffix in ('.dbg', '.annodbg')
 
     total_size = _directory_size(output_dir)
     final_artifacts = []
@@ -537,8 +543,35 @@ def _apply_annotation_options(config, annotation_formats, annotation_labels_sour
         config['count_width'] = count_width
 
 
+def _set_samples_config(config, samples, output_dir):
+    """Set the seqs config keys from a single samples path.
+
+    Auto-detects: directory -> SEQS_DIR_PATH; regular file ->
+    SEQS_FILE_LIST_PATH. Process substitution `<(...)` shows up as a
+    FIFO that becomes unreadable once the parent CLI exits, so we
+    snapshot its content to ``<output_dir>/samples.txt`` and point the
+    config at the snapshot.
+    """
+    samples_path = Path(samples).expanduser()
+    if samples_path.is_dir():
+        config[SEQS_DIR_PATH] = str(samples_path)
+        return
+    if samples_path.is_fifo() or samples_path.is_char_device():
+        output_dir_path = Path(output_dir)
+        output_dir_path.mkdir(parents=True, exist_ok=True)
+        snapshot = output_dir_path / 'samples.txt'
+        with open(samples_path, 'r') as src, open(snapshot, 'w') as dst:
+            dst.write(src.read())
+        config[SEQS_FILE_LIST_PATH] = str(snapshot)
+        return
+    if samples_path.is_file():
+        config[SEQS_FILE_LIST_PATH] = str(samples_path)
+        return
+    raise ValueError(f"samples path not found: {samples_path}")
+
+
 def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
-                           disk_swap_dir, mem_cap_gb, dryrun):
+                           disk_swap_dir, mem_gb, brwt_subsample, dryrun):
     """Apply runtime / resource fields to config; raise on invalid values."""
     config['metagraph_cmd'] = metagraph_cmd if metagraph_cmd else config['metagraph_cmd']
     if not dryrun:
@@ -551,16 +584,19 @@ def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd
         config['annotate_threads_each'] = annotate_threads_each
     if disk_swap_dir is not None:
         config['tmpdir'] = str(disk_swap_dir)
-    if mem_cap_gb is not None:
-        if mem_cap_gb <= 0:
-            raise ValueError(f"--mem-cap-gb must be > 0, got {mem_cap_gb}")
-        config['max_memory_mb'] = int(mem_cap_gb * 1024)
+    if mem_gb is not None:
+        if mem_gb <= 0:
+            raise ValueError(f"--mem-gb must be > 0, got {mem_gb}")
+        config['max_memory_mb'] = int(mem_gb * 1024)
+    if brwt_subsample is not None:
+        if brwt_subsample < 1:
+            raise ValueError(f"--brwt-subsample must be >= 1, got {brwt_subsample}")
+        config['brwt_linkage_subsample'] = brwt_subsample
 
 
 def run_build_workflow(
         output_dir: Path,
-        seqs_file_list_path: Optional[Path] = None,
-        seqs_dir_path: Optional[Path] = None,
+        samples: Path,
         k: Optional[int] = None,
         base_name: Optional[str] = None,
         build_primary_graph: bool = False,
@@ -571,7 +607,8 @@ def run_build_workflow(
         count_width: Optional[int] = None,
         annotate_threads_each: Optional[int] = None,
         disk_swap_dir: Optional[Path] = None,
-        mem_cap_gb: Optional[float] = None,
+        mem_gb: Optional[float] = None,
+        brwt_subsample: Optional[int] = None,
         metagraph_cmd: Optional[str] = None,
         threads: Optional[int] = None,
         force: bool = False,
@@ -582,13 +619,7 @@ def run_build_workflow(
     with open(default_path, 'r') as f:
         config = yaml.safe_load(f)
 
-    if not seqs_file_list_path and not seqs_dir_path:
-        raise ValueError("seqs_file_list_path and seqs_dir_path cannot both be None")
-
-    if seqs_file_list_path:
-        config[SEQS_FILE_LIST_PATH] = str(seqs_file_list_path)
-    if seqs_dir_path:
-        config[SEQS_DIR_PATH] = str(seqs_dir_path)
+    _set_samples_config(config, samples, output_dir)
 
     config['output_directory'] = str(output_dir)
     config['k'] = k if k else config['k']
@@ -598,7 +629,7 @@ def run_build_workflow(
     _apply_annotation_options(config, annotation_formats, annotation_labels_source,
                               with_counts, with_coordinates, count_width)
     _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
-                           disk_swap_dir, mem_cap_gb, dryrun)
+                           disk_swap_dir, mem_gb, brwt_subsample, dryrun)
 
     _invoke_snakemake(config, output_dir, threads=threads, force=force,
                       dryrun=dryrun, verbose=verbose,
@@ -652,8 +683,7 @@ def _invoke_snakemake(config, output_dir, threads, force, dryrun, verbose,
 def run_annotate_workflow(
         output_dir: Path,
         graph: Path,
-        seqs_file_list_path: Optional[Path] = None,
-        seqs_dir_path: Optional[Path] = None,
+        samples: Path,
         base_name: Optional[str] = None,
         annotation_formats: Iterable[AnnotationFormats] = (),
         annotation_labels_source: Optional[AnnotationLabelsSource] = None,
@@ -662,7 +692,8 @@ def run_annotate_workflow(
         count_width: Optional[int] = None,
         annotate_threads_each: Optional[int] = None,
         disk_swap_dir: Optional[Path] = None,
-        mem_cap_gb: Optional[float] = None,
+        mem_gb: Optional[float] = None,
+        brwt_subsample: Optional[int] = None,
         metagraph_cmd: Optional[str] = None,
         threads: Optional[int] = None,
         force: bool = False,
@@ -680,17 +711,11 @@ def run_annotate_workflow(
     with open(default_path, 'r') as f:
         config = yaml.safe_load(f)
 
-    if not seqs_file_list_path and not seqs_dir_path:
-        raise ValueError("seqs_file_list_path and seqs_dir_path cannot both be None")
-
     graph_path = Path(graph).expanduser().resolve()
     if not graph_path.exists():
         raise ValueError(f"Graph file not found: {graph_path}")
 
-    if seqs_file_list_path:
-        config[SEQS_FILE_LIST_PATH] = str(seqs_file_list_path)
-    if seqs_dir_path:
-        config[SEQS_DIR_PATH] = str(seqs_dir_path)
+    _set_samples_config(config, samples, output_dir)
 
     config['output_directory'] = str(output_dir)
     config['base_name'] = base_name if base_name else config['base_name']
@@ -703,7 +728,7 @@ def run_annotate_workflow(
     _apply_annotation_options(config, annotation_formats, annotation_labels_source,
                               with_counts, with_coordinates, count_width)
     _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
-                           disk_swap_dir, mem_cap_gb, dryrun)
+                           disk_swap_dir, mem_gb, brwt_subsample, dryrun)
 
     # Symlink the user's graph as <base_name>.dbg so downstream rules
     # see it as a satisfied input and snakemake doesn't try to rebuild.
@@ -719,22 +744,20 @@ def run_annotate_workflow(
                       additional_snakemake_args=additional_snakemake_args)
 
 
-def _add_seq_input_args(group, required=True):
-    """Add --seqs-file-list-path / --seqs-dir-path / -o / --output_dir.
+def _add_seq_input_args(group):
+    """Add the positional `samples` and `-o/--output_dir` arguments.
 
-    Returns the mutually-exclusive group so callers can attach more
-    members before the parse, if needed.
+    `samples` accepts either a directory (interpreted as a directory of
+    sample files) or a regular file (interpreted as a text file listing
+    sample paths, one per line). Process substitution `<(...)` is also
+    accepted: the CLI snapshots the FIFO contents to a real file inside
+    the output dir before invoking snakemake.
     """
-    xor = group.add_mutually_exclusive_group(required=required)
-    xor.add_argument('--seqs-file-list-path',
-                     metavar='PATH',
-                     help='Path to a text file with sample paths (one per line) []')
-    xor.add_argument('--seqs-dir-path',
-                     metavar='DIR',
-                     help="Directory containing samples []")
+    group.add_argument('samples', type=Path, metavar='SAMPLES',
+                       help='Either a directory of sample files OR a text file listing sample\n'
+                            '  paths (one per line). The type is auto-detected.')
     group.add_argument('-o', '--output_dir', type=Path, required=True,
                        help='Output directory [required]')
-    return xor
 
 
 def _add_annotation_args(annotation):
@@ -797,16 +820,21 @@ def _add_workflow_args(workflow):
     """Add the shared `other` argument group (threads, disk/mem, force,
     verbose, dryrun, metagraph-cmd, extra-args)."""
     workflow.add_argument('--threads', type=int, default=None, metavar='N',
-                          help='Max cores for Snakemake execution [num_cores]')
+                          help='Maximum CPU cores to use [num_cores]')
     workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir', type=Path, default=None,
                           metavar='DIR',
                           help='Directory for on-disk buffers (passed as --disk-swap). Omit to keep everything in RAM. [none]')
-    workflow.add_argument('--mem-cap-gb', dest='mem_cap_gb', type=float, default=None,
+    workflow.add_argument('--mem-gb', type=float, default=None,
                           metavar='GB',
-                          help='Per-rule memory budget; drives the auto --mem-cap-gb of each metagraph stage. [4]')
+                          help='Approximate RAM budget per rule (in GB); drives the auto --mem-cap-gb\n'
+                               '  passed to each metagraph stage. [4]')
     workflow.add_argument('--annotate-threads-each', type=int, default=None, metavar='N',
-                          help='Threads per file in `annotate --separately`. Parallel columns = --threads // N;\n'
-                               '  raise N to give each column more --mem-cap-gb buffer. [8]')
+                          help='Threads used to annotate each input file. Parallel columns = --threads // N;\n'
+                               '  raise N to give each column more --mem-cap-gb buffer.\n'
+                               '  [8 for binary/counts, 16 for coords]')
+    workflow.add_argument('--brwt-subsample', type=int, default=None, metavar='N',
+                          help='Number of bits subsampled for distance estimation when clustering BRWT\n'
+                               '  columns (passed as --subsample to transform_anno --anno-type *_brwt*). [1000000]')
     workflow.add_argument('--force', default=False, action='store_true',
                           help='Force re-run all rules [False]')
     workflow.add_argument('--verbose', default=False, action='store_true',
@@ -837,14 +865,18 @@ def setup_build_parser(parser):
     )
     parser.epilog = (
         "Examples:\n"
-        "  metagraph-workflows build --seqs-file-list-path files.txt -k 31 -o out/\n"
-        "  metagraph-workflows build --seqs-file-list-path files.txt --with-counts -o out/\n"
-        "  metagraph-workflows build --seqs-file-list-path files.txt --with-coords -o out/"
+        "  metagraph-workflows build samples_dir/ -k 31 -o out/\n"
+        "  metagraph-workflows build <(ls /data/samples/*.fa) -k 31 -o out/\n"
+        "  metagraph-workflows build files.txt --with-counts -o out/\n"
+        "  metagraph-workflows build samples_dir/ --with-coords -o out/"
     )
 
     _add_seq_input_args(parser.add_argument_group('input/output'))
 
     graph = parser.add_argument_group('graph')
+    graph.add_argument('--graph', type=Path, default=None, metavar='PATH',
+                       help='Reuse an existing .dbg graph instead of building one from SAMPLES.\n'
+                            '  Skips the build pipeline; runs annotation + row-diff transforms only.')
     graph.add_argument('-k', type=int, default=31, metavar='K',
                        help='k-mer length [31]')
     graph.add_argument('--base-name', default='graph', metavar='NAME',
@@ -887,10 +919,36 @@ def _parse_additional_snakemake_args(arg: str) -> Dict[str, Any]:
 
 
 def init_build(args):
+    # If the user supplied --graph, bypass the build pipeline and run
+    # annotation-only against that graph. Otherwise build from samples.
+    if args.graph is not None:
+        run_annotate_workflow(
+            args.output_dir,
+            graph=args.graph,
+            samples=args.samples,
+            base_name=args.base_name,
+            annotation_formats=[_parse_annotation_format_value(af) for af in args.annotation_format],
+            annotation_labels_source=args.annotation_labels_source,
+            with_counts=args.with_counts,
+            with_coordinates=args.with_coordinates,
+            count_width=args.count_width,
+            annotate_threads_each=args.annotate_threads_each,
+            disk_swap_dir=args.disk_swap_dir,
+            mem_gb=args.mem_gb,
+            brwt_subsample=args.brwt_subsample,
+            metagraph_cmd=args.metagraph_cmd,
+            threads=args.threads,
+            force=args.force,
+            verbose=args.verbose,
+            dryrun=args.dryrun,
+            additional_snakemake_args=_parse_additional_snakemake_args(
+                getattr(args, "additional_snakemake_args", "")
+            )
+        )
+        return
     run_build_workflow(
         args.output_dir,
-        seqs_file_list_path=args.seqs_file_list_path,
-        seqs_dir_path=args.seqs_dir_path,
+        samples=args.samples,
         k=args.k,
         base_name=args.base_name,
         build_primary_graph=args.build_primary_graph,
@@ -901,7 +959,8 @@ def init_build(args):
         count_width=args.count_width,
         annotate_threads_each=args.annotate_threads_each,
         disk_swap_dir=args.disk_swap_dir,
-        mem_cap_gb=args.mem_cap_gb,
+        mem_gb=args.mem_gb,
+        brwt_subsample=args.brwt_subsample,
         metagraph_cmd=args.metagraph_cmd,
         threads=args.threads,
         force=args.force,
@@ -926,8 +985,7 @@ def setup_annotate_parser(parser):
     )
     parser.epilog = (
         "Examples:\n"
-        "  metagraph-workflows annotate --graph mouse.dbg \\\n"
-        "      --seqs-file-list-path files.txt -o out/"
+        "  metagraph-workflows annotate --graph mouse.dbg files.txt -o out/"
     )
 
     io_group = parser.add_argument_group('input/output')
@@ -948,8 +1006,7 @@ def init_annotate(args):
     run_annotate_workflow(
         args.output_dir,
         graph=args.graph,
-        seqs_file_list_path=args.seqs_file_list_path,
-        seqs_dir_path=args.seqs_dir_path,
+        samples=args.samples,
         base_name=args.base_name,
         annotation_formats=[_parse_annotation_format_value(af) for af in args.annotation_format],
         annotation_labels_source=args.annotation_labels_source,
@@ -958,7 +1015,8 @@ def init_annotate(args):
         count_width=args.count_width,
         annotate_threads_each=args.annotate_threads_each,
         disk_swap_dir=args.disk_swap_dir,
-        mem_cap_gb=args.mem_cap_gb,
+        mem_gb=args.mem_gb,
+        brwt_subsample=args.brwt_subsample,
         metagraph_cmd=args.metagraph_cmd,
         threads=args.threads,
         force=args.force,

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -183,14 +183,14 @@ def _print_run_summary(output_dir: Path, dryrun: bool) -> None:
         print("1) Executed steps: unavailable (no timing entries found).")
 
     def _is_final_artifact(path: Path) -> bool:
-        # Final .dbg / .annodbg files live at the top of output_dir;
-        # per-column intermediates live in subdirectories
+        # Final .dbg / .annodbg / .seqs files live at the top of
+        # output_dir; per-column intermediates live in subdirectories
         # (columns.<mode>/, rd_cols.<mode>/). Build sidecars like
         # graph.dbg.pred / .succ / .anchors have a different suffix
         # so they're naturally excluded.
         if path.parent != output_dir:
             return False
-        return path.suffix in ('.dbg', '.annodbg')
+        return path.suffix in ('.dbg', '.annodbg', '.seqs')
 
     total_size = _directory_size(output_dir)
     final_artifacts = []

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -827,7 +827,7 @@ def _add_workflow_args(workflow):
                           help='Maximum CPU cores to use [num_cores]')
     workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir', type=Path, default=None,
                           metavar='DIR',
-                          help='Directory for on-disk buffers (passed as --disk-swap). Omit to keep everything in RAM. [none]')
+                          help='Directory for on-disk buffers; omit to stay in RAM [none]')
     workflow.add_argument('--mem-gb', type=float, default=None,
                           metavar='GB',
                           help='Approximate RAM budget per rule (in GB); drives the auto --mem-cap-gb\n'

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -844,7 +844,7 @@ def _add_workflow_args(workflow):
 def _add_help_arg(parser):
     options = parser.add_argument_group('options')
     options.add_argument('-v', '--verbose', default=False, action='store_true',
-                         help='Print verbose config/runtime logs and pass -v to metagraph [False]')
+                         help='Stream metagraph progress to the terminal (logs always capture full -v output) [False]')
     options.add_argument('--metagraph-cmd', type=str, default=None, metavar='CMD',
                          help='Path/command for metagraph executable [metagraph from PATH]')
     options.add_argument('--extra-args', dest='additional_snakemake_args', metavar='ARGS', type=str, default='',

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -596,7 +596,7 @@ def _set_samples_config(config, samples, output_dir):
     raise ValueError(f"samples path not found: {samples_path}")
 
 
-def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
+def _apply_runtime_options(config, output_dir, threads, annotate_threads_each, metagraph_cmd,
                            disk_swap_dir, mem_gb, brwt_subsample, dryrun):
     """Apply runtime / resource fields to config; raise on invalid values."""
     config['metagraph_cmd'] = metagraph_cmd or config['metagraph_cmd']
@@ -608,8 +608,24 @@ def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd
             raise ValueError(
                 f"--anno-threads-each must be >= 1, got {annotate_threads_each}")
         config['annotate_threads_each'] = annotate_threads_each
-    if disk_swap_dir is not None:
+    # Disk swap:
+    #   None  -> default to <output_dir>/temp so metagraph stages can spill
+    #            without surprising fallback to OUT_BASEDIR (transform_anno's
+    #            default).
+    #   ""    -> explicit "off": don't set tmpdir; temp_dir_config will emit
+    #            `--disk-swap ""` and keep everything in RAM.
+    #   path  -> use as given.
+    if disk_swap_dir is None:
+        config['tmpdir'] = str(Path(output_dir) / 'temp')
+    elif str(disk_swap_dir) == '':
+        config.pop('tmpdir', None)
+    else:
         config['tmpdir'] = str(disk_swap_dir)
+
+    # metagraph stages create temp files in the swap dir and expect the
+    # directory itself to already exist; create it eagerly.
+    if 'tmpdir' in config and not dryrun:
+        Path(config['tmpdir']).mkdir(parents=True, exist_ok=True)
     if mem_gb is not None:
         if mem_gb <= 0:
             raise ValueError(f"--mem-gb must be > 0, got {mem_gb}")
@@ -672,7 +688,7 @@ def run_workflow(
 
     _apply_annotation_options(config, annotation_formats, annotation_labels_source,
                               with_counts, with_coordinates, count_width)
-    _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd,
+    _apply_runtime_options(config, output_dir, threads, annotate_threads_each, metagraph_cmd,
                            disk_swap_dir, mem_gb, brwt_subsample, dryrun)
 
     if graph is not None:
@@ -828,9 +844,9 @@ def _add_workflow_args(workflow):
     workflow.add_argument('--mem-gb', type=float, default=None,
                           metavar='GB',
                           help='Approximate RAM budget in GB; used to derive --mem-cap-gb for each stage [16]')
-    workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir', type=Path, default=None,
-                          metavar='DIR',
-                          help='Directory for on-disk buffers; omit to stay in RAM [none]')
+    workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir',
+                          type=_disk_swap_dir_value, default=None, metavar='DIR',
+                          help='Directory for disk swap; pass "" to disable [<OUTPUT_DIR>/temp]')
     workflow.add_argument('--anno-threads-each', dest='annotate_threads_each',
                           type=int, default=None, metavar='N',
                           help='Threads used to annotate each input file. Parallel columns = ceil(-p / N);\n'
@@ -892,6 +908,15 @@ def setup_build_parser(parser):
     _add_help_arg(parser)
 
     parser.set_defaults(func=init_build)
+
+
+def _disk_swap_dir_value(value: str):
+    """argparse type for --disk-swap-dir.
+
+    Empty string is the explicit "off" sentinel (keeps everything in RAM);
+    any other value is treated as a directory path.
+    """
+    return '' if value == '' else Path(value)
 
 
 def _int_or_sci(value: str) -> int:

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -769,26 +769,30 @@ def _add_annotation_args(annotation):
     coord_formats = sorted([f.value for f in COORD_COMPATIBLE_FORMATS])
     count_formats_display = [_help_color(fmt, "33") for fmt in count_formats]
     coord_formats_display = [_help_color(fmt, "35") for fmt in coord_formats]
-    classic_fmt_names = [
-        "row", "bin_rel_wt", "flat", "rbfish", "brwt", "relax.brwt",
-        "rb_brwt", "row_diff_brwt", "relax.row_diff_brwt",
+    plain_fmt_names = [
+        "row", "bin_rel_wt", "flat", "rbfish", "brwt", "relax.brwt", "rb_brwt",
+    ]
+    rd_fmt_names = [
+        "row_diff_brwt", "relax.row_diff_brwt",
+        "row_diff_flat", "row_diff_sparse", "row_diff_disk",
     ]
 
     def _with_default(name: str, color: str, default_name: str) -> str:
         colored = _help_color(name, color)
         return f"[{colored}]" if name == default_name else colored
 
-    classic_fmt_help = [_with_default(f, "36", "relax.row_diff_brwt") for f in classic_fmt_names]
+    plain_fmt_help = [_with_default(f, "36", "") for f in plain_fmt_names]
+    rd_fmt_help = [_with_default(f, "36", "relax.row_diff_brwt") for f in rd_fmt_names]
     count_fmt_help = [_with_default(f, "33", "row_diff_int_brwt") for f in count_formats]
     coord_fmt_help = [_with_default(f, "35", "row_diff_brwt_coord") for f in coord_formats]
     default_count_width = _help_color("8", "33")
     zero_count_width = _help_color("0", "36")
 
     all_formats_help = "\n".join([
-        f"    {classic_fmt_help[0]}, {classic_fmt_help[1]}, {classic_fmt_help[2]}, {classic_fmt_help[3]}, {classic_fmt_help[4]}, {classic_fmt_help[5]}, {classic_fmt_help[6]},",
-        f"             {classic_fmt_help[7]}, {classic_fmt_help[8]}",
-        f"    {count_fmt_help[0]}, {count_fmt_help[1]}, {count_fmt_help[2]}",
-        f"    {coord_fmt_help[0]}, {coord_fmt_help[2]}, {coord_fmt_help[1]}, {coord_fmt_help[3]}",
+        f"    {', '.join(plain_fmt_help)}",
+        f"    {', '.join(rd_fmt_help)}",
+        f"    {', '.join(count_fmt_help)}",
+        f"    {', '.join(coord_fmt_help)}",
     ])
 
     annotation.add_argument('--anno-source',

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -831,7 +831,7 @@ def _add_workflow_args(workflow):
     workflow.add_argument('--mem-gb', type=float, default=None,
                           metavar='GB',
                           help='Approximate RAM budget per rule (in GB); drives the auto --mem-cap-gb\n'
-                               '  passed to each metagraph stage. [4]')
+                               '  passed to each metagraph stage. [16]')
     workflow.add_argument('--annotate-threads-each', type=int, default=None, metavar='N',
                           help='Threads used to annotate each input file. Parallel columns = --threads // N;\n'
                                '  raise N to give each column more --mem-cap-gb buffer.\n'

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -761,9 +761,9 @@ def _add_annotation_args(annotation):
     annotation.add_argument('--anno-source',
                             dest='annotation_labels_source',
                             type=AnnotationLabelsSource,
-                            default=AnnotationLabelsSource.SEQUENCE_HEADERS,
+                            default=AnnotationLabelsSource.FILENAME,
                             metavar='SOURCE',
-                            help=f"Column label source: {', '.join(label_sources)} [sequence_headers]\n"
+                            help=f"Column label source: {', '.join(label_sources)} [filename]\n"
                                  "  ")
     annotation.add_argument('--annotation-format', action='append',
                             default=[],

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -543,8 +543,8 @@ def _apply_annotation_options(config, annotation_formats, annotation_labels_sour
         invalid = [af.value for af in annotation_formats if af not in COUNT_COMPATIBLE_FORMATS]
         if invalid:
             raise ValueError(
-                "Count-aware mode is enabled (--with-counts or count-capable --annotation-format), "
-                "--annotation-format must be one of: "
+                "Count-aware mode is enabled (--with-counts or count-capable --anno-type), "
+                "--anno-type must be one of: "
                 + ", ".join(sorted([f.value for f in COUNT_COMPATIBLE_FORMATS]))
                 + f". Got: {', '.join(invalid)}"
             )
@@ -552,8 +552,8 @@ def _apply_annotation_options(config, annotation_formats, annotation_labels_sour
         invalid = [af.value for af in annotation_formats if af not in COORD_COMPATIBLE_FORMATS]
         if invalid:
             raise ValueError(
-                "Coordinate-aware mode is enabled (--with-coords or *_coord --annotation-format), "
-                "--annotation-format must be one of: "
+                "Coordinate-aware mode is enabled (--with-coords or *_coord --anno-type), "
+                "--anno-type must be one of: "
                 + ", ".join(sorted([f.value for f in COORD_COMPATIBLE_FORMATS]))
                 + f". Got: {', '.join(invalid)}"
             )
@@ -606,7 +606,7 @@ def _apply_runtime_options(config, threads, annotate_threads_each, metagraph_cmd
     if annotate_threads_each is not None:
         if annotate_threads_each < 1:
             raise ValueError(
-                f"--annotate-threads-each must be >= 1, got {annotate_threads_each}")
+                f"--anno-threads-each must be >= 1, got {annotate_threads_each}")
         config['annotate_threads_each'] = annotate_threads_each
     if disk_swap_dir is not None:
         config['tmpdir'] = str(disk_swap_dir)
@@ -737,7 +737,7 @@ def _invoke_snakemake(config, output_dir, threads, force, dryrun, verbose,
 
 
 def _add_seq_input_args(group):
-    """Add the positional `samples` and `-o/--output_dir` arguments.
+    """Add the positional `samples`, `-o`, and `--base-name` arguments.
 
     `samples` accepts either a directory (interpreted as a directory of
     sample files) or a regular file (interpreted as a text file listing
@@ -748,12 +748,15 @@ def _add_seq_input_args(group):
     group.add_argument('samples', type=Path, metavar='SAMPLES',
                        help='Either a directory of sample files OR a text file listing sample\n'
                             '  paths (one per line). The type is auto-detected.')
-    group.add_argument('-o', '--output_dir', type=Path, required=True,
+    group.add_argument('-o', dest='output_dir', type=Path, required=True,
+                       metavar='DIR',
                        help='Output directory [required]')
+    group.add_argument('--base-name', default='graph', metavar='NAME',
+                       help='Base output name [graph]')
 
 
 def _add_annotation_args(annotation):
-    """Add the shared annotation argument group (anno-source, annotation-format,
+    """Add the shared annotation argument group (anno-source, anno-type,
     with-counts, count-width, with-coords) with help text that highlights the
     per-mode default formats inline."""
     label_sources = [v.value for v in AnnotationLabelsSource]
@@ -794,7 +797,8 @@ def _add_annotation_args(annotation):
                             metavar='SOURCE',
                             help=f"Column label source: {', '.join(label_sources)} [filename]\n"
                                  "  ")
-    annotation.add_argument('--annotation-format', action='append',
+    annotation.add_argument('--anno-type', action='append',
+                            dest='annotation_format',
                             default=[],
                             metavar='FORMAT',
                             help=f"Annotation format (can be used multiple times).\n"
@@ -824,7 +828,8 @@ def _add_workflow_args(workflow):
                           metavar='GB',
                           help='Approximate RAM budget per rule (in GB); drives the auto --mem-cap-gb\n'
                                '  passed to each metagraph stage. [16]')
-    workflow.add_argument('--annotate-threads-each', type=int, default=None, metavar='N',
+    workflow.add_argument('--anno-threads-each', dest='annotate_threads_each',
+                          type=int, default=None, metavar='N',
                           help='Threads used to annotate each input file. Parallel columns = ceil(--threads / N);\n'
                                '  raise N to give each column more --mem-cap-gb buffer.\n'
                                '  [8 for binary/counts, 16 for coords]')
@@ -875,8 +880,6 @@ def setup_build_parser(parser):
                             '  Skips the build pipeline; runs annotation + row-diff transforms only.')
     graph.add_argument('-k', type=int, default=31, metavar='K',
                        help='k-mer length [31]')
-    graph.add_argument('--base-name', default='graph', metavar='NAME',
-                       help='Base output name [graph]')
     graph.add_argument('--primary', dest='build_primary_graph', default=False,
                        action='store_true',
                        help='Build canonical graph first, then derive/build primary graph [False]')

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -3,6 +3,7 @@ import difflib
 import importlib
 import logging
 import os
+import re
 import shlex
 import shutil
 import sys
@@ -39,12 +40,13 @@ COORD_COMPATIBLE_FORMATS = {
 
 
 # Colorize a few flag names in --help so users can see at a glance which
-# flags belong to count-aware (yellow, 33) vs coord-aware (purple, 35)
-# modes. Matches the colors already used for the format-name lists in
-# `_add_annotation_args`.
+# flags belong to count-aware (orange, 38;5;208) vs coord-aware (purple, 35)
+# modes. Matches the colors used for the format-name lists in
+# `_add_annotation_args`. We deliberately avoid yellow (33) and cyan (36)
+# because argparse 3.14 already uses those for metavars and option strings.
 _FLAG_COLORS = {
-    '--with-counts': '33',
-    '--count-width': '33',
+    '--with-counts': '38;5;208',
+    '--count-width': '38;5;208',
     '--with-coords': '35',
 }
 
@@ -55,7 +57,42 @@ class _ColorHelpFormatter(argparse.RawTextHelpFormatter):
     We wrap the flag in ANSI codes after argparse has already computed
     its column widths, so the alignment of the help text is unaffected
     (ANSI escape codes render at zero width in the terminal).
+
+    Also overrides argparse 3.14 theme defaults so the palette stays
+    readable on both dark and light terminal backgrounds: flag names,
+    positionals and metavars render in plain default fg (no hue, no
+    bold) instead of argparse's bold magenta / cyan / green / yellow.
+    The prog name keeps a bold weight so it stands out at the start of
+    the usage line. The custom highlights (orange / magenta / cyan)
+    come from our own coloring on top.
     """
+
+    def _set_color(self, color):
+        super()._set_color(color)
+        if color and getattr(self._theme, "prog", None):
+            import dataclasses
+            self._theme = dataclasses.replace(
+                self._theme,
+                # Prog name: bold default fg.
+                prog="\033[1m",
+                prog_extra="",
+                # Flag names, positionals, metavars: no styling.
+                long_option="",
+                short_option="",
+                action="",
+                label="",
+                summary_long_option="",
+                summary_short_option="",
+                summary_action="",
+                summary_label="",
+            )
+
+    # Bold the contents of [..] defaults at end of help lines. We skip
+    # bracket pairs that already contain an ANSI escape so existing
+    # color-coded defaults (e.g. [row_diff_int_brwt], [0/8]) keep their
+    # own styling. The negative lookbehind avoids matching `[` characters
+    # that are part of an ANSI escape sequence (i.e. `\x1b[`).
+    _DEFAULT_BRACKET_RE = re.compile(r"(?<!\x1b)\[([^\[\]\n\x1b]+)\]")
 
     def _format_action(self, action):
         text = super()._format_action(action)
@@ -63,7 +100,9 @@ class _ColorHelpFormatter(argparse.RawTextHelpFormatter):
             return text
         for flag, code in _FLAG_COLORS.items():
             if flag in action.option_strings:
-                return text.replace(flag, f"\033[{code}m{flag}\033[0m", 1)
+                text = text.replace(flag, f"\033[{code}m{flag}\033[0m", 1)
+                break
+        text = self._DEFAULT_BRACKET_RE.sub(r"[\033[1m\1\033[0m]", text)
         return text
 
 
@@ -774,7 +813,7 @@ def _add_seq_input_args(group):
                             '  paths (one per line). The type is auto-detected.')
     group.add_argument('-o', dest='output_dir', type=Path, required=True,
                        metavar='DIR',
-                       help='Output directory [required]')
+                       help='Output directory []')
     group.add_argument('--base-name', default='graph', metavar='NAME',
                        help='Base output name [graph]')
 
@@ -786,7 +825,7 @@ def _add_annotation_args(annotation):
     label_sources = [v.value for v in AnnotationLabelsSource]
     count_formats = sorted([f.value for f in COUNT_COMPATIBLE_FORMATS])
     coord_formats = sorted([f.value for f in COORD_COMPATIBLE_FORMATS])
-    count_formats_display = [_help_color(fmt, "33") for fmt in count_formats]
+    count_formats_display = [_help_color(fmt, "38;5;208") for fmt in count_formats]
     coord_formats_display = [_help_color(fmt, "35") for fmt in coord_formats]
     plain_fmt_names = [
         "row", "bin_rel_wt", "flat", "rbfish", "brwt", "relax.brwt", "rb_brwt",
@@ -796,16 +835,21 @@ def _add_annotation_args(annotation):
         "row_diff_flat", "row_diff_sparse", "row_diff_disk",
     ]
 
-    def _with_default(name: str, color: str, default_name: str) -> str:
-        colored = _help_color(name, color)
-        return f"[{colored}]" if name == default_name else colored
+    def _with_default(name: str, color: str, default_name: str, bold_default: bool = False) -> str:
+        if name == default_name:
+            highlight = f"1;{color}" if bold_default else color
+            return f"[{_help_color(name, highlight)}]"
+        return _help_color(name, color)
 
-    plain_fmt_help = [_with_default(f, "36", "") for f in plain_fmt_names]
-    rd_fmt_help = [_with_default(f, "36", "relax.row_diff_brwt") for f in rd_fmt_names]
-    count_fmt_help = [_with_default(f, "33", "row_diff_int_brwt") for f in count_formats]
+    # Binary (plain + row-diff) formats: cyan, with only the default
+    # additionally bolded. Count / coord formats keep the orange /
+    # magenta family coloring (no extra bold on default).
+    plain_fmt_help = [_with_default(f, "36", "", bold_default=True) for f in plain_fmt_names]
+    rd_fmt_help = [_with_default(f, "36", "relax.row_diff_brwt", bold_default=True) for f in rd_fmt_names]
+    count_fmt_help = [_with_default(f, "38;5;208", "row_diff_int_brwt") for f in count_formats]
     coord_fmt_help = [_with_default(f, "35", "row_diff_brwt_coord") for f in coord_formats]
-    default_count_width = _help_color("8", "33")
-    zero_count_width = _help_color("0", "36")
+    default_count_width = _help_color("8", "38;5;208")
+    zero_count_width = _help_color("0", "1")
 
     all_formats_help = "\n".join([
         f"    {', '.join(plain_fmt_help)}",
@@ -819,7 +863,7 @@ def _add_annotation_args(annotation):
                             type=AnnotationLabelsSource,
                             default=AnnotationLabelsSource.FILENAME,
                             metavar='SOURCE',
-                            help=f"Column label source: {', '.join(label_sources)} [filename]\n"
+                            help=f"Column label source: {'/'.join(label_sources)} [filename]\n"
                                  "  ")
     annotation.add_argument('--anno-type', action='append',
                             dest='annotation_format',
@@ -829,14 +873,14 @@ def _add_annotation_args(annotation):
                                  f"{all_formats_help}\n"
                                  "  ")
     annotation.add_argument('--with-counts', default=False, action='store_true',
-                            help=f"Index with k-mer counts [False]\n"
+                            help=f"Index with k-mer counts [off]\n"
                                  f"  Supported for {', '.join(count_formats_display)}.")
     annotation.add_argument('--count-width', type=int, default=None,
                             metavar='BITS',
                             help=f"Bit width for count values (passed to annotate/transform_anno) [{zero_count_width}/{default_count_width}]\n"
                                  "  ")
     annotation.add_argument('--with-coords', dest='with_coordinates', default=False, action='store_true',
-                            help=f"Index with k-mer positions [False]\n"
+                            help=f"Index with k-mer positions [off]\n"
                                  f"  Supported for {coord_formats_display[0]}, {coord_formats_display[2]}, {coord_formats_display[1]}, {coord_formats_display[3]}")
 
 
@@ -861,58 +905,61 @@ def _add_workflow_args(workflow):
                                '  columns (passed as --subsample to transform_anno --anno-type *_brwt*) [1e6]')
     workflow.add_argument('--keep-columns', default=False, action='store_true',
                           help='Keep per-sample column annotations (columns.<mode>/) after the\n'
-                               '  final annotation is built [False]')
+                               '  final annotation is built [off]')
     workflow.add_argument('--keep-rd-columns', default=False, action='store_true',
                           help='Keep per-sample row-diff column annotations (rd_cols.<mode>/) and\n'
                                '  the rd_succ / anchors graph sidecars, so the BRWT clustering\n'
-                               '  step can be re-run with different parameters [False]')
+                               '  step can be re-run with different parameters [off]')
 
 
 def _add_help_arg(parser):
     options = parser.add_argument_group('options')
     options.add_argument('-v', '--verbose', default=False, action='store_true',
-                         help='Stream metagraph progress to the terminal (logs always capture full -v output) [False]')
+                         help='Stream metagraph progress to the terminal (logs always capture full -v output) [off]')
     options.add_argument('--metagraph-cmd', type=str, default=None, metavar='CMD',
-                         help='Path/command for metagraph executable [metagraph from PATH]')
+                         help='Path/command for metagraph executable [metagraph]')
     options.add_argument('--extra-args', dest='additional_snakemake_args', metavar='ARGS', type=str, default='',
                          help='Extra arguments to pass to snakemake [none]\n'
                               '  Example: --extra-args="arg1=val1 arg2=val2"')
     options.add_argument('--force', default=False, action='store_true',
-                         help='Force re-run all rules [False]')
+                         help='Force re-run all rules [off]')
     options.add_argument('--dryrun', default=False, action='store_true',
-                         help='Render DAG and config only; do not execute rules [False]')
+                         help='Render DAG and config only; do not execute rules [off]')
     options.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
                          help='Show this help message and exit')
 
 
 def setup_build_parser(parser):
+    primary_flag = "--primary"
+    with_counts_flag = _help_color("--with-counts", "38;5;208")
+    with_coords_flag = _help_color("--with-coords", "35")
     parser.description = (
         "Build a MetaGraph graph + annotation workflow from a sequence list or directory.\n"
         "\n"
         "Inputs are assumed to be contigs with deduplicated k-mers (one fasta.gz\n"
-        "per sample). When building a primary graph (--primary), they must be\n"
-        "primary contigs. For --with-coords, inputs must instead be the full,\n"
+        f"per sample). When building a primary graph ({primary_flag}), they must be\n"
+        f"primary contigs. For {with_coords_flag}, inputs must instead be the full,\n"
         "non-deduplicated samples."
     )
     parser.epilog = (
         "Examples:\n"
         "  metagraph-workflows build samples_dir/ -k 31 -o out/\n"
         "  metagraph-workflows build <(ls /data/samples/*.fa) -k 31 -o out/\n"
-        "  metagraph-workflows build files.txt --with-counts -o out/\n"
-        "  metagraph-workflows build samples_dir/ --with-coords -o out/"
+        f"  metagraph-workflows build files.txt {with_counts_flag} -o out/\n"
+        f"  metagraph-workflows build samples_dir/ {with_coords_flag} -o out/"
     )
 
     _add_seq_input_args(parser.add_argument_group('input/output'))
 
     graph = parser.add_argument_group('graph')
     graph.add_argument('--graph', type=Path, default=None, metavar='PATH',
-                       help='Reuse an existing .dbg graph instead of building one from SAMPLES.\n'
+                       help='Reuse an existing .dbg graph instead of building one from SAMPLES []\n'
                             '  Skips the build pipeline; runs annotation + row-diff transforms only.')
     graph.add_argument('-k', type=int, default=31, metavar='K',
                        help='k-mer length [31]')
     graph.add_argument('--primary', dest='build_primary_graph', default=False,
                        action='store_true',
-                       help='Build canonical graph first, then derive/build primary graph [False]')
+                       help='Build canonical graph first, then derive/build primary graph [off]')
 
     _add_annotation_args(parser.add_argument_group('annotation'))
     _add_workflow_args(parser.add_argument_group('other'))

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -698,6 +698,10 @@ def _invoke_snakemake(config, output_dir, threads, force, dryrun, verbose,
     snakefile_path = Path(WORKFLOW_ROOT / 'Snakefile')
     output_dir_path = Path(output_dir)
 
+    # The Snakefile reads `verbose` from config to decide whether to add
+    # `-v` to each metagraph invocation.
+    config['verbose'] = verbose
+
     if verbose:
         importlib.reload(logging)
         logging.basicConfig(format=LOGGING_FORMAT, level=logging.INFO)
@@ -838,8 +842,9 @@ def _add_workflow_args(workflow):
                                '  columns (passed as --subsample to transform_anno --anno-type *_brwt*). [1000000]')
     workflow.add_argument('--force', default=False, action='store_true',
                           help='Force re-run all rules [False]')
-    workflow.add_argument('--verbose', default=False, action='store_true',
-                          help='Print verbose config/runtime logs [False]')
+    workflow.add_argument('-v', '--verbose', default=False, action='store_true',
+                          help='Print verbose config/runtime logs and pass -v to each\n'
+                               '  underlying metagraph invocation [False]')
     workflow.add_argument('--dryrun', default=False, action='store_true',
                           help='Render DAG and config only; do not execute rules [False]')
     workflow.add_argument('--metagraph-cmd', type=str, default=None, metavar='CMD',

--- a/metagraph/workflows/metagraph_workflows/cli.py
+++ b/metagraph/workflows/metagraph_workflows/cli.py
@@ -821,40 +821,39 @@ def _add_annotation_args(annotation):
 
 
 def _add_workflow_args(workflow):
-    """Add the shared `other` argument group (threads, disk/mem, force,
-    verbose, dryrun, metagraph-cmd, extra-args)."""
-    workflow.add_argument('--threads', type=int, default=None, metavar='N',
+    """Add the shared `other` argument group (threads, disk/mem,
+    verbose, metagraph-cmd, extra-args, force, dryrun)."""
+    workflow.add_argument('-p', dest='threads', type=int, default=None, metavar='N',
                           help='Maximum CPU cores to use [num_cores]')
-    workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir', type=Path, default=None,
-                          metavar='DIR',
-                          help='Directory for on-disk buffers; omit to stay in RAM [none]')
     workflow.add_argument('--mem-gb', type=float, default=None,
                           metavar='GB',
                           help='Approximate RAM budget in GB; used to derive --mem-cap-gb for each stage [16]')
+    workflow.add_argument('--disk-swap-dir', dest='disk_swap_dir', type=Path, default=None,
+                          metavar='DIR',
+                          help='Directory for on-disk buffers; omit to stay in RAM [none]')
     workflow.add_argument('--anno-threads-each', dest='annotate_threads_each',
                           type=int, default=None, metavar='N',
-                          help='Threads used to annotate each input file. Parallel columns = ceil(--threads / N);\n'
+                          help='Threads used to annotate each input file. Parallel columns = ceil(-p / N);\n'
                                '  raise N to give each column more --mem-cap-gb buffer.\n'
                                '  [8 for binary/counts, 16 for coords]')
-    workflow.add_argument('--brwt-subsample', type=int, default=None, metavar='N',
+    workflow.add_argument('--brwt-subsample', type=_int_or_sci, default=None, metavar='N',
                           help='Number of bits subsampled for distance estimation when clustering BRWT\n'
-                               '  columns (passed as --subsample to transform_anno --anno-type *_brwt*). [1000000]')
-    workflow.add_argument('--force', default=False, action='store_true',
-                          help='Force re-run all rules [False]')
-    workflow.add_argument('-v', '--verbose', default=False, action='store_true',
-                          help='Print verbose config/runtime logs and pass -v to each\n'
-                               '  underlying metagraph invocation [False]')
-    workflow.add_argument('--dryrun', default=False, action='store_true',
-                          help='Render DAG and config only; do not execute rules [False]')
-    workflow.add_argument('--metagraph-cmd', type=str, default=None, metavar='CMD',
-                          help='Path/command for metagraph executable [metagraph from PATH]')
-    workflow.add_argument('--extra-args', dest='additional_snakemake_args', metavar='ARGS', type=str, default='',
-                          help='Extra arguments to pass to snakemake [none]\n'
-                               '  Example: --extra-args="arg1=val1 arg2=val2"')
+                               '  columns (passed as --subsample to transform_anno --anno-type *_brwt*) [1e6]')
 
 
 def _add_help_arg(parser):
     options = parser.add_argument_group('options')
+    options.add_argument('-v', '--verbose', default=False, action='store_true',
+                         help='Print verbose config/runtime logs and pass -v to metagraph [False]')
+    options.add_argument('--metagraph-cmd', type=str, default=None, metavar='CMD',
+                         help='Path/command for metagraph executable [metagraph from PATH]')
+    options.add_argument('--extra-args', dest='additional_snakemake_args', metavar='ARGS', type=str, default='',
+                         help='Extra arguments to pass to snakemake [none]\n'
+                              '  Example: --extra-args="arg1=val1 arg2=val2"')
+    options.add_argument('--force', default=False, action='store_true',
+                         help='Force re-run all rules [False]')
+    options.add_argument('--dryrun', default=False, action='store_true',
+                         help='Render DAG and config only; do not execute rules [False]')
     options.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS,
                          help='Show this help message and exit')
 
@@ -893,6 +892,19 @@ def setup_build_parser(parser):
     _add_help_arg(parser)
 
     parser.set_defaults(func=init_build)
+
+
+def _int_or_sci(value: str) -> int:
+    """Argparse type that accepts plain ints and scientific notation
+    (e.g. `1e6`). Useful for knobs like --brwt-subsample where typical
+    values are powers of ten."""
+    try:
+        f = float(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"expected integer, got {value!r}")
+    if not f.is_integer():
+        raise argparse.ArgumentTypeError(f"expected integer, got {value!r}")
+    return int(f)
 
 
 def _convert_type(v: str) -> Any:

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -52,11 +52,17 @@ class ResourceConfig:
             if not mem_mb:
                 mem_mb = self._get_mem_estimate(wildcards, input, threads)
 
-                max_mem = _get_max_memory(self.config)
-                if mem_mb > max_mem:
-                    logger.warning(
-                        f"The estimated memory of {mem_mb} MB "
-                        f"is larger than the max memory {max_mem}.")
+                # `_get_mem_estimate` returns TBDString() when an input
+                # the estimate depends on isn't materialized yet (e.g.
+                # at dryrun / DAG-construction time). Skip the
+                # over-budget warning in that case -- it'd fail in
+                # snakemake 9.21+ where TBDString rejects comparisons.
+                if not isinstance(mem_mb, TBDString):
+                    max_mem = _get_max_memory(self.config)
+                    if mem_mb > max_mem:
+                        logger.warning(
+                            f"The estimated memory of {mem_mb} MB "
+                            f"is larger than the max memory {max_mem}.")
 
             return mem_mb
 

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -17,7 +17,7 @@ FALLBACK_MAX_DISK = 10 * 1024
 
 
 def _get_max_memory(config):
-    return config.get(workflow_configs.MAX_MEMORY_MB, FALLBACK_MAX_MEM)
+    return config.get(workflow_configs.MEMORY_MB, FALLBACK_MAX_MEM)
 
 
 def _get_max_disk(config):

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -223,7 +223,7 @@ class AnnotateResources(SupportsMemBufferSize):
     `metagraph annotate --mem-cap-gb` is a *per-column* buffer, applied
     independently to each column constructed in parallel under --separately.
     Total memory used is approximately `mem_cap_gb * parallel_cols`, where
-    `parallel_cols = max_threads // threads_each`. Override the buffer
+    `parallel_cols = ceil(max_threads / threads_each)`. Override the buffer
     heuristic accordingly.
     """
 

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -166,11 +166,18 @@ class BuildGraphResourcesWithKmerEstimates(SupportsMemBufferSizeWithEstimation, 
 
         unique_kmers = kmc_data[self.KMC_STATS_KEY][self.KMC_UNIQUE_KMER_CNT]
 
-        bytes_per_kmer = 2.6
-        kmer_count = 2.6 * unique_kmers  # 2x canonical+non-canonical +  ~30% for dummy kmers (typically it's 10%)
-        required_ram = int(math.ceil(kmer_count * bytes_per_kmer / 1024**2))
-        required_ram_mb = max(required_ram, 1024)
-
+        # Two independent factors:
+        #   - expansion factor 2.6: 2x for canonical+reverse, ~30% extra
+        #     for dummy k-mers (typically 10-30%); ~= 2 * 1.3.
+        #   - 2.6 bytes per stored k-mer during succinct-graph
+        #     construction (peak working-set per k-mer, empirical).
+        # Total peak RSS ~= 6.76 bytes per unique k-mer reported by KMC.
+        # If this underestimates on a particular dataset, override via
+        # `rules.<rule>.mem_buffer_mb` in the workflow config.
+        EXPANSION_FACTOR = 2.6
+        BYTES_PER_KMER = 2.6
+        required_ram_bytes = unique_kmers * EXPANSION_FACTOR * BYTES_PER_KMER
+        required_ram_mb = max(int(math.ceil(required_ram_bytes / 1024**2)), 1024)
         return required_ram_mb
 
 

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -11,6 +11,9 @@ from metagraph_workflows.workflow_configs import MEM_MB_KEY, DISK_MB_KEY, \
 from metagraph_workflows.utils import logger, get_rule_specific_config
 
 BASE_MEM = 1 * 1024
+# Floor on the auto-derived `--mem-cap-gb` buffer (in MiB); avoids zero
+# or absurdly tiny buffers when the rule's RAM budget is very small.
+MIN_MEM_BUFFER_MB = 1024
 FALLBACK_MAX_MEM = 4 * 1024
 FALLBACK_MAX_DISK = 10 * 1024
 
@@ -116,7 +119,7 @@ class SupportsMemBufferSize(ResourceConfig):
 
         if avail_mem_mb == TBDString():
             return TBDString()
-        return max(int(self.CAP_MEM_FRACTION * avail_mem_mb), 1024) # TODO: parametrize constant?
+        return max(int(self.CAP_MEM_FRACTION * avail_mem_mb), MIN_MEM_BUFFER_MB)
 
 
 class SupportsMemBufferSizeWithEstimation(SupportsMemBufferSize):
@@ -170,7 +173,7 @@ class BuildGraphResourcesWithKmerEstimates(SupportsMemBufferSizeWithEstimation):
         EXPANSION_FACTOR = 2.6
         BYTES_PER_KMER = 2.6
         required_ram_bytes = unique_kmers * EXPANSION_FACTOR * BYTES_PER_KMER
-        required_ram_mb = max(int(math.ceil(required_ram_bytes / 1024**2)), 1024)
+        required_ram_mb = max(int(math.ceil(required_ram_bytes / 1024**2)), MIN_MEM_BUFFER_MB)
         return required_ram_mb
 
 
@@ -271,11 +274,11 @@ class AnnotateResources(SupportsMemBufferSize):
                 if avail_mem_mb == TBDString():
                     return TBDString()
 
-                total_buf_mb = max(int(self.CAP_MEM_FRACTION * avail_mem_mb), 1024)
+                total_buf_mb = max(int(self.CAP_MEM_FRACTION * avail_mem_mb), MIN_MEM_BUFFER_MB)
                 total_buf_mb = min(total_buf_mb, self.config[workflow_configs.MAX_BUFFER_SIZE_MB])
 
                 parallel_cols = self.get_parallel_cols(threads)
-                mem_cap_mb = max(total_buf_mb // parallel_cols, 1024)
+                mem_cap_mb = max(total_buf_mb // parallel_cols, MIN_MEM_BUFFER_MB)
 
             return int(math.ceil(mem_cap_mb / 1024.0))
 

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -139,18 +139,11 @@ class SupportsMemBufferSizeWithEstimation(SupportsMemBufferSize):
         return mem_cap_mib + max(int(mem_cap_mib/self.CAP_MEM_FRACTION * (1-self.CAP_MEM_FRACTION)), BASE_MEM)
 
 
-class SupportsDiskCap(ResourceConfig):
-    def get_disk_cap(self):
-        def _get_disk_cap(wildcards):
-            return int(self.get_disk()(wildcards) / 1024)
-        return _get_disk_cap # TODO: come up with a heuristic
-
-
-class BuildGraphResources(SupportsMemBufferSize, SupportsDiskCap):
+class BuildGraphResources(SupportsMemBufferSize):
     pass
 
 
-class BuildGraphResourcesWithKmerEstimates(SupportsMemBufferSizeWithEstimation, SupportsDiskCap):
+class BuildGraphResourcesWithKmerEstimates(SupportsMemBufferSizeWithEstimation):
 
     KMC_STATS_KEY = "Stats"
     KMC_UNIQUE_KMER_CNT = "#Unique_counted_k-mers"

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -78,6 +78,13 @@ class SupportsMemBufferSize(ResourceConfig):
 
     CAP_MEM_FRACTION = 0.85
 
+    # If True, clip the auto-derived buffer to `max_buffer_size_mb`.
+    # build/annotate need this (their --mem-cap-gb is a preallocated
+    # buffer that competes with other in-memory state). Row-diff
+    # transforms scale with annotation size and routinely need
+    # >> max_buffer_size_mb, so those subclasses opt out.
+    APPLY_MAX_BUFFER_CAP = True
+
     def get_mem_buffer_gib(self):
         """
         value for the `--mem-cap-gb` parameter (in GiB)
@@ -90,7 +97,8 @@ class SupportsMemBufferSize(ResourceConfig):
                 mem_cap_mb = self._mem_buf_estimate(wildcards, resources, input, threads)
                 if mem_cap_mb == TBDString():
                     return TBDString()
-                mem_cap_mb = min(mem_cap_mb, self.config[workflow_configs.MAX_BUFFER_SIZE_MB])
+                if self.APPLY_MAX_BUFFER_CAP:
+                    mem_cap_mb = min(mem_cap_mb, self.config[workflow_configs.MAX_BUFFER_SIZE_MB])
 
             return int(math.ceil(mem_cap_mb / 1024.0))
 
@@ -185,6 +193,8 @@ class PrimarizeCanonicalGraphSingleSampleResources(ResourceConfig):
 
 
 class TransformRdStage0Resources(SupportsMemBufferSizeWithEstimation):
+    APPLY_MAX_BUFFER_CAP = False
+
     def __init__(self, config):
         super().__init__('transform_rd_stage0', config)
 
@@ -195,11 +205,15 @@ class TransformRdStage0Resources(SupportsMemBufferSizeWithEstimation):
 
 
 class TransformRdStage1Resources(SupportsMemBufferSize):
+    APPLY_MAX_BUFFER_CAP = False
+
     def __init__(self, config):
         super().__init__('transform_rd_stage1', config)
 
 
 class TransformRdStage2Resources(SupportsMemBufferSize):
+    APPLY_MAX_BUFFER_CAP = False
+
     def __init__(self, config):
         super().__init__('transform_rd_stage2', config)
 

--- a/metagraph/workflows/metagraph_workflows/resource_management.py
+++ b/metagraph/workflows/metagraph_workflows/resource_management.py
@@ -202,3 +202,67 @@ class TransformRdStage1Resources(SupportsMemBufferSize):
 class TransformRdStage2Resources(SupportsMemBufferSize):
     def __init__(self, config):
         super().__init__('transform_rd_stage2', config)
+
+
+class AnnotateResources(SupportsMemBufferSize):
+    """
+    `metagraph annotate --mem-cap-gb` is a *per-column* buffer, applied
+    independently to each column constructed in parallel under --separately.
+    Total memory used is approximately `mem_cap_gb * parallel_cols`, where
+    `parallel_cols = max_threads // threads_each`. Override the buffer
+    heuristic accordingly.
+    """
+
+    def __init__(self, config):
+        super().__init__('annotate', config)
+        threads_each = config.get(workflow_configs.ANNOTATE_THREADS_EACH, 1) or 1
+        self.threads_each = max(int(threads_each), 1)
+
+    def get_parallel_cols(self, threads):
+        """Number of columns built in parallel.
+
+        Ceiling division: when `threads` is not a multiple of
+        `threads_each` we'd rather fit one extra column than leave
+        Snakemake-reserved cores idle.
+        """
+        return max(math.ceil(int(threads) / self.threads_each), 1)
+
+    def get_effective_threads_each(self, threads):
+        """Threads passed to `--threads-each`.
+
+        Ceiling division so no reserved core sits idle when `threads` is
+        not divisible by `parallel_cols`. May overcommit by up to
+        `parallel_cols - 1` threads at boundary inputs (e.g. 13/8 -> 2*7
+        = 14), which the OS scheduler absorbs.
+        """
+        return max(math.ceil(int(threads) / self.get_parallel_cols(threads)), 1)
+
+    def get_mem_buffer_gib(self):
+        """
+        Returns the per-column buffer in GiB for `--mem-cap-gb`. If
+        `mem_buffer_mb` is set in the rule config, treat it as the
+        per-column value (matches the CLI semantic). Otherwise split the
+        global mem budget across columns built in parallel.
+        """
+        def _get_mem_buffer(wildcards, input, threads, resources):
+            mem_cap_mb = get_rule_specific_config(self.rule_name,
+                                                  MEM_BUFFER_MB_KEY, self.config)
+
+            if not mem_cap_mb:
+                avail_mem_mb = get_rule_specific_config(self.rule_name, MEM_MB_KEY,
+                                                        self.config)
+                if not avail_mem_mb:
+                    avail_mem_mb = resources.get('mem_mb', _get_max_memory(self.config))
+
+                if avail_mem_mb == TBDString():
+                    return TBDString()
+
+                total_buf_mb = max(int(self.CAP_MEM_FRACTION * avail_mem_mb), 1024)
+                total_buf_mb = min(total_buf_mb, self.config[workflow_configs.MAX_BUFFER_SIZE_MB])
+
+                parallel_cols = self.get_parallel_cols(threads)
+                mem_cap_mb = max(total_buf_mb // parallel_cols, 1024)
+
+            return int(math.ceil(mem_cap_mb / 1024.0))
+
+        return _get_mem_buffer

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -81,9 +81,27 @@ external_graph = config.get('external_graph', False)
 #   - the annotation columns are keyed by file (`--anno-filename`).
 # In `--anno-header` mode each sequence already gets its own column, so
 # coords are per-sequence and no sidecar is needed.
+#
+# The consumer (load_annotated_graph.cpp) strips the annotation's full
+# kExtension (e.g. `.row_diff_brwt_coord.annodbg`) from the annotation
+# path and appends `.seqs`, so all coord formats sharing the same graph
+# look for the SAME path: `<graph>.seqs`. We can only emit one. BRWT
+# clustering may reorder columns differently per format, so the .seqs
+# content is only correct for one format -- we derive it from the first
+# coord format in the requested list (the typical workflow request is
+# `--with-coords` which defaults to a single format).
+coord_sidecar_anno_type = next(
+    (af for af in annotation_formats
+     if AnnotationFormats(af) in {AnnotationFormats.BRWT_COORD,
+                                  AnnotationFormats.ROW_DIFF_COORD,
+                                  AnnotationFormats.ROW_DIFF_BRWT_COORD,
+                                  AnnotationFormats.ROW_DIFF_DISK_COORD}),
+    None,
+)
 build_coord_sidecar = (
     with_coordinates
     and AnnotationLabelsSource(config['annotation_labels_source']) == AnnotationLabelsSource.FILENAME
+    and coord_sidecar_anno_type is not None
 )
 
 rule all:
@@ -93,13 +111,7 @@ rule all:
         # already has their built graph; we don't want to re-transform it.
         *([small_graph_path] if not external_graph else []),
         [wdir/f'{graph}.{anno_type}.annodbg' for anno_type in annotation_formats],
-        # One .seqs sidecar per requested coord format. The loader strips
-        # `.annodbg` from the annotation path and appends `.seqs`, so the
-        # paths must match per-format. The content can differ across
-        # formats because BRWT clustering reorders columns, so we build
-        # one .seqs per format using each annotation's own column order.
-        *([wdir/f'{graph}.{anno_type}.seqs' for anno_type in annotation_formats]
-          if build_coord_sidecar else []),
+        *([wdir/f'{graph}.seqs'] if build_coord_sidecar else []),
 
 
 if not external_graph:
@@ -184,47 +196,54 @@ rule annotate:
         """
 
 INDEX_HEADER_COORDS_RULE="index_header_coords"
-rule index_header_coords:
-    """Build the CoordToHeader (.seqs) sidecar used by coord queries.
+if build_coord_sidecar:
+    rule index_header_coords:
+        """Build the CoordToHeader (.seqs) sidecar used by coord queries.
 
-    `metagraph annotate --index-header-coords` is a separate pass that
-    re-reads the input fastas; the file labels and coord offsets line up
-    with the annotation only if the inputs are passed in the same order
-    as the columns in the final annotation. BRWT clustering reorders
-    columns, so the order we annotated with no longer matches the order
-    in the transformed annotation -- we recover it from the annotation
-    itself via `stats --print-col-names`. Each coord-aware column label
-    is the absolute fasta path (see annotate.cpp: `labels.push_back(file)`
-    in `--anno-filename` mode), so the column-name list piped from
-    `stats` is exactly what `annotate --index-header-coords` expects on
-    stdin.
-    """
-    input:
-        annotation=wdir/f'{graph}.{{anno_type}}.annodbg',
-        dbg_graph=graph_path,
-    output:
-        seqs_sidecar=wdir/f'{graph}.{{anno_type}}.seqs',
-    wildcard_constraints:
-        anno_type="brwt_coord|row_diff_coord|row_diff_brwt_coord|row_diff_disk_coord",
-    threads: max_threads
-    resources:
-        mem_mb=ResourceConfig(INDEX_HEADER_COORDS_RULE, config).get_mem(),
-    log: utils.get_log_path(INDEX_HEADER_COORDS_RULE, config, ['anno_type'])
-    shell:
+        `metagraph annotate --index-header-coords` is a separate pass
+        that re-reads the input fastas; the file labels and coord
+        offsets line up with the annotation only if the inputs are
+        passed in the same order as the columns in the final
+        annotation. BRWT clustering reorders columns, so the order we
+        annotated with no longer matches the order in the transformed
+        annotation -- we recover it from the annotation itself via
+        `stats --print-col-names`. Each coord-aware column label is the
+        absolute fasta path (see annotate.cpp:
+        `labels.push_back(file)` in `--anno-filename` mode), so the
+        column-name list piped from `stats` is exactly what `annotate
+        --index-header-coords` expects on stdin.
+
+        The output is `<graph>.seqs` because the consumer
+        (load_annotated_graph.cpp) strips the annotation's full
+        kExtension (e.g. `.row_diff_brwt_coord.annodbg`) and appends
+        `.seqs` -- so every coord format looks at the same path.
         """
-        OUT_BASE={output.seqs_sidecar}
-        # `stats --print-col-names` prints "Number of columns: N" on the
-        # first line, then one column label per line in annotation order.
-        # Skip the header line and pipe the rest to annotate.
-        {metagraph_cmd} stats --print-col-names -a {input.annotation} 2>>{log} \
-            | tail -n +2 \
-            | {time_cmd} {metagraph_cmd} annotate {verbose_opt} \
-                --anno-filename \
-                --index-header-coords \
-                -p {threads} \
-                -i {input.dbg_graph} \
-                -o ${{OUT_BASE%.seqs}} >> {log} 2>&1
-        """
+        input:
+            annotation=wdir/f'{graph}.{coord_sidecar_anno_type}.annodbg',
+            dbg_graph=graph_path,
+        output:
+            seqs_sidecar=wdir/f'{graph}.seqs',
+        threads: max_threads
+        resources:
+            mem_mb=ResourceConfig(INDEX_HEADER_COORDS_RULE, config).get_mem(),
+        log: utils.get_log_path(INDEX_HEADER_COORDS_RULE, config)
+        shell:
+            """
+            OUT_BASE={output.seqs_sidecar}
+            # `stats --print-col-names` interleaves a logger
+            # `[info] Scanning ...` line on stdout and then
+            # `Number of columns: N` followed by one column label per
+            # line. We want only the labels, so drop everything up to
+            # (and including) the "Number of columns:" marker.
+            {metagraph_cmd} stats --print-col-names -a {input.annotation} 2>>{log} \
+                | awk '/^Number of columns:/ {{found=1; next}} found' \
+                | {time_cmd} {metagraph_cmd} annotate {verbose_opt} \
+                    --anno-filename \
+                    --index-header-coords \
+                    -p {threads} \
+                    -i {input.dbg_graph} \
+                    -o ${{OUT_BASE%.seqs}} >> {log} 2>&1
+            """
 
 
 GENERATE_COLUMN_LIST_RULE="generate_column_list"

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -75,7 +75,30 @@ rule all:
         [wdir/f'{graph}.{anno_type}.annodbg' for anno_type in annotation_formats]
 
 
-include: 'build.smk'
+if not config.get('external_graph', False):
+    include: 'build.smk'
+
+
+BUILD_SMALL_GRAPH_RULE="build_small_graph"
+rule build_small_graph:
+    input: graph_path
+    output: small_graph_path
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(BUILD_SMALL_GRAPH_RULE, config).get_mem(),
+    log: utils.get_log_path(BUILD_SMALL_GRAPH_RULE, config)
+    shell:
+        # `metagraph transform -o` takes a basename and appends `.dbg`,
+        # so strip the suffix before passing.
+        """
+        OUT_BASE={output}
+        {time_cmd} {metagraph_cmd} transform {verbose_opt} \
+        --state small \
+        -p {threads} \
+        -o ${{OUT_BASE%.dbg}} \
+        {input} > {log} 2>&1
+        """
+
 
 ANNOTATE_RULE="annotate"
 rule annotate:
@@ -273,7 +296,7 @@ rule transform_rd_stage0:
         """
         COLS_DIR=$(dirname {output.columns_rd_row_count})
         mkdir -p $COLS_DIR
-        
+
         cat {input.columns_file} | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff \
             --row-diff-stage 0 \

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -209,6 +209,7 @@ ruleorder: annotate_row_diff_int_disk > transform_annotation
 ruleorder: annotate_row_diff_brwt_coord > transform_annotation
 ruleorder: annotate_row_diff_coord > transform_annotation
 ruleorder: annotate_row_diff_disk_coord > transform_annotation
+ruleorder: annotate_row_diff_binary > transform_annotation
 
 TRANSFORM_ANNOTATION_RULE="transform_annotation"
 rule transform_annotation:
@@ -502,6 +503,50 @@ rule annotate_row_diff_int_brwt:
             --subsample {params.subsample} \
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
+            -i {input.dbg_graph} \
+            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+        """
+
+
+ANNOTATE_ROW_DIFF_BINARY_RULE="annotate_row_diff_binary"
+rule annotate_row_diff_binary:
+    """Binary row-diff annotation in flat / sparse / disk form.
+
+    The three formats share the same input (row-diff stage-2 columns +
+    graph) and CLI shape. `--mem-cap-gb` is only meaningful for
+    row_diff_disk (which materializes the row-diff buffer to disk);
+    flat / sparse don't use it, matching the convention in
+    experiments/large_index_scripts.md.
+    """
+    input:
+        rd_succ=rules.transform_rd_stage1.output.rd_succ,
+        anchors=rules.transform_rd_stage2.output.anchors,
+        rd_cols_done=rules.transform_rd_stage2.output.rd_cols_done,
+        rd_col_annodbg_files=rules.transform_rd_stage2.output.rd_col_annodbg_files,
+        rd_col_count_files=rules.transform_rd_stage2.output.rd_col_count_files,
+        rd_col_coord_files=rules.transform_rd_stage2.output.rd_col_coord_files,
+        dbg_graph=graph_path
+    output:
+        annotations=wdir/f'{graph}.{{anno_type}}.annodbg',
+    wildcard_constraints:
+        anno_type="row_diff_flat|row_diff_sparse|row_diff_disk",
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_BINARY_RULE, config).get_mem(),
+    params:
+        tempdir_opt=utils.temp_dir_config(config),
+        mem_cap_arg=(
+            lambda wildcards, input, threads, resources:
+                f"--mem-cap-gb {TransformRdStage2Resources(config).get_mem_buffer_gib()(wildcards, input, threads, resources)}"
+                if wildcards.anno_type == "row_diff_disk" else ""
+        ),
+    log: utils.get_log_path(ANNOTATE_ROW_DIFF_BINARY_RULE, config, ['anno_type'])
+    shell:
+        r"""
+        find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
+            --anno-type {wildcards.anno_type} \
+            -p {threads} \
+            {params.mem_cap_arg} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -524,7 +524,6 @@ rule annotate_row_diff_brwt:
     log: utils.get_log_path(ANNOTATE_ROW_DIFF_BRWT_RULE, config)
     shell:
         r"""
-        echo $(find $(dirname {input.rd_cols_done}) -name \*.annodbg)
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_brwt \
             --greedy \

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -13,10 +13,19 @@ build_primary=config['build_primary_graph']
 
 annotation_formats = config['annotation_formats'] if isinstance(config['annotation_formats'], list) else [config['annotation_formats']]
 
-# validate values
+# Validate annotation_formats values. The CLI parses these through
+# `_parse_annotation_format_value` (which already produces a friendlier
+# error with format suggestions), so we should only land here when the
+# Snakefile is invoked directly with a hand-written configfile.
 for af in annotation_formats:
-    AnnotationFormats(af)
-    # TODO: make a nicer error
+    try:
+        AnnotationFormats(af)
+    except ValueError:
+        valid = ', '.join(v.value for v in AnnotationFormats)
+        raise ValueError(
+            f"Unsupported annotation format {af!r} in config['annotation_formats']. "
+            f"Valid values: {valid}."
+        )
 
 annotation_labels_opt = AnnotationLabelsSource(config['annotation_labels_source']).to_annotation_cmd_option()
 with_counts = config[workflow_configs.WITH_COUNTS]
@@ -37,7 +46,7 @@ if workflow_configs.ANNOTATE_THREADS_EACH not in config:
 
 
 metagraph_cmd=config['metagraph_cmd']
-time_cmd=utils.get_gnu_time_command(config)
+time_cmd=utils.get_time_wrapper_command(config)
 
 max_threads = config.get(workflow_configs.MAX_THREADS) or workflow.cores
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -293,8 +293,6 @@ rd_col_annodbg_paths = utils.generate_col_paths(rd_cols_dir, seqs_file_list_path
 rd_col_counts_paths = [Path(str(p) + '.counts') for p in rd_col_annodbg_paths] if with_counts else []
 rd_col_coords_paths = [Path(str(p) + '.coords') for p in rd_col_annodbg_paths] if with_coordinates else []
 
-from metagraph_workflows.resource_management import TransformRdStage0Resources
-
 TRANSFORM_RD_STAGE0_RULE="transform_rd_stage0"
 rule transform_rd_stage0:
     input:

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -82,6 +82,17 @@ column_anno_paths = utils.generate_col_paths(annotation_cols_path, seqs_file_lis
 column_counts_paths = [Path(str(p) + '.counts') for p in column_anno_paths] if with_counts else []
 column_coords_paths = [Path(str(p) + '.coords') for p in column_anno_paths] if with_coordinates else []
 
+
+# When the user sets --keep-columns / --keep-rd-columns, the per-sample
+# column files survive past the rules that produce them; otherwise
+# snakemake's `temp()` marker tells it to delete them once no live
+# job needs them.
+def _maybe_temp_columns(paths):
+    return paths if config.get('keep_columns', False) else temp(paths)
+
+def _maybe_temp_rd_columns(paths):
+    return paths if config.get('keep_rd_columns', False) else temp(paths)
+
 contigs_dir=wdir/'contigs'
 
 seq_ids_dict = {}
@@ -165,9 +176,9 @@ rule annotate:
         dbg_graph=graph_path,
     output:
         done=touch(annotation_path_done),
-        column_anno_files=temp(column_anno_paths),
-        column_count_files=(temp(column_counts_paths) if with_counts else []),
-        column_coord_files=(temp(column_coords_paths) if with_coordinates else []),
+        column_anno_files=_maybe_temp_columns(column_anno_paths),
+        column_count_files=(_maybe_temp_columns(column_counts_paths) if with_counts else []),
+        column_coord_files=(_maybe_temp_columns(column_coords_paths) if with_coordinates else []),
     threads: max_threads
     resources:
         mem_mb=ResourceConfig(ANNOTATE_RULE, config).get_mem(),
@@ -437,11 +448,18 @@ rule transform_rd_stage1:
         column_coord_files=rules.annotate.output.column_coord_files,
         columns_rd_row_count=rules.transform_rd_stage0.output.columns_rd_row_count
     output:
+        # pred/succ/pred_boundary/succ_boundary/row_reduction are
+        # consumed only by `transform_rd_stage2`; keep them temp()
+        # regardless. `rd_succ` is also an input to every
+        # `annotate_row_diff_*` rule, so it gets kept by
+        # `--keep-rd-columns` (paired with `anchors` from stage 2)
+        # to let the BRWT-clustering step be re-run with different
+        # parameters without redoing stages 1-2.
         pred=temp(wdir / f'{graph}.dbg.pred'),
         pred_boundary=temp(wdir / f'{graph}.dbg.pred_boundary'),
         succ=temp(wdir / f'{graph}.dbg.succ'),
         succ_boundary=temp(wdir / f'{graph}.dbg.succ_boundary'),
-        rd_succ=temp(wdir / f'{graph}.dbg.rd_succ'),
+        rd_succ=_maybe_temp_rd_columns(wdir / f'{graph}.dbg.rd_succ'),
         row_reduction=temp(rd_cols_dir / 'vector.row_reduction'),
         stage1_done=touch(rd_cols_dir / 'stage1.DONE')
     threads: max_threads
@@ -483,11 +501,11 @@ rule transform_rd_stage2:
         rd_succ=rules.transform_rd_stage1.output.rd_succ,
         stage1_done=rules.transform_rd_stage1.output.stage1_done
     output:
-        anchors=temp(wdir/f'{graph}.dbg.anchors'),
+        anchors=_maybe_temp_rd_columns(wdir/f'{graph}.dbg.anchors'),
         rd_cols_done=touch(rd_cols_dir/DONE),
-        rd_col_annodbg_files=temp(rd_col_annodbg_paths),
-        rd_col_count_files=(temp(rd_col_counts_paths) if with_counts else []),
-        rd_col_coord_files=(temp(rd_col_coords_paths) if with_coordinates else []),
+        rd_col_annodbg_files=_maybe_temp_rd_columns(rd_col_annodbg_paths),
+        rd_col_count_files=(_maybe_temp_rd_columns(rd_col_counts_paths) if with_counts else []),
+        rd_col_coord_files=(_maybe_temp_rd_columns(rd_col_coords_paths) if with_coordinates else []),
     threads: max_threads
     resources:
         mem_mb=TransformRdStage2Resources(config).get_mem(),

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -75,13 +75,31 @@ localrules: generate_column_list
 
 external_graph = config.get('external_graph', False)
 
+# The CoordToHeader sidecar (.seqs) maps file-level coord ranges to the
+# original sequence headers. It only makes sense when:
+#   - the annotation is coordinate-aware (`with_coordinates`), AND
+#   - the annotation columns are keyed by file (`--anno-filename`).
+# In `--anno-header` mode each sequence already gets its own column, so
+# coords are per-sequence and no sidecar is needed.
+build_coord_sidecar = (
+    with_coordinates
+    and AnnotationLabelsSource(config['annotation_labels_source']) == AnnotationLabelsSource.FILE_NAMES
+)
+
 rule all:
     input:
         graph_path,
         # Skip the small-state graph in annotate-only mode: the user
         # already has their built graph; we don't want to re-transform it.
         *([small_graph_path] if not external_graph else []),
-        [wdir/f'{graph}.{anno_type}.annodbg' for anno_type in annotation_formats]
+        [wdir/f'{graph}.{anno_type}.annodbg' for anno_type in annotation_formats],
+        # One .seqs sidecar per requested coord format. The loader strips
+        # `.annodbg` from the annotation path and appends `.seqs`, so the
+        # paths must match per-format. The content can differ across
+        # formats because BRWT clustering reorders columns, so we build
+        # one .seqs per format using each annotation's own column order.
+        *([wdir/f'{graph}.{anno_type}.seqs' for anno_type in annotation_formats]
+          if build_coord_sidecar else []),
 
 
 if not external_graph:
@@ -164,6 +182,50 @@ rule annotate:
           --separately \
           -o $OUT_DIR {params.tempdir_opt} > {log} 2>&1
         """
+
+INDEX_HEADER_COORDS_RULE="index_header_coords"
+rule index_header_coords:
+    """Build the CoordToHeader (.seqs) sidecar used by coord queries.
+
+    `metagraph annotate --index-header-coords` is a separate pass that
+    re-reads the input fastas; the file labels and coord offsets line up
+    with the annotation only if the inputs are passed in the same order
+    as the columns in the final annotation. BRWT clustering reorders
+    columns, so the order we annotated with no longer matches the order
+    in the transformed annotation -- we recover it from the annotation
+    itself via `stats --print-col-names`. Each coord-aware column label
+    is the absolute fasta path (see annotate.cpp: `labels.push_back(file)`
+    in `--anno-filename` mode), so the column-name list piped from
+    `stats` is exactly what `annotate --index-header-coords` expects on
+    stdin.
+    """
+    input:
+        annotation=wdir/f'{graph}.{{anno_type}}.annodbg',
+        dbg_graph=graph_path,
+    output:
+        seqs_sidecar=wdir/f'{graph}.{{anno_type}}.seqs',
+    wildcard_constraints:
+        anno_type="brwt_coord|row_diff_coord|row_diff_brwt_coord|row_diff_disk_coord",
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(INDEX_HEADER_COORDS_RULE, config).get_mem(),
+    log: utils.get_log_path(INDEX_HEADER_COORDS_RULE, config, ['anno_type'])
+    shell:
+        """
+        OUT_BASE={output.seqs_sidecar}
+        # `stats --print-col-names` prints "Number of columns: N" on the
+        # first line, then one column label per line in annotation order.
+        # Skip the header line and pipe the rest to annotate.
+        {metagraph_cmd} stats --print-col-names -a {input.annotation} 2>>{log} \
+            | tail -n +2 \
+            | {time_cmd} {metagraph_cmd} annotate {verbose_opt} \
+                --anno-filename \
+                --index-header-coords \
+                -p {threads} \
+                -i {input.dbg_graph} \
+                -o ${{OUT_BASE%.seqs}} >> {log} 2>&1
+        """
+
 
 GENERATE_COLUMN_LIST_RULE="generate_column_list"
 rule generate_column_list:

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -83,7 +83,7 @@ external_graph = config.get('external_graph', False)
 # coords are per-sequence and no sidecar is needed.
 build_coord_sidecar = (
     with_coordinates
-    and AnnotationLabelsSource(config['annotation_labels_source']) == AnnotationLabelsSource.FILE_NAMES
+    and AnnotationLabelsSource(config['annotation_labels_source']) == AnnotationLabelsSource.FILENAME
 )
 
 rule all:

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -68,14 +68,18 @@ if not config[workflow_configs.SAMPLE_IDS_PATH]:
 
 localrules: generate_column_list
 
+external_graph = config.get('external_graph', False)
+
 rule all:
     input:
         graph_path,
-        small_graph_path,
+        # Skip the small-state graph in annotate-only mode: the user
+        # already has their built graph; we don't want to re-transform it.
+        *([small_graph_path] if not external_graph else []),
         [wdir/f'{graph}.{anno_type}.annodbg' for anno_type in annotation_formats]
 
 
-if not config.get('external_graph', False):
+if not external_graph:
     include: 'build.smk'
 
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -2,7 +2,6 @@ from pathlib import Path
 
 import metagraph_workflows.utils
 from metagraph_workflows import workflow_configs, utils
-from metagraph_workflows.utils import take_value_or_default
 from metagraph_workflows.workflow_configs import AnnotationLabelsSource, \
     AnnotationFormats
 from metagraph_workflows.resource_management import TransformRdStage0Resources, TransformRdStage1Resources, TransformRdStage2Resources, AnnotateResources, ResourceConfig
@@ -40,7 +39,7 @@ if workflow_configs.ANNOTATE_THREADS_EACH not in config:
 metagraph_cmd=config['metagraph_cmd']
 time_cmd=utils.get_gnu_time_command(config)
 
-max_threads=take_value_or_default(workflow_configs.MAX_THREADS, workflow.cores, config)
+max_threads = config.get(workflow_configs.MAX_THREADS) or workflow.cores
 
 verbose_opt=' -v '
 
@@ -111,6 +110,8 @@ rule build_small_graph:
 
 
 ANNOTATE_RULE="annotate"
+_annotate_resources = AnnotateResources(config)
+
 rule annotate:
     input:
         seqs=utils.get_build_joint_input(config, contigs_dir, seq_ids_dict, seqs_file_list_path),
@@ -125,8 +126,8 @@ rule annotate:
         mem_mb=ResourceConfig(ANNOTATE_RULE, config).get_mem(),
     params:
         separate_build=str(bool(config[workflow_configs.PRIMARIZE_SAMPLES_SEPARATELY])).lower(),
-        threads_each=lambda wildcards, threads: AnnotateResources(config).get_effective_threads_each(threads),
-        parallel_cols=lambda wildcards, threads: AnnotateResources(config).get_parallel_cols(threads),
+        threads_each=lambda wildcards, threads: _annotate_resources.get_effective_threads_each(threads),
+        parallel_cols=lambda wildcards, threads: _annotate_resources.get_parallel_cols(threads),
         # `--mem-cap-gb` and `--disk-swap` only matter when annotating
         # with counts or coordinates (the per-k-mer payload is large
         # enough that the buffer can overflow). For binary annotation,
@@ -134,7 +135,7 @@ rule annotate:
         # spill path. Matches experiments/large_index_scripts.md.
         mem_cap_arg=(
             (lambda wildcards, input, threads, resources:
-                f"--mem-cap-gb {AnnotateResources(config).get_mem_buffer_gib()(wildcards, input, threads, resources)}")
+                f"--mem-cap-gb {_annotate_resources.get_mem_buffer_gib()(wildcards, input, threads, resources)}")
             if (with_counts or with_coordinates) else ''
         ),
         tempdir_opt=utils.temp_dir_config(config) if (with_counts or with_coordinates) else '',
@@ -160,7 +161,6 @@ rule annotate:
           {count_kmers_opt} \
           {coordinates_opt} \
           {count_width_opt} \
-          --anno-type column \
           --separately \
           -o $OUT_DIR {params.tempdir_opt} > {log} 2>&1
         """

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -174,8 +174,6 @@ rule generate_column_list:
             f.write('\n'.join([str(l) for l in input]))
 
 
-max_path_length=None
-
 GENERATE_BRWT_LINKAGE_RULE="generate_brwt_linkage"
 rule generate_brwt_linkage:
     input:

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -42,6 +42,7 @@ DONE="DONE"
 
 ## Paths
 graph_path=wdir/f'{graph}.dbg'
+small_graph_path=wdir/f'{graph}_small.dbg'
 if with_counts:
     annotation_mode_suffix = f'counts.w{count_width}'
 elif with_coordinates:
@@ -70,6 +71,7 @@ localrules: generate_column_list
 rule all:
     input:
         graph_path,
+        small_graph_path,
         [wdir/f'{graph}.{anno_type}.annodbg' for anno_type in annotation_formats]
 
 
@@ -108,7 +110,7 @@ rule annotate:
         mkdir -p $OUT_DIR
         cat $SEQ_PATHS | {time_cmd} {metagraph_cmd} annotate \
           {verbose_opt} \
-          --parallel {params.parallel_cols} \
+          -p {params.parallel_cols} \
           --threads-each {params.threads_each} \
           --mem-cap-gb {params.mem_buffer} \
           -i {input.dbg_graph} \
@@ -154,7 +156,7 @@ rule generate_brwt_linkage:
             --linkage \
             --greedy \
             --subsample {params.subsample} \
-            --parallel {threads} \
+            -p {threads} \
             -o {output.linkage} > {log} 2>&1
         """
 
@@ -185,7 +187,7 @@ rule transform_annotation:
         """        
         cat {input.columns_file} | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type {wildcards.anno_type} \
-            --parallel {threads} \
+            -p {threads} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
 
@@ -213,7 +215,7 @@ rule annotate_brwt:
             --anno-type brwt \
             --parallel-nodes {params.parallel_nodes} \
             --greedy \
-            --parallel {threads} \
+            -p {threads} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
 
@@ -236,7 +238,7 @@ rule relax_brwt:
             -o {output.annotations} \
             {verbose_opt} \
             --relax-arity {params.relax_arity} \
-            --parallel {threads} \
+            -p {threads} \
             {input.brwt_annots} > {log} 2>&1
         """
 
@@ -276,7 +278,7 @@ rule transform_rd_stage0:
             --anno-type row_diff \
             --row-diff-stage 0 \
             -i {input.dbg_graph} \
-            --parallel {threads} \
+            -p {threads} \
             {count_kmers_opt} \
             {coordinates_opt} \
             {count_width_opt} \
@@ -315,7 +317,7 @@ rule transform_rd_stage1:
             --anno-type row_diff \
             --row-diff-stage 1 \
             -i {input.dbg_graph} \
-            --parallel {threads} \
+            -p {threads} \
             {count_kmers_opt} \
             {coordinates_opt} \
             {count_width_opt} \
@@ -358,7 +360,7 @@ rule transform_rd_stage2:
             --anno-type row_diff \
             --row-diff-stage 2 \
             -i {input.dbg_graph} \
-            --parallel {threads} \
+            -p {threads} \
             {count_kmers_opt} \
             {coordinates_opt} \
             {count_width_opt} \
@@ -394,7 +396,7 @@ rule annotate_row_diff_brwt:
             --anno-type row_diff_brwt \
             --greedy \
             --parallel-nodes {params.parallel_nodes} \
-            --parallel {threads} \
+            -p {threads} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
@@ -418,7 +420,7 @@ rule relax_row_diff_brwt:
             -o {output.annotations_relaxed} \
             {verbose_opt} \
             --relax-arity {params.relax_arity} \
-            --parallel {threads} \
+            -p {threads} \
             {input.brwt_annots} > {log} 2>&1
         """
 
@@ -449,7 +451,7 @@ rule annotate_row_diff_int_brwt:
             --anno-type row_diff_int_brwt \
             --greedy \
             --parallel-nodes {params.parallel_nodes} \
-            --parallel {threads} \
+            -p {threads} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
@@ -477,7 +479,7 @@ rule annotate_row_diff_int_disk:
         r"""
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_int_disk \
-            --parallel {threads} \
+            -p {threads} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
@@ -509,7 +511,7 @@ rule annotate_row_diff_brwt_coord:
             --anno-type row_diff_brwt_coord \
             --greedy \
             --parallel-nodes {params.parallel_nodes} \
-            --parallel {threads} \
+            -p {threads} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
@@ -537,7 +539,7 @@ rule annotate_row_diff_coord:
         r"""
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_coord \
-            --parallel {threads} \
+            -p {threads} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
@@ -565,7 +567,7 @@ rule annotate_row_diff_disk_coord:
         r"""
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_disk_coord \
-            --parallel {threads} \
+            -p {threads} \
             -i {input.dbg_graph} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -10,7 +10,7 @@ from metagraph_workflows.resource_management import TransformRdStage0Resources, 
 wdir=utils.get_wdir(config)
 
 graph=config['base_name']
-build_primary=take_value_or_default('build_primary_graph', False, config)
+build_primary=config['build_primary_graph']
 
 annotation_formats = config['annotation_formats'] if isinstance(config['annotation_formats'], list) else [config['annotation_formats']]
 
@@ -20,12 +20,12 @@ for af in annotation_formats:
     # TODO: make a nicer error
 
 annotation_labels_opt = AnnotationLabelsSource(config['annotation_labels_source']).to_annotation_cmd_option()
-with_counts = take_value_or_default(workflow_configs.WITH_COUNTS, False, config)
-with_coordinates = take_value_or_default(workflow_configs.WITH_COORDINATES, False, config)
+with_counts = config[workflow_configs.WITH_COUNTS]
+with_coordinates = config[workflow_configs.WITH_COORDINATES]
 if with_counts and with_coordinates:
     raise RuntimeError(
         'with_counts and with_coordinates cannot both be true (same constraint as metagraph row-diff).')
-count_width = take_value_or_default(workflow_configs.COUNT_WIDTH, 8, config)
+count_width = config[workflow_configs.COUNT_WIDTH]
 count_kmers_opt = '--count-kmers' if with_counts else ''
 coordinates_opt = '--coordinates' if with_coordinates else ''
 count_width_opt = f'--count-width {count_width}' if with_counts else ''
@@ -35,9 +35,6 @@ metagraph_cmd=config['metagraph_cmd']
 time_cmd=utils.get_gnu_time_command(config)
 
 max_threads=take_value_or_default(workflow_configs.MAX_THREADS, workflow.cores, config)
-
-# TODO
-max_memory_mb=take_value_or_default('max_memory_mb', 4000, config)
 
 verbose_opt=' -v '
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -41,7 +41,15 @@ time_cmd=utils.get_gnu_time_command(config)
 
 max_threads = config.get(workflow_configs.MAX_THREADS) or workflow.cores
 
-verbose_opt=' -v '
+# Always pass -v to metagraph so logs are complete; whether the user
+# sees that on their terminal is controlled by `log_tail` below.
+verbose_opt = ' -v '
+
+# Tail of the `tee {log}` pipeline: when the workflow is verbose, tee's
+# stdout falls through to the caller's terminal so the user sees all
+# metagraph progress / traces live; otherwise we silence tee's stdout
+# and the same content lives in {log} only.
+log_tail = '' if config.get('verbose', False) else '> /dev/null'
 
 DONE="DONE"
 
@@ -135,7 +143,7 @@ rule build_small_graph:
         --state small \
         -p {threads} \
         -o ${{OUT_BASE%.dbg}} \
-        {input} > {log} 2>&1
+        {input} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -192,7 +200,7 @@ rule annotate:
           {coordinates_opt} \
           {count_width_opt} \
           --separately \
-          -o $OUT_DIR {params.tempdir_opt} > {log} 2>&1
+          -o $OUT_DIR {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 INDEX_HEADER_COORDS_RULE="index_header_coords"
@@ -242,7 +250,7 @@ if build_coord_sidecar:
                     --index-header-coords \
                     -p {threads} \
                     -i {input.dbg_graph} \
-                    -o ${{OUT_BASE%.seqs}} >> {log} 2>&1
+                    -o ${{OUT_BASE%.seqs}} 2>&1 | tee -a {log} {log_tail}
             """
 
 
@@ -278,7 +286,7 @@ rule generate_brwt_linkage:
             --greedy \
             --subsample {params.subsample} \
             -p {threads} \
-            -o {output.linkage} > {log} 2>&1
+            -o {output.linkage} 2>&1 | tee {log} {log_tail}
         """
 
 ruleorder: relax_brwt > transform_annotation # more specific rule has priority
@@ -310,7 +318,7 @@ rule transform_annotation:
         cat {input.columns_file} | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type {wildcards.anno_type} \
             -p {threads} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -340,7 +348,7 @@ rule annotate_brwt:
             --subsample {params.subsample} \
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -363,7 +371,7 @@ rule relax_brwt:
             {verbose_opt} \
             --relax-arity {params.relax_arity} \
             -p {threads} \
-            {input.brwt_annots} > {log} 2>&1
+            {input.brwt_annots} 2>&1 | tee {log} {log_tail}
         """
 
 rd_cols_dir = wdir/f'rd_cols.{annotation_mode_suffix}'
@@ -407,7 +415,7 @@ rule transform_rd_stage0:
             {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
-            -o {output.columns_rd_row_count} > {log} 2>&1
+            -o {output.columns_rd_row_count} 2>&1 | tee {log} {log_tail}
         """
 
 TRANSFORM_RD_STAGE1_RULE="transform_rd_stage1"
@@ -446,7 +454,7 @@ rule transform_rd_stage1:
             {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
-            -o {output.row_reduction} {params.tempdir_opt} > {log} 2>&1
+            -o {output.row_reduction} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -489,7 +497,7 @@ rule transform_rd_stage2:
             {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
-            -o {output.rd_cols_done} {params.tempdir_opt} > {log} 2>&1
+            -o {output.rd_cols_done} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -524,7 +532,7 @@ rule annotate_row_diff_brwt:
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
             -i {input.dbg_graph} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -547,7 +555,7 @@ rule relax_row_diff_brwt:
             {verbose_opt} \
             --relax-arity {params.relax_arity} \
             -p {threads} \
-            {input.brwt_annots} > {log} 2>&1
+            {input.brwt_annots} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -581,7 +589,7 @@ rule annotate_row_diff_int_brwt:
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
             -i {input.dbg_graph} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -626,7 +634,7 @@ rule annotate_row_diff_binary:
             -p {threads} \
             {params.mem_cap_arg} \
             -i {input.dbg_graph} \
-            -o {output.annotations} > {log} 2>&1
+            -o {output.annotations} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -654,7 +662,7 @@ rule annotate_row_diff_int_disk:
             --anno-type row_diff_int_disk \
             -p {threads} \
             -i {input.dbg_graph} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -688,7 +696,7 @@ rule annotate_row_diff_brwt_coord:
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
             -i {input.dbg_graph} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -716,7 +724,7 @@ rule annotate_row_diff_coord:
             --anno-type row_diff_coord \
             -p {threads} \
             -i {input.dbg_graph} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -744,5 +752,5 @@ rule annotate_row_diff_disk_coord:
             --anno-type row_diff_disk_coord \
             -p {threads} \
             -i {input.dbg_graph} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -232,16 +232,15 @@ rule relax_brwt:
         mem_mb=ResourceConfig(RELAX_BRWT_RULE, config).get_mem(),
     params:
         relax_arity=config[workflow_configs.BRWT_RELAX_ARITY],
-        tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(RELAX_BRWT_RULE, config, ['brwt_fmt'])
     shell:
-        """        
+        """
         {time_cmd} {metagraph_cmd} relax_brwt \
             -o {output.annotations} \
             {verbose_opt} \
             --relax-arity {params.relax_arity} \
             --parallel {threads} \
-            {input.brwt_annots} {params.tempdir_opt} > {log} 2>&1
+            {input.brwt_annots} > {log} 2>&1
         """
 
 rd_cols_dir = wdir/f'rd_cols.{annotation_mode_suffix}'
@@ -415,16 +414,15 @@ rule relax_row_diff_brwt:
         mem_mb=ResourceConfig(RELAX_ROW_DIFF_BRWT_RULE, config).get_mem(),
     params:
         relax_arity = config[workflow_configs.BRWT_RELAX_ARITY],
-        tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(RELAX_ROW_DIFF_BRWT_RULE, config)
     shell:
-        """        
+        """
         {time_cmd} {metagraph_cmd} relax_brwt \
             -o {output.annotations_relaxed} \
             {verbose_opt} \
             --relax-arity {params.relax_arity} \
             --parallel {threads} \
-            {input.brwt_annots} {params.tempdir_opt} > {log} 2>&1
+            {input.brwt_annots} > {log} 2>&1
         """
 
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -5,7 +5,7 @@ from metagraph_workflows import workflow_configs, utils
 from metagraph_workflows.utils import take_value_or_default
 from metagraph_workflows.workflow_configs import AnnotationLabelsSource, \
     AnnotationFormats
-from metagraph_workflows.resource_management import TransformRdStage0Resources, TransformRdStage1Resources, TransformRdStage2Resources, ResourceConfig
+from metagraph_workflows.resource_management import TransformRdStage0Resources, TransformRdStage1Resources, TransformRdStage2Resources, AnnotateResources, ResourceConfig
 
 wdir=utils.get_wdir(config)
 
@@ -94,6 +94,9 @@ rule annotate:
     params:
         separate_build=str(bool(config[workflow_configs.PRIMARIZE_SAMPLES_SEPARATELY])).lower(),
         tempdir_opt=utils.temp_dir_config(config),
+        threads_each=lambda wildcards, threads: AnnotateResources(config).get_effective_threads_each(threads),
+        parallel_cols=lambda wildcards, threads: AnnotateResources(config).get_parallel_cols(threads),
+        mem_buffer=AnnotateResources(config).get_mem_buffer_gib(),
     log: utils.get_log_path(ANNOTATE_RULE, config)
     shell:
         """
@@ -108,7 +111,9 @@ rule annotate:
         mkdir -p $OUT_DIR
         cat $SEQ_PATHS | {time_cmd} {metagraph_cmd} annotate \
           {verbose_opt} \
-          --parallel {threads} \
+          --parallel {params.parallel_cols} \
+          --threads-each {params.threads_each} \
+          --mem-cap-gb {params.mem_buffer} \
           -i {input.dbg_graph} \
           {annotation_labels_opt} \
           {count_kmers_opt} \

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -30,6 +30,12 @@ count_kmers_opt = '--count-kmers' if with_counts else ''
 coordinates_opt = '--coordinates' if with_coordinates else ''
 count_width_opt = f'--count-width {count_width}' if with_counts else ''
 
+# Auto-derive `annotate_threads_each` from annotation mode if not set
+# by the user. Coordinate annotation has larger per-k-mer work, so each
+# column gets more threads and fewer columns run in parallel.
+if workflow_configs.ANNOTATE_THREADS_EACH not in config:
+    config[workflow_configs.ANNOTATE_THREADS_EACH] = 16 if with_coordinates else 8
+
 
 metagraph_cmd=config['metagraph_cmd']
 time_cmd=utils.get_gnu_time_command(config)
@@ -119,10 +125,19 @@ rule annotate:
         mem_mb=ResourceConfig(ANNOTATE_RULE, config).get_mem(),
     params:
         separate_build=str(bool(config[workflow_configs.PRIMARIZE_SAMPLES_SEPARATELY])).lower(),
-        tempdir_opt=utils.temp_dir_config(config),
         threads_each=lambda wildcards, threads: AnnotateResources(config).get_effective_threads_each(threads),
         parallel_cols=lambda wildcards, threads: AnnotateResources(config).get_parallel_cols(threads),
-        mem_buffer=AnnotateResources(config).get_mem_buffer_gib(),
+        # `--mem-cap-gb` and `--disk-swap` only matter when annotating
+        # with counts or coordinates (the per-k-mer payload is large
+        # enough that the buffer can overflow). For binary annotation,
+        # omit both: per-column buffers are tiny and never need a
+        # spill path. Matches experiments/large_index_scripts.md.
+        mem_cap_arg=(
+            (lambda wildcards, input, threads, resources:
+                f"--mem-cap-gb {AnnotateResources(config).get_mem_buffer_gib()(wildcards, input, threads, resources)}")
+            if (with_counts or with_coordinates) else ''
+        ),
+        tempdir_opt=utils.temp_dir_config(config) if (with_counts or with_coordinates) else '',
     log: utils.get_log_path(ANNOTATE_RULE, config)
     shell:
         """
@@ -139,7 +154,7 @@ rule annotate:
           {verbose_opt} \
           -p {params.parallel_cols} \
           --threads-each {params.threads_each} \
-          --mem-cap-gb {params.mem_buffer} \
+          {params.mem_cap_arg} \
           -i {input.dbg_graph} \
           {annotation_labels_opt} \
           {count_kmers_opt} \
@@ -234,14 +249,16 @@ rule annotate_brwt:
         mem_mb=ResourceConfig(ANNOTATE_BRWT_RULE, config).get_mem(),
     params:
         parallel_nodes=config[workflow_configs.BRWT_PARALLEL_NODES],
+        subsample=config[workflow_configs.BRWT_LINKAGE_SUBSAMPLE],
         tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(ANNOTATE_BRWT_RULE, config)
     shell:
-        """        
+        """
         cat {input.columns_file} | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type brwt \
-            --parallel-nodes {params.parallel_nodes} \
             --greedy \
+            --subsample {params.subsample} \
+            --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
             -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
         """
@@ -294,9 +311,11 @@ rule transform_rd_stage0:
         mem_mb=TransformRdStage0Resources(config).get_mem()
     params:
         mem_buffer=TransformRdStage0Resources(config).get_mem_buffer_gib(),
-        tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(TRANSFORM_RD_STAGE0_RULE,config)
     shell:
+        # Stage 0 builds the row-count vector in RAM only; metagraph
+        # does not use --disk-swap at this stage, so the flag is
+        # intentionally omitted (matches large_index_scripts.md).
         """
         COLS_DIR=$(dirname {output.columns_rd_row_count})
         mkdir -p $COLS_DIR
@@ -310,7 +329,7 @@ rule transform_rd_stage0:
             {coordinates_opt} \
             {count_width_opt} \
             --mem-cap-gb {params.mem_buffer} \
-            -o {output.columns_rd_row_count} {params.tempdir_opt} > {log} 2>&1
+            -o {output.columns_rd_row_count} > {log} 2>&1
         """
 
 TRANSFORM_RD_STAGE1_RULE="transform_rd_stage1"
@@ -414,6 +433,7 @@ rule annotate_row_diff_brwt:
         mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_BRWT_RULE, config).get_mem(),
     params:
         parallel_nodes=config[workflow_configs.BRWT_PARALLEL_NODES],
+        subsample=config[workflow_configs.BRWT_LINKAGE_SUBSAMPLE],
         tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(ANNOTATE_ROW_DIFF_BRWT_RULE, config)
     shell:
@@ -422,6 +442,7 @@ rule annotate_row_diff_brwt:
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_brwt \
             --greedy \
+            --subsample {params.subsample} \
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
             -i {input.dbg_graph} \
@@ -470,6 +491,7 @@ rule annotate_row_diff_int_brwt:
         mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_INT_BRWT_RULE, config).get_mem(),
     params:
         parallel_nodes=config[workflow_configs.BRWT_PARALLEL_NODES],
+        subsample=config[workflow_configs.BRWT_LINKAGE_SUBSAMPLE],
         tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(ANNOTATE_ROW_DIFF_INT_BRWT_RULE, config)
     shell:
@@ -477,6 +499,7 @@ rule annotate_row_diff_int_brwt:
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_int_brwt \
             --greedy \
+            --subsample {params.subsample} \
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
             -i {input.dbg_graph} \
@@ -530,6 +553,7 @@ rule annotate_row_diff_brwt_coord:
         mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_BRWT_COORD_RULE, config).get_mem(),
     params:
         parallel_nodes=config[workflow_configs.BRWT_PARALLEL_NODES],
+        subsample=config[workflow_configs.BRWT_LINKAGE_SUBSAMPLE],
         tempdir_opt=utils.temp_dir_config(config),
     log: utils.get_log_path(ANNOTATE_ROW_DIFF_BRWT_COORD_RULE, config)
     shell:
@@ -537,6 +561,7 @@ rule annotate_row_diff_brwt_coord:
         find $(dirname {input.rd_cols_done}) -name \*.annodbg | {time_cmd} {metagraph_cmd} transform_anno {verbose_opt} \
             --anno-type row_diff_brwt_coord \
             --greedy \
+            --subsample {params.subsample} \
             --parallel-nodes {params.parallel_nodes} \
             -p {threads} \
             -i {input.dbg_graph} \

--- a/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
+++ b/metagraph/workflows/metagraph_workflows/snakemake/Snakefile
@@ -513,9 +513,11 @@ rule annotate_row_diff_binary:
     """Binary row-diff annotation in flat / sparse / disk form.
 
     The three formats share the same input (row-diff stage-2 columns +
-    graph) and CLI shape. `--mem-cap-gb` is only meaningful for
-    row_diff_disk (which materializes the row-diff buffer to disk);
-    flat / sparse don't use it, matching the convention in
+    graph) and CLI shape. Only row_diff_disk actually consumes
+    `--mem-cap-gb` (the other two have `mem_bytes` commented out in
+    metagraph's convert_to_row_diff implementation); none of them use
+    `--disk-swap` internally, so neither is emitted for flat / sparse
+    and only --mem-cap-gb is emitted for disk. Matches
     experiments/large_index_scripts.md.
     """
     input:
@@ -534,7 +536,6 @@ rule annotate_row_diff_binary:
     resources:
         mem_mb=ResourceConfig(ANNOTATE_ROW_DIFF_BINARY_RULE, config).get_mem(),
     params:
-        tempdir_opt=utils.temp_dir_config(config),
         mem_cap_arg=(
             lambda wildcards, input, threads, resources:
                 f"--mem-cap-gb {TransformRdStage2Resources(config).get_mem_buffer_gib()(wildcards, input, threads, resources)}"
@@ -548,7 +549,7 @@ rule annotate_row_diff_binary:
             -p {threads} \
             {params.mem_cap_arg} \
             -i {input.dbg_graph} \
-            -o {output.annotations} {params.tempdir_opt} > {log} 2>&1
+            -o {output.annotations} > {log} 2>&1
         """
 
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/build.smk
+++ b/metagraph/workflows/metagraph_workflows/snakemake/build.smk
@@ -25,7 +25,7 @@ rule build:
     shell:
         """
         cat {input} | {time_cmd} {metagraph_cmd} build {verbose_opt} \
-        --parallel {threads} \
+        -p {threads} \
         -k {params.k} \
         -o {output} \
         --mem-cap-gb {params.mem_buffer} \
@@ -145,7 +145,7 @@ rule build_canonical_graph_single_sample:
         fi
         
         $INPUT_CMD | {time_cmd} {metagraph_cmd} build {verbose_opt} \
-        --parallel {threads} \
+        -p {threads} \
         --mode canonical \
         -k {params.k} \
         -o {output.graph} \
@@ -169,7 +169,7 @@ rule primarize_canonical_graph_single_sample:
         echo "{input}" | {time_cmd} {metagraph_cmd} transform {verbose_opt} \
         --to-fasta \
         --primary-kmers \
-        --parallel {threads} \
+        -p {threads} \
         -o {output} > {log} 2>&1
         """
 
@@ -199,7 +199,7 @@ rule build_joint_graph:
         fi
 
         cat $SEQ_PATHS | {time_cmd} {metagraph_cmd} build {verbose_opt} \
-        --parallel {threads} \
+        -p {threads} \
         --mode canonical \
         -k {params.k} \
         -o {output} \
@@ -222,7 +222,7 @@ rule primarize_joint_graph:
         echo "{input}" | {time_cmd} {metagraph_cmd} transform {verbose_opt} \
         --to-fasta \
         --primary-kmers \
-        --parallel {threads} \
+        -p {threads} \
         -o {output} > {log} 2>&1
         """
 
@@ -244,7 +244,7 @@ rule build_joint_primary:
     shell:
         """
         {time_cmd} {metagraph_cmd} build {verbose_opt} \
-        --parallel {threads} \
+        -p {threads} \
         --mode primary \
         -k {params.k} \
         -o {output} \
@@ -252,4 +252,25 @@ rule build_joint_primary:
         --disk-cap-gb {params.disk_cap} \
         {input} \
         {params.tempdir_opt} > {log} 2>&1
+        """
+
+
+BUILD_SMALL_GRAPH_RULE="build_small_graph"
+rule build_small_graph:
+    input: graph_path
+    output: small_graph_path
+    threads: max_threads
+    resources:
+        mem_mb=ResourceConfig(BUILD_SMALL_GRAPH_RULE, config).get_mem(),
+    log: utils.get_log_path(BUILD_SMALL_GRAPH_RULE, config)
+    shell:
+        # `metagraph transform -o` takes a basename and appends `.dbg`,
+        # so strip the suffix before passing.
+        """
+        OUT_BASE={output}
+        {time_cmd} {metagraph_cmd} transform {verbose_opt} \
+        --state small \
+        -p {threads} \
+        -o ${{OUT_BASE%.dbg}} \
+        {input} > {log} 2>&1
         """

--- a/metagraph/workflows/metagraph_workflows/snakemake/build.smk
+++ b/metagraph/workflows/metagraph_workflows/snakemake/build.smk
@@ -43,10 +43,7 @@ canonical_graph_path=wdir/f'{graph}_canonical.dbg'
 
 joint_contigs_path=wdir/f'{graph}_primary.fasta.gz'
 
-
-sample_ids_spec = False
 orig_samples_path=wdir/'orig_samples'
-
 
 
 STAGE_SAMPLES_RULE="stage_samples"
@@ -109,13 +106,11 @@ rule extract_kmer_counts:
         {time_cmd} kmc -v -k{params.k} -m{params.mem_buffer} -sm -t{threads} -ci1 -cs65535 -n$KMC_BINS -j{output.summary} $FORMAT_FLAG $INPUT {params.base} {output.temp_dir} > {log} 2>&1
         """
 
-kmer_estimates=True
-
 BUILD_CANONICAL_GRAPH_SINGLE_SAMPLE_RULE="build_canonical_graph_single_sample"
 rule build_canonical_graph_single_sample:
     input:
         seq=utils.get_build_single_sample_input(config, orig_samples_path, seq_ids_dict),
-        kmer=kmc_dir/"{sample_id}.json" if kmer_estimates else []
+        kmer=kmc_dir/"{sample_id}.json"
     output:
         graph=temp(canonical_graphs_dir/"{sample_id}.dbg"),
         temp_dir=temp(directory(wdir / "temp_build_canonical_{sample_id}")),

--- a/metagraph/workflows/metagraph_workflows/snakemake/build.smk
+++ b/metagraph/workflows/metagraph_workflows/snakemake/build.smk
@@ -28,7 +28,7 @@ rule build:
         -k {params.k} \
         -o {output} \
         --mem-cap-gb {params.mem_buffer} \
-        {params.tempdir_opt} > {log} 2>&1
+        {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -55,7 +55,7 @@ rule stage_samples:
     log: utils.get_log_path(STAGE_SAMPLES_RULE, config, ['sample_id'])
     shell:
         """
-        bash {params.staging_script_path} {wildcards.sample_id} {output} {params.additional_options} > {log} 2>&1
+        bash {params.staging_script_path} {wildcards.sample_id} {output} {params.additional_options} 2>&1 | tee {log} {log_tail}
         """
 
 EXTRACT_KMER_COUNTS_RULE="extract_kmer_counts"
@@ -101,7 +101,7 @@ rule extract_kmer_counts:
              FORMAT_FLAG="-fm"
         fi
         
-        {time_cmd} kmc -v -k{params.k} -m{params.mem_buffer} -sm -t{threads} -ci1 -cs65535 -n$KMC_BINS -j{output.summary} $FORMAT_FLAG $INPUT {params.base} {output.temp_dir} > {log} 2>&1
+        {time_cmd} kmc -v -k{params.k} -m{params.mem_buffer} -sm -t{threads} -ci1 -cs65535 -n$KMC_BINS -j{output.summary} $FORMAT_FLAG $INPUT {params.base} {output.temp_dir} 2>&1 | tee {log} {log_tail}
         """
 
 BUILD_CANONICAL_GRAPH_SINGLE_SAMPLE_RULE="build_canonical_graph_single_sample"
@@ -141,7 +141,7 @@ rule build_canonical_graph_single_sample:
         -k {params.k} \
         -o {output.graph} \
         --mem-cap-gb {params.mem_buffer} \
-        {params.tempdir_opt} > {log} 2>&1
+        {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -160,7 +160,7 @@ rule primarize_canonical_graph_single_sample:
         --to-fasta \
         --primary-kmers \
         -p {threads} \
-        -o {output} > {log} 2>&1
+        -o {output} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -193,7 +193,7 @@ rule build_joint_graph:
         -k {params.k} \
         -o {output} \
         --mem-cap-gb {params.mem_buffer} \
-        {params.tempdir_opt} > {log} 2>&1
+        {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 PRIMARIZE_JOINT_GRAPH_RULE="primarize_joint_graph"
@@ -210,7 +210,7 @@ rule primarize_joint_graph:
         --to-fasta \
         --primary-kmers \
         -p {threads} \
-        -o {output} > {log} 2>&1
+        -o {output} 2>&1 | tee {log} {log_tail}
         """
 
 
@@ -236,7 +236,7 @@ rule build_joint_primary:
         -o {output} \
         --mem-cap-gb {params.mem_buffer} \
         {input} \
-        {params.tempdir_opt} > {log} 2>&1
+        {params.tempdir_opt} 2>&1 | tee {log} {log_tail}
         """
 
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/build.smk
+++ b/metagraph/workflows/metagraph_workflows/snakemake/build.smk
@@ -255,22 +255,3 @@ rule build_joint_primary:
         """
 
 
-BUILD_SMALL_GRAPH_RULE="build_small_graph"
-rule build_small_graph:
-    input: graph_path
-    output: small_graph_path
-    threads: max_threads
-    resources:
-        mem_mb=ResourceConfig(BUILD_SMALL_GRAPH_RULE, config).get_mem(),
-    log: utils.get_log_path(BUILD_SMALL_GRAPH_RULE, config)
-    shell:
-        # `metagraph transform -o` takes a basename and appends `.dbg`,
-        # so strip the suffix before passing.
-        """
-        OUT_BASE={output}
-        {time_cmd} {metagraph_cmd} transform {verbose_opt} \
-        --state small \
-        -p {threads} \
-        -o ${{OUT_BASE%.dbg}} \
-        {input} > {log} 2>&1
-        """

--- a/metagraph/workflows/metagraph_workflows/snakemake/build.smk
+++ b/metagraph/workflows/metagraph_workflows/snakemake/build.smk
@@ -20,7 +20,6 @@ rule build:
         k=config['k'],
         tempdir_opt=utils.temp_dir_config(config),
         mem_buffer=BuildGraphResources(BUILD_RULE, config).get_mem_buffer_gib(),
-        disk_cap=BuildGraphResources(BUILD_RULE, config).get_disk_cap(),
     log: utils.get_log_path(BUILD_RULE, config)
     shell:
         """
@@ -29,7 +28,6 @@ rule build:
         -k {params.k} \
         -o {output} \
         --mem-cap-gb {params.mem_buffer} \
-        --disk-cap-gb {params.disk_cap} \
         {params.tempdir_opt} > {log} 2>&1
         """
 
@@ -124,29 +122,26 @@ rule build_canonical_graph_single_sample:
         tempdir_opt=utils.temp_dir_config(config),
         temp_file=wdir,
         mem_buffer=BuildGraphResourcesWithKmerEstimates(BUILD_CANONICAL_GRAPH_SINGLE_SAMPLE_RULE, config).get_mem_buffer_gib(),
-        disk_cap=BuildGraphResourcesWithKmerEstimates(BUILD_CANONICAL_GRAPH_SINGLE_SAMPLE_RULE, config).get_disk_cap(),
     log: utils.get_log_path(BUILD_CANONICAL_GRAPH_SINGLE_SAMPLE_RULE, config, ['sample_id'])
     shell:
         """
-        
         INPUT_CMD="echo {input.seq}"
-        
+
         mkdir -p {output.temp_dir}
-        
+
         SAMPLE_FILE={output.temp_dir}/samples.lst
         if [ -d {input.seq} ]; then
             ls {input.seq}/* > $SAMPLE_FILE
             INPUT_CMD="cat $SAMPLE_FILE"
         fi
-        
+
         $INPUT_CMD | {time_cmd} {metagraph_cmd} build {verbose_opt} \
         -p {threads} \
         --mode canonical \
         -k {params.k} \
         -o {output.graph} \
         --mem-cap-gb {params.mem_buffer} \
-        --disk-cap-gb {params.disk_cap} \
-        {params.tempdir_opt} > {log} 2>&1  
+        {params.tempdir_opt} > {log} 2>&1
         """
 
 
@@ -182,7 +177,6 @@ rule build_joint_graph:
         separate_build=str(bool(config[workflow_configs.PRIMARIZE_SAMPLES_SEPARATELY])).lower(),
         tempdir_opt=utils.temp_dir_config(config),
         mem_buffer=BuildGraphResources(BUILD_JOINT_GRAPH_RULE, config).get_mem_buffer_gib(),
-        disk_cap=BuildGraphResources(BUILD_JOINT_GRAPH_RULE, config).get_disk_cap(),
     log: utils.get_log_path(BUILD_JOINT_GRAPH_RULE, config)
     shell:
         """
@@ -199,9 +193,7 @@ rule build_joint_graph:
         -k {params.k} \
         -o {output} \
         --mem-cap-gb {params.mem_buffer} \
-        --disk-cap-gb {params.disk_cap} \
         {params.tempdir_opt} > {log} 2>&1
-        
         """
 
 PRIMARIZE_JOINT_GRAPH_RULE="primarize_joint_graph"
@@ -234,7 +226,6 @@ rule build_joint_primary:
         k=config['k'],
         tempdir_opt=utils.temp_dir_config(config),
         mem_buffer=BuildGraphResources(BUILD_JOINT_PRIMARY_RULE, config).get_mem_buffer_gib(),
-        disk_cap=BuildGraphResources(BUILD_JOINT_PRIMARY_RULE, config).get_disk_cap()
     log: utils.get_log_path(BUILD_JOINT_PRIMARY_RULE, config)
     shell:
         """
@@ -244,7 +235,6 @@ rule build_joint_primary:
         -k {params.k} \
         -o {output} \
         --mem-cap-gb {params.mem_buffer} \
-        --disk-cap-gb {params.disk_cap} \
         {input} \
         {params.tempdir_opt} > {log} 2>&1
         """

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -15,6 +15,12 @@ annotation_labels_source: 'sequence_headers'
 with_counts: false
 with_coordinates: false
 count_width: 8
+# Threads used per file when annotating with --separately. The annotate
+# rule runs (max_threads // annotate_threads_each) columns in parallel,
+# and --mem-cap-gb is allocated per column, so raising this value reduces
+# parallel columns and increases each column's buffer budget.
+# Default of 8 matches the value most large-index runs use in practice.
+annotate_threads_each: 8
 
 brwt_relax_arity: 32
 brwt_parallel_nodes: 5

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -28,9 +28,9 @@ brwt_linkage_subsample: 100000
 
 metagraph_cmd: 'metagraph'
 
-default_disk_mb: 10000
+max_disk_mb: 1048576  # 1 TiB; surfaces as --disk-cap-gb 1024 in metagraph stages
 max_memory_mb: 4048
-max_buffer_size_mb: 51200
+max_buffer_size_mb: 81920
 
 sample_ids_path: ''
 sample_staging_script_path: ''

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -47,7 +47,7 @@ brwt_linkage_subsample: 1000000
 
 metagraph_cmd: 'metagraph'
 
-max_disk_mb: 1048576  # 1 TiB; surfaces as --disk-cap-gb 1024 in metagraph stages
+max_disk_mb: 1048576  # 1 TiB; declared as a Snakemake `disk_mb` resource on build rules (no metagraph flag)
 max_memory_mb: 16384  # 16 GiB default RAM budget per rule
 max_buffer_size_mb: 81920
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -48,7 +48,7 @@ brwt_linkage_subsample: 1000000
 metagraph_cmd: 'metagraph'
 
 max_disk_mb: 1048576  # 1 TiB; declared as a Snakemake `disk_mb` resource on build rules (no metagraph flag)
-max_memory_mb: 16384  # 16 GiB default RAM budget per rule
+memory_mb: 16384  # 16 GiB default RAM budget per rule
 max_buffer_size_mb: 81920
 
 sample_ids_path: ''

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -23,7 +23,7 @@ kmc_mem_overhead_factor: 1.1
 
 # annotation options
 annotation_formats: ['relax.row_diff_brwt']
-annotation_labels_source: 'sequence_headers'
+annotation_labels_source: 'filename'
 with_counts: false
 with_coordinates: false
 count_width: 8

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -3,6 +3,18 @@ k: 31
 base_name: 'graph'
 build_primary_graph: False
 
+# Input assumption for `metagraph-workflows`:
+#   - Each input sample is assumed to be a contig file with deduplicated
+#     k-mers (one fasta.gz per sample). For a primary graph (--primary),
+#     the contigs must already be primary contigs (canonicalized).
+#   - For coordinate annotations (`--with-coords`), inputs must instead
+#     be the full, non-deduplicated samples, since coordinate annotation
+#     needs the original sequence positions.
+#
+# `primarize_samples_separately: True` makes the workflow build a
+# canonical graph per sample and primarize it before joint build /
+# annotation. Use only if your inputs are raw / non-primarized reads
+# that the workflow itself should primarize.
 primarize_samples_separately: False
 
 kmc_mem_mb_per_thread: 2048

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -48,7 +48,7 @@ brwt_linkage_subsample: 1000000
 metagraph_cmd: 'metagraph'
 
 max_disk_mb: 1048576  # 1 TiB; surfaces as --disk-cap-gb 1024 in metagraph stages
-max_memory_mb: 4048
+max_memory_mb: 16384  # 16 GiB default RAM budget per rule
 max_buffer_size_mb: 81920
 
 sample_ids_path: ''

--- a/metagraph/workflows/metagraph_workflows/snakemake/default.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/default.yml
@@ -27,16 +27,23 @@ annotation_labels_source: 'sequence_headers'
 with_counts: false
 with_coordinates: false
 count_width: 8
-# Threads used per file when annotating with --separately. The annotate
-# rule runs (max_threads // annotate_threads_each) columns in parallel,
-# and --mem-cap-gb is allocated per column, so raising this value reduces
-# parallel columns and increases each column's buffer budget.
-# Default of 8 matches the value most large-index runs use in practice.
-annotate_threads_each: 8
+# `annotate_threads_each` (threads used per file in `metagraph annotate
+# --separately`) is mode-derived in the Snakefile when unset here: 8 for
+# binary and counts mode (per-k-mer payload is small), 16 for coordinate
+# mode (positions inflate per-k-mer work, so each column gets more
+# threads and fewer columns run in parallel). Set explicitly to override.
 
 brwt_relax_arity: 32
-brwt_parallel_nodes: 5
-brwt_linkage_subsample: 100000
+# Number of BRWT tree nodes processed in parallel during row_diff_brwt /
+# brwt construction. Scripts in experiments/large_index_scripts.md use 10
+# (FUNGI, Random100, Mouse).
+brwt_parallel_nodes: 10
+# Bits subsampled for distance estimation during BRWT column
+# clustering (--subsample). Larger values give more accurate clustering
+# at the cost of more memory/time. Scripts in
+# experiments/large_index_scripts.md range from 2e5 (FUNGI) to 1e7
+# (Random100); 1e6 is a reasonable middle ground.
+brwt_linkage_subsample: 1000000
 
 metagraph_cmd: 'metagraph'
 

--- a/metagraph/workflows/metagraph_workflows/snakemake/test_workflow/test.yml
+++ b/metagraph/workflows/metagraph_workflows/snakemake/test_workflow/test.yml
@@ -6,7 +6,7 @@ primarize_samples_separately: True
 output_directory: 'output_dir_test'
 seqs_file_list_path: '' # using dummy_staging_script.sh staging script, to "stage" data
 
-annotation_labels_source: 'file_names'
+annotation_labels_source: 'filename'
 
 sample_ids_path: 'test_workflow/sample_ids.txt'
 sample_staging_script_path: 'test_workflow/dummy_staging_script.sh'

--- a/metagraph/workflows/metagraph_workflows/utils.py
+++ b/metagraph/workflows/metagraph_workflows/utils.py
@@ -140,7 +140,7 @@ def get_log_path(rule_name, config, wildcards=None):
 
 
 def temp_dir_config(config):
-    return f"--disk-swap {config[TMP_DIR]}" if TMP_DIR in config else '',
+    return f"--disk-swap {config[TMP_DIR]}" if TMP_DIR in config else ''
 
 
 def get_rule_specific_config(rule, key, config):

--- a/metagraph/workflows/metagraph_workflows/utils.py
+++ b/metagraph/workflows/metagraph_workflows/utils.py
@@ -28,7 +28,7 @@ def get_seqs_file_list_path(wdir, config):
 
 
 def take_value_or_default(key, default, config):
-    return config[key] if (key in config.keys() and config[key]) else default
+    return config[key] if key in config else default
 
 
 def create_transcript_path_list(path: Union[Path, str], transcript_path: Union[Path, str], suffix=''):

--- a/metagraph/workflows/metagraph_workflows/utils.py
+++ b/metagraph/workflows/metagraph_workflows/utils.py
@@ -136,7 +136,15 @@ def get_log_path(rule_name, config, wildcards=None):
 
 
 def temp_dir_config(config):
-    return f"--disk-swap {config[TMP_DIR]}" if TMP_DIR in config else ''
+    """Return the `--disk-swap` flag for a metagraph invocation.
+
+    Always emit the flag explicitly so transform_anno doesn't fall back
+    to its `[OUT_BASEDIR]` default (which would silently spill temp
+    files next to the output). `metagraph build` and `metagraph annotate`
+    both default to off and accept an empty string identically, so the
+    explicit `--disk-swap ""` form is safe for all callers.
+    """
+    return f'--disk-swap "{config[TMP_DIR]}"' if TMP_DIR in config else '--disk-swap ""'
 
 
 def get_rule_specific_config(rule, key, config):

--- a/metagraph/workflows/metagraph_workflows/utils.py
+++ b/metagraph/workflows/metagraph_workflows/utils.py
@@ -52,7 +52,7 @@ def derive_sample_dictionary(transcript_path_list_path: Union[Path, str]):
 
 def get_build_single_sample_input(config, orig_samples_path, seq_ids_dict):
     def _sample_input(wildcards):
-        sample_id = wildcards[0] # TODO:
+        sample_id = wildcards[0]
 
         if config[workflow_configs.SAMPLE_IDS_PATH]:
             return orig_samples_path / f"{{sample_id}}{config[workflow_configs.SAMPLE_STAGING_FILE_ENDING]}"
@@ -118,11 +118,6 @@ def get_time_wrapper_command(config):
     del config
     module_call = [shlex.quote(os.environ.get("PYTHON", "python")), "-m", "metagraph_workflows.time_wrapper"]
     return " ".join(module_call)
-
-
-def get_gnu_time_command(config):
-    """Backward-compatible alias for old Snakefiles."""
-    return get_time_wrapper_command(config)
 
 
 def get_log_path(rule_name, config, wildcards=None):

--- a/metagraph/workflows/metagraph_workflows/utils.py
+++ b/metagraph/workflows/metagraph_workflows/utils.py
@@ -27,10 +27,6 @@ def get_seqs_file_list_path(wdir, config):
     return seqs_file_list_path
 
 
-def take_value_or_default(key, default, config):
-    return config[key] if key in config else default
-
-
 def create_transcript_path_list(path: Union[Path, str], transcript_path: Union[Path, str], suffix=''):
     paths = [str(p.absolute()) for p in Path(path).glob(f'*{suffix}')]
 

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -36,7 +36,6 @@ MEM_MB_KEY = 'mem_mb'
 DISK_MB_KEY = 'disk_mb'
 
 MEM_BUFFER_MB_KEY = 'mem_buffer_mb'
-DISK_CAP_MB_KEY = 'disk_cap_mb'
 
 WITH_COUNTS = 'with_counts'
 COUNT_WIDTH = 'count_width'

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -42,6 +42,8 @@ WITH_COUNTS = 'with_counts'
 COUNT_WIDTH = 'count_width'
 WITH_COORDINATES = 'with_coordinates'
 
+ANNOTATE_THREADS_EACH = 'annotate_threads_each'
+
 
 class AnnotationLabelsSource(Enum):
     SEQUENCE_HEADERS = 'sequence_headers'

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -26,7 +26,7 @@ BRWT_PARALLEL_NODES="brwt_parallel_nodes"
 BRWT_LINKAGE_SUBSAMPLE="brwt_linkage_subsample"
 
 MAX_THREADS = 'max_threads'
-MAX_MEMORY_MB = 'max_memory_mb'
+MEMORY_MB = 'memory_mb'
 MAX_DISK_MB = 'max_disk_mb'
 MAX_BUFFER_SIZE_MB = 'max_buffer_size_mb'
 

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -59,7 +59,6 @@ class AnnotationLabelsSource(Enum):
 
 
 class AnnotationFormats(Enum):
-    # COLUMN = 'column' # TODO: need special case in the workflow
     ROW = 'row'
     BIN_REL_WT = 'bin_rel_wt'
     FLAT = 'flat'

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -45,13 +45,14 @@ ANNOTATE_THREADS_EACH = 'annotate_threads_each'
 
 
 class AnnotationLabelsSource(Enum):
-    SEQUENCE_HEADERS = 'sequence_headers'
-    FILE_NAMES = 'file_names'
+    # Values mirror the metagraph CLI flags: --anno-header and --anno-filename.
+    HEADER = 'header'
+    FILENAME = 'filename'
 
     def to_annotation_cmd_option(self):
-        if self == self.FILE_NAMES:
+        if self == self.FILENAME:
             return '--anno-filename'
-        elif self == self.SEQUENCE_HEADERS:
+        elif self == self.HEADER:
             return '--anno-header'
         else:
             raise ValueError(f"Invalid value of AnnotationLabelsSource: got {self}")

--- a/metagraph/workflows/metagraph_workflows/workflow_configs.py
+++ b/metagraph/workflows/metagraph_workflows/workflow_configs.py
@@ -68,6 +68,9 @@ class AnnotationFormats(Enum):
     RELAXED_BRWT = 'relax.brwt'
     RB_BRWT = 'rb_brwt'
     #RELAXED_RB_BRWT = 'relax.rb_brwt' # not possible
+    ROW_DIFF_FLAT = 'row_diff_flat'
+    ROW_DIFF_SPARSE = 'row_diff_sparse'
+    ROW_DIFF_DISK = 'row_diff_disk'
     ROW_DIFF_BRWT = 'row_diff_brwt'
     RELAXED_ROW_DIFF_BRWT = 'relax.row_diff_brwt'
     INT_BRWT = 'int_brwt'

--- a/metagraph/workflows/notebooks/workflow_end_to_end_example.ipynb
+++ b/metagraph/workflows/notebooks/workflow_end_to_end_example.ipynb
@@ -574,9 +574,9 @@
     }
    ],
    "source": [
-    "cli.run_build_workflow(output_dir, sample_list_path, build_primary_graph=True, \n",
-    "                       force=True, k=5, verbose=False, threads=2,\n",
-    "                       annotation_labels_source=workflow_configs.AnnotationLabelsSource.SEQUENCE_HEADERS);"
+    "cli.run_workflow(output_dir, sample_list_path, build_primary_graph=True, \n",
+    "                 force=True, k=5, verbose=False, threads=2,\n",
+    "                 annotation_labels_source=workflow_configs.AnnotationLabelsSource.SEQUENCE_HEADERS);"
    ]
   },
   {

--- a/metagraph/workflows/notebooks/workflow_end_to_end_example.ipynb
+++ b/metagraph/workflows/notebooks/workflow_end_to_end_example.ipynb
@@ -576,7 +576,7 @@
    "source": [
     "cli.run_workflow(output_dir, sample_list_path, build_primary_graph=True, \n",
     "                 force=True, k=5, verbose=False, threads=2,\n",
-    "                 annotation_labels_source=workflow_configs.AnnotationLabelsSource.SEQUENCE_HEADERS);"
+    "                 annotation_labels_source=workflow_configs.AnnotationLabelsSource.HEADER);"
    ]
   },
   {

--- a/metagraph/workflows/requirements.txt
+++ b/metagraph/workflows/requirements.txt
@@ -1,2 +1,2 @@
-snakemake>=9.15.0,<9.16.0
+snakemake>=9.21.0,<9.22.0
 pandas

--- a/metagraph/workflows/setup.py
+++ b/metagraph/workflows/setup.py
@@ -14,7 +14,7 @@ setup_requirements = ['pytest-runner']
 with open('requirements.txt') as f:
     requirements = list(f.readlines())
 
-test_requirements = ['pytest']
+test_requirements = ['pytest', 'pytest-xdist']
 
 with open('../../package.json') as f:
     version = json.load(f)['version']

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -505,6 +505,27 @@ def test_coords_mode_auto_picks_threads_each_16(sample_list_path, output_dir):
     assert "--threads-each 16" in out
 
 
+@pytest.mark.parametrize("fmt", ["row_diff_flat", "row_diff_sparse", "row_diff_disk"])
+def test_row_diff_binary_formats_reach_shell(sample_list_path, output_dir, fmt):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--annotation-format', fmt,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    out = proc.stdout.decode()
+    # Resolved by the shared annotate_row_diff_binary rule, which passes
+    # --anno-type <fmt> and -i graph.dbg (row-diff transform input).
+    assert f"--anno-type {fmt}" in out
+    assert "annotate_row_diff_binary" in out
+    if fmt == "row_diff_disk":
+        # disk variant gets --mem-cap-gb; the other two omit it.
+        assert "--mem-cap-gb" in out
+
+
 def test_brwt_parallel_nodes_default_is_10(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -369,3 +369,86 @@ def test_count_width_out_of_range_fails(sample_list_path, output_dir, invalid_co
     ])
     assert proc.returncode != 0
     assert "--count-width must be in range [2, 32]" in proc.stdout.decode()
+
+
+def test_annotate_threads_each_default_is_eight(sample_list_path, output_dir):
+    # 16 threads / threads_each=8 -> parallel_cols=2, effective_each=8.
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--threads', '16',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "annotate_threads_each: 8" in cfg
+    out = proc.stdout.decode()
+    assert "--parallel 2" in out
+    assert "--threads-each 8" in out
+
+
+def test_annotate_threads_each_overrides_default(sample_list_path, output_dir):
+    # 16 threads / threads_each=4 -> parallel_cols=4, effective_each=4.
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--threads', '16',
+        '--annotate-threads-each', '4',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "annotate_threads_each: 4" in cfg
+    out = proc.stdout.decode()
+    assert "--parallel 4" in out
+    assert "--threads-each 4" in out
+
+
+def test_annotate_threads_each_redistributes_leftover(sample_list_path, output_dir):
+    # 12 threads / threads_each=8 -> parallel_cols=ceil(12/8)=2,
+    # effective_each=ceil(12/2)=6, total used = 12 (no waste).
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--threads', '12',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "--parallel 2" in out
+    assert "--threads-each 6" in out
+
+
+def test_annotate_threads_each_ceiling_overcommits_at_boundary(sample_list_path, output_dir):
+    # 13 threads / threads_each=8 -> parallel_cols=ceil(13/8)=2,
+    # effective_each=ceil(13/2)=7, total=14 (1-thread overcommit).
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--threads', '13',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "--parallel 2" in out
+    assert "--threads-each 7" in out
+
+
+def test_annotate_threads_each_must_be_positive(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--annotate-threads-each', '0',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "--annotate-threads-each must be >= 1" in proc.stdout.decode()

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -373,7 +373,7 @@ def test_annotate_threads_each_default_is_eight(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--threads', '16',
+        '-p', '16',
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -389,7 +389,7 @@ def test_annotate_threads_each_overrides_default(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--threads', '16',
+        '-p', '16',
         '--anno-threads-each', '4',
         '--dryrun',
         '--extra-args=printshellcmds=True',
@@ -409,7 +409,7 @@ def test_annotate_threads_each_redistributes_leftover(sample_list_path, output_d
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--threads', '12',
+        '-p', '12',
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -426,7 +426,7 @@ def test_annotate_threads_each_ceiling_overcommits_at_boundary(sample_list_path,
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--threads', '13',
+        '-p', '13',
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -621,7 +621,7 @@ def test_coords_mode_auto_picks_threads_each_16(sample_list_path, output_dir):
         'build',
         sample_list_path,
         '--anno-type', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
-        '--threads', '16',
+        '-p', '16',
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -690,6 +690,20 @@ def test_brwt_subsample_default_and_override(sample_list_path, output_dir, tmpdi
     ])
     assert proc.returncode == 0
     assert "--subsample 200000" in proc.stdout.decode()
+
+
+@pytest.mark.parametrize("expr,expanded", [("1e6", 1000000), ("2.5e4", 25000)])
+def test_brwt_subsample_accepts_scientific_notation(sample_list_path, output_dir, expr, expanded):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--brwt-subsample', expr,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    assert f"--subsample {expanded}" in proc.stdout.decode()
 
 
 @pytest.mark.parametrize("bad", [0, 1, 999])

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -506,6 +506,41 @@ def test_default_silences_metagraph_terminal_output(sample_list_path, output_dir
         assert '> /dev/null' in line, f"non-verbose tee missing silencer: {line}"
 
 
+@pytest.mark.parametrize("flag,cfg_key", [
+    ("--keep-columns", "keep_columns"),
+    ("--keep-rd-columns", "keep_rd_columns"),
+])
+def test_keep_columns_flags_propagate_to_config(sample_list_path, output_dir, flag, cfg_key):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        flag,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    cfg = (output_dir / "config.yaml").read()
+    assert f"{cfg_key}: true" in cfg
+
+
+def test_default_marks_columns_as_temp(sample_list_path, output_dir):
+    # Without --keep-columns, the per-sample column annotations are
+    # `temp()` outputs of `rule annotate` and disappear from the
+    # snakemake DAG's "Removing temporary" notices during a real run.
+    # In a dryrun the flag itself isn't surfaced; we instead check that
+    # the config keys default to false.
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "keep_columns: false" in cfg
+    assert "keep_rd_columns: false" in cfg
+
+
 def test_disk_swap_dir_empty_string_disables_swap(sample_list_path, output_dir):
     # `--disk-swap-dir ""` is the explicit-off sentinel: every metagraph
     # invocation gets `--disk-swap ""` so nothing spills to disk.

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -598,9 +598,9 @@ def stub_graph_path(tmpdir):
     return p
 
 
-def test_annotate_subcommand_skips_build_rules(sample_list_path, stub_graph_path, output_dir):
+def test_build_with_graph_skips_build_rules(sample_list_path, stub_graph_path, output_dir):
     proc = run_wrapper([
-        'annotate',
+        'build',
         '--graph', stub_graph_path,
         sample_list_path,
         '--dryrun',
@@ -609,7 +609,7 @@ def test_annotate_subcommand_skips_build_rules(sample_list_path, stub_graph_path
     ])
     assert proc.returncode == 0, proc.stdout.decode()
     out = proc.stdout.decode()
-    # The build pipeline must not appear in annotate-mode DAG.
+    # The build pipeline must not appear when --graph is provided.
     for build_rule in (
         "build_joint_graph",
         "build_joint_primary",
@@ -618,7 +618,7 @@ def test_annotate_subcommand_skips_build_rules(sample_list_path, stub_graph_path
         "primarize_canonical_graph_single_sample",
         "extract_kmer_counts",
     ):
-        assert build_rule not in out, f"unexpected build rule in annotate DAG: {build_rule}"
+        assert build_rule not in out, f"unexpected build rule in DAG: {build_rule}"
     # Annotate + transforms still run.
     for kept_rule in (
         "rule annotate:",
@@ -627,8 +627,8 @@ def test_annotate_subcommand_skips_build_rules(sample_list_path, stub_graph_path
         "rule transform_rd_stage2",
         "rule annotate_row_diff_brwt",
     ):
-        assert kept_rule in out, f"missing rule in annotate DAG: {kept_rule}"
-    # Small-state graph is intentionally skipped in annotate-only mode.
+        assert kept_rule in out, f"missing rule in DAG: {kept_rule}"
+    # Small-state graph is intentionally skipped when --graph is provided.
     assert "rule build_small_graph" not in out
 
     cfg = (output_dir / "config.yaml").read()
@@ -638,10 +638,10 @@ def test_annotate_subcommand_skips_build_rules(sample_list_path, stub_graph_path
     assert target.exists()
 
 
-def test_annotate_subcommand_requires_existing_graph(sample_list_path, output_dir, tmpdir):
+def test_build_with_graph_requires_existing_graph(sample_list_path, output_dir, tmpdir):
     missing = tmpdir / "does_not_exist.dbg"
     proc = run_wrapper([
-        'annotate',
+        'build',
         '--graph', missing,
         sample_list_path,
         '--dryrun',

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -386,7 +386,7 @@ def test_annotate_threads_each_default_is_eight(sample_list_path, output_dir):
     cfg = (output_dir / "config.yaml").read()
     assert "annotate_threads_each: 8" in cfg
     out = proc.stdout.decode()
-    assert "--parallel 2" in out
+    assert "-p 2" in out
     assert "--threads-each 8" in out
 
 
@@ -405,7 +405,7 @@ def test_annotate_threads_each_overrides_default(sample_list_path, output_dir):
     cfg = (output_dir / "config.yaml").read()
     assert "annotate_threads_each: 4" in cfg
     out = proc.stdout.decode()
-    assert "--parallel 4" in out
+    assert "-p 4" in out
     assert "--threads-each 4" in out
 
 
@@ -422,7 +422,7 @@ def test_annotate_threads_each_redistributes_leftover(sample_list_path, output_d
     ])
     assert proc.returncode == 0
     out = proc.stdout.decode()
-    assert "--parallel 2" in out
+    assert "-p 2" in out
     assert "--threads-each 6" in out
 
 
@@ -439,7 +439,7 @@ def test_annotate_threads_each_ceiling_overcommits_at_boundary(sample_list_path,
     ])
     assert proc.returncode == 0
     out = proc.stdout.decode()
-    assert "--parallel 2" in out
+    assert "-p 2" in out
     assert "--threads-each 7" in out
 
 
@@ -512,6 +512,66 @@ def test_mem_cap_gb_must_be_positive(sample_list_path, output_dir):
     ])
     assert proc.returncode != 0
     assert "--mem-cap-gb must be > 0" in proc.stdout.decode()
+
+
+@pytest.fixture
+def stub_graph_path(tmpdir):
+    p = tmpdir / "graph_in.dbg"
+    p.write("")  # zero-byte placeholder is enough for snakemake's existence check
+    return p
+
+
+def test_annotate_subcommand_skips_build_rules(sample_list_path, stub_graph_path, output_dir):
+    proc = run_wrapper([
+        'annotate',
+        '--graph', stub_graph_path,
+        '--seqs-file-list-path', sample_list_path,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        '-o', output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    out = proc.stdout.decode()
+    # The build pipeline must not appear in annotate-mode DAG.
+    for build_rule in (
+        "build_joint_graph",
+        "build_joint_primary",
+        "build_canonical_graph_single_sample",
+        "primarize_joint_graph",
+        "primarize_canonical_graph_single_sample",
+        "extract_kmer_counts",
+    ):
+        assert build_rule not in out, f"unexpected build rule in annotate DAG: {build_rule}"
+    # Annotate + transforms still run.
+    for kept_rule in (
+        "rule annotate:",
+        "rule transform_rd_stage0",
+        "rule transform_rd_stage1",
+        "rule transform_rd_stage2",
+        "rule annotate_row_diff_brwt",
+    ):
+        assert kept_rule in out, f"missing rule in annotate DAG: {kept_rule}"
+    # Small-state graph is intentionally skipped in annotate-only mode.
+    assert "rule build_small_graph" not in out
+
+    cfg = (output_dir / "config.yaml").read()
+    assert "external_graph: true" in cfg
+    # The user's graph must be symlinked into the output dir.
+    target = output_dir / "graph.dbg"
+    assert target.exists()
+
+
+def test_annotate_subcommand_requires_existing_graph(sample_list_path, output_dir, tmpdir):
+    missing = tmpdir / "does_not_exist.dbg"
+    proc = run_wrapper([
+        'annotate',
+        '--graph', missing,
+        '--seqs-file-list-path', sample_list_path,
+        '--dryrun',
+        '-o', output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "Graph file not found" in proc.stdout.decode()
 
 
 def test_annotate_threads_each_must_be_positive(sample_list_path, output_dir):

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -124,7 +124,7 @@ def test_workflow_invocation_via_python(sample_list_path, output_dir):
     if metagraph_cmd is None and shutil.which("metagraph") is None:
         pytest.skip("metagraph executable not found in PATH and local build/metagraph missing")
 
-    assert cli.run_build_workflow(
+    assert cli.run_workflow(
         output_dir,
         samples=sample_list_path,
         metagraph_cmd=metagraph_cmd,

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -501,8 +501,12 @@ def test_index_header_coords_fires_in_coords_filenames_mode(sample_list_path, ou
     assert proc.returncode == 0, proc.stdout.decode()
     out = proc.stdout.decode()
     assert "rule index_header_coords" in out
-    # Per-format output: <graph>.<fmt>.seqs sits next to <graph>.<fmt>.annodbg.
-    assert f"graph.{fmt}.seqs" in out
+    # The loader (load_annotated_graph.cpp) strips the annotation's full
+    # kExtension (e.g. `.row_diff_brwt_coord.annodbg`) and appends `.seqs`,
+    # so it always looks for `<graph>.seqs`. A per-format file would never
+    # be picked up.
+    assert "/graph.seqs" in out
+    assert f"/graph.{fmt}.seqs" not in out
     # Column order comes from the final annotation (not the input file list),
     # so BRWT-reordered columns line up.
     assert "stats --print-col-names" in out
@@ -524,6 +528,8 @@ def test_with_coords_alone_fires_seqs_sidecar(sample_list_path, output_dir):
     out = proc.stdout.decode()
     assert "rule index_header_coords" in out
     assert "--index-header-coords" in out
+    # Loader looks for <graph>.seqs, not per-format.
+    assert "/graph.seqs" in out
 
 
 @pytest.mark.parametrize("flags,reason", [
@@ -623,6 +629,19 @@ def test_brwt_subsample_default_and_override(sample_list_path, output_dir, tmpdi
     ])
     assert proc.returncode == 0
     assert "--subsample 200000" in proc.stdout.decode()
+
+
+@pytest.mark.parametrize("bad", [0, 1, 999])
+def test_brwt_subsample_below_1000_rejected(sample_list_path, output_dir, bad):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--brwt-subsample', str(bad),
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "--brwt-subsample must be >= 1000" in proc.stdout.decode()
 
 
 def test_mem_gb_sets_max_memory_mb(sample_list_path, output_dir):

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -719,7 +719,7 @@ def test_brwt_subsample_below_1000_rejected(sample_list_path, output_dir, bad):
     assert "--brwt-subsample must be >= 1000" in proc.stdout.decode()
 
 
-def test_mem_gb_sets_max_memory_mb(sample_list_path, output_dir):
+def test_mem_gb_sets_memory_mb(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
         sample_list_path,
@@ -730,7 +730,7 @@ def test_mem_gb_sets_max_memory_mb(sample_list_path, output_dir):
     assert proc.returncode == 0
     cfg = (output_dir / "config.yaml").read()
     # 12 GiB -> 12 * 1024 = 12288 MB.
-    assert "max_memory_mb: 12288" in cfg
+    assert "memory_mb: 12288" in cfg
 
 
 def test_mem_gb_must_be_positive(sample_list_path, output_dir):

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -454,6 +454,58 @@ def test_disk_swap_dir_propagates_to_metagraph_stages(sample_list_path, output_d
     assert '--disk-swap "/var/tmp/test-swap"' in out
 
 
+def test_metagraph_always_runs_with_v(sample_list_path, output_dir):
+    # `-v` is always passed to metagraph so log files capture every
+    # trace; the workflow's --verbose only controls whether that output
+    # also streams to the terminal.
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "metagraph build  -v" in out
+
+
+@pytest.mark.parametrize("flag", ["-v", "--verbose"])
+def test_verbose_streams_metagraph_output_to_terminal(sample_list_path, output_dir, flag):
+    # With --verbose, tee's stdout goes through; otherwise it's silenced
+    # (> /dev/null) so metagraph output lives in {log} only.
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        flag,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    out = proc.stdout.decode()
+    assert "tee" in out
+    assert "/dev/null" not in out
+
+
+def test_default_silences_metagraph_terminal_output(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    # Without --verbose, every tee redirects stdout to /dev/null so
+    # the user's terminal only sees Snakemake job-status lines.
+    for line in out.splitlines():
+        if 'tee ' not in line:
+            continue
+        assert '> /dev/null' in line, f"non-verbose tee missing silencer: {line}"
+
+
 def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
     # `metagraph transform_anno --disk-swap` defaults to OUT_BASEDIR (not
     # off), so without an explicit --disk-swap-dir the workflow must pass

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -49,12 +49,11 @@ def run_wrapper(args_list):
     code_base = Path(os.path.realpath(__file__)).parent.parent
     normalized_args = list(args_list)
     if normalized_args and normalized_args[0] == "build":
-        has_output_flag = any(arg in ("-o", "--output_dir") for arg in normalized_args)
-        if not has_output_flag and len(normalized_args) > 1:
+        if "-o" not in normalized_args and len(normalized_args) > 1:
             last = normalized_args[-1]
             last_str = str(last)
             if not last_str.startswith("-"):
-                normalized_args = normalized_args[:-1] + ["--output_dir", last]
+                normalized_args = normalized_args[:-1] + ["-o", last]
 
     process_args = ['python', '-m', 'metagraph_workflows.cli'] + normalized_args
 
@@ -95,7 +94,7 @@ def test_build_workflow(primary, annotation_format, annotation_label_src, sample
     base_args = ['build',
                  sample_list_path,
                  '-k', 5,
-                 '--annotation-format', annotation_format.value,
+                 '--anno-type', annotation_format.value,
                  '--anno-source', annotation_label_src.value]
     if annotation_format in COUNT_FORMATS:
         base_args += ['--with-counts']
@@ -161,7 +160,7 @@ def test_with_counts_rejects_incompatible_annotation_format(sample_list_path, ou
         'build',
         sample_list_path,
         '--with-counts',
-        '--annotation-format', AnnotationFormats.BRWT.value,
+        '--anno-type', AnnotationFormats.BRWT.value,
         '--dryrun',
         output_dir,
     ])
@@ -189,7 +188,7 @@ def test_with_coordinates_rejects_incompatible_annotation_format(sample_list_pat
         'build',
         sample_list_path,
         '--with-coords',
-        '--annotation-format', AnnotationFormats.BRWT.value,
+        '--anno-type', AnnotationFormats.BRWT.value,
         '--dryrun',
         output_dir,
     ])
@@ -202,7 +201,7 @@ def test_with_counts_respects_explicit_annotation_format(sample_list_path, outpu
         'build',
         sample_list_path,
         '--with-counts',
-        '--annotation-format', AnnotationFormats.INT_BRWT.value,
+        '--anno-type', AnnotationFormats.INT_BRWT.value,
         '--dryrun',
         output_dir,
     ])
@@ -216,7 +215,7 @@ def test_count_capable_format_auto_enables_with_counts(sample_list_path, output_
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_DISK.value,
+        '--anno-type', AnnotationFormats.ROW_DIFF_INT_DISK.value,
         '--dryrun',
         output_dir,
     ])
@@ -230,7 +229,7 @@ def test_coord_capable_format_auto_enables_with_coordinates(sample_list_path, ou
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
+        '--anno-type', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
         '--dryrun',
         output_dir,
     ])
@@ -257,8 +256,8 @@ def test_mixed_count_and_coord_formats_are_mutually_exclusive(sample_list_path, 
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
-        '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
+        '--anno-type', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
+        '--anno-type', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
         '--dryrun',
         output_dir,
     ])
@@ -308,7 +307,7 @@ def test_invalid_annotation_format_shows_suggestion(sample_list_path, output_dir
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', 'row_diff_int_brwt1',
+        '--anno-type', 'row_diff_int_brwt1',
         '--dryrun',
         output_dir,
     ])
@@ -322,7 +321,7 @@ def test_invalid_coord_annotation_format_shows_suggestion(sample_list_path, outp
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', 'row_diff_brwt_coord1',
+        '--anno-type', 'row_diff_brwt_coord1',
         '--dryrun',
         output_dir,
     ])
@@ -337,7 +336,7 @@ def test_count_width_is_propagated_to_count_build_steps(sample_list_path, output
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
+        '--anno-type', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
         '--count-width', str(count_width),
         '--dryrun',
         '--extra-args=printshellcmds=True',
@@ -359,7 +358,7 @@ def test_count_width_out_of_range_fails(sample_list_path, output_dir, invalid_co
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
+        '--anno-type', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
         '--count-width', str(invalid_count_width),
         '--dryrun',
         output_dir,
@@ -391,7 +390,7 @@ def test_annotate_threads_each_overrides_default(sample_list_path, output_dir):
         'build',
         sample_list_path,
         '--threads', '16',
-        '--annotate-threads-each', '4',
+        '--anno-threads-each', '4',
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -493,7 +492,7 @@ def test_index_header_coords_fires_in_coords_filenames_mode(sample_list_path, ou
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', fmt,
+        '--anno-type', fmt,
         '--anno-source', 'filename',
         '--dryrun',
         '--extra-args=printshellcmds=True',
@@ -554,7 +553,7 @@ def test_coords_mode_auto_picks_threads_each_16(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
+        '--anno-type', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
         '--threads', '16',
         '--dryrun',
         '--extra-args=printshellcmds=True',
@@ -571,7 +570,7 @@ def test_row_diff_binary_formats_reach_shell(sample_list_path, output_dir, fmt):
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotation-format', fmt,
+        '--anno-type', fmt,
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -716,9 +715,9 @@ def test_annotate_threads_each_must_be_positive(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
         sample_list_path,
-        '--annotate-threads-each', '0',
+        '--anno-threads-each', '0',
         '--dryrun',
         output_dir,
     ])
     assert proc.returncode != 0
-    assert "--annotate-threads-each must be >= 1" in proc.stdout.decode()
+    assert "--anno-threads-each must be >= 1" in proc.stdout.decode()

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -97,7 +97,7 @@ def sample_list_path(tmpdir):
 def test_build_workflow(primary, annotation_format, annotation_label_src, sample_list_path, output_dir):
 
     base_args = ['build',
-                 '--seqs-file-list-path', sample_list_path,
+                 sample_list_path,
                  '-k', 5,
                  '--annotation-format', annotation_format.value,
                  '--anno-source', annotation_label_src.value]
@@ -126,14 +126,14 @@ def test_workflow_invocation_via_python(sample_list_path, output_dir):
 
     assert cli.run_build_workflow(
         output_dir,
-        seqs_file_list_path=sample_list_path,
+        samples=sample_list_path,
         metagraph_cmd=metagraph_cmd,
     ) is None
 
 
 def test_workflow_invocation_additional_args(sample_list_path, output_dir):
     base_args = ['build',
-                 '--seqs-file-list-path', sample_list_path,
+                 sample_list_path,
                  '-k', 5,
                  '--extra-args="summary=True"']
 
@@ -148,7 +148,7 @@ def test_workflow_invocation_additional_args(sample_list_path, output_dir):
 def test_with_counts_defaults_to_row_diff_int_brwt(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--with-counts',
         '--dryrun',
         output_dir,
@@ -163,7 +163,7 @@ def test_with_counts_defaults_to_row_diff_int_brwt(sample_list_path, output_dir)
 def test_with_counts_rejects_incompatible_annotation_format(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--with-counts',
         '--annotation-format', AnnotationFormats.BRWT.value,
         '--dryrun',
@@ -176,7 +176,7 @@ def test_with_counts_rejects_incompatible_annotation_format(sample_list_path, ou
 def test_with_coordinates_defaults_to_row_diff_brwt_coord(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--with-coords',
         '--dryrun',
         output_dir,
@@ -191,7 +191,7 @@ def test_with_coordinates_defaults_to_row_diff_brwt_coord(sample_list_path, outp
 def test_with_coordinates_rejects_incompatible_annotation_format(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--with-coords',
         '--annotation-format', AnnotationFormats.BRWT.value,
         '--dryrun',
@@ -204,7 +204,7 @@ def test_with_coordinates_rejects_incompatible_annotation_format(sample_list_pat
 def test_with_counts_respects_explicit_annotation_format(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--with-counts',
         '--annotation-format', AnnotationFormats.INT_BRWT.value,
         '--dryrun',
@@ -219,7 +219,7 @@ def test_with_counts_respects_explicit_annotation_format(sample_list_path, outpu
 def test_count_capable_format_auto_enables_with_counts(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotation-format', AnnotationFormats.ROW_DIFF_INT_DISK.value,
         '--dryrun',
         output_dir,
@@ -233,7 +233,7 @@ def test_count_capable_format_auto_enables_with_counts(sample_list_path, output_
 def test_coord_capable_format_auto_enables_with_coordinates(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
         '--dryrun',
         output_dir,
@@ -247,7 +247,7 @@ def test_coord_capable_format_auto_enables_with_coordinates(sample_list_path, ou
 def test_with_counts_and_with_coordinates_are_mutually_exclusive(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--with-counts',
         '--with-coords',
         '--dryrun',
@@ -260,7 +260,7 @@ def test_with_counts_and_with_coordinates_are_mutually_exclusive(sample_list_pat
 def test_mixed_count_and_coord_formats_are_mutually_exclusive(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
         '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
         '--dryrun',
@@ -286,7 +286,7 @@ def test_build_help_mentions_defaults():
 def test_dryrun_prints_summary(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--dryrun',
         output_dir,
     ])
@@ -299,7 +299,7 @@ def test_dryrun_prints_summary(sample_list_path, output_dir):
 def test_missing_metagraph_executable_fails_fast(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--metagraph-cmd', 'definitely_missing_metagraph_binary_12345',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -311,7 +311,7 @@ def test_missing_metagraph_executable_fails_fast(sample_list_path, output_dir):
 def test_invalid_annotation_format_shows_suggestion(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotation-format', 'row_diff_int_brwt1',
         '--dryrun',
         output_dir,
@@ -325,7 +325,7 @@ def test_invalid_annotation_format_shows_suggestion(sample_list_path, output_dir
 def test_invalid_coord_annotation_format_shows_suggestion(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotation-format', 'row_diff_brwt_coord1',
         '--dryrun',
         output_dir,
@@ -340,7 +340,7 @@ def test_invalid_coord_annotation_format_shows_suggestion(sample_list_path, outp
 def test_count_width_is_propagated_to_count_build_steps(sample_list_path, output_dir, count_width):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
         '--count-width', str(count_width),
         '--dryrun',
@@ -362,7 +362,7 @@ def test_count_width_is_propagated_to_count_build_steps(sample_list_path, output
 def test_count_width_out_of_range_fails(sample_list_path, output_dir, invalid_count_width):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotation-format', AnnotationFormats.ROW_DIFF_INT_BRWT.value,
         '--count-width', str(invalid_count_width),
         '--dryrun',
@@ -374,17 +374,16 @@ def test_count_width_out_of_range_fails(sample_list_path, output_dir, invalid_co
 
 def test_annotate_threads_each_default_is_eight(sample_list_path, output_dir):
     # 16 threads / threads_each=8 -> parallel_cols=2, effective_each=8.
+    # threads_each defaults to 8 for binary mode (mode-derived).
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--threads', '16',
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
     ])
     assert proc.returncode == 0
-    cfg = (output_dir / "config.yaml").read()
-    assert "annotate_threads_each: 8" in cfg
     out = proc.stdout.decode()
     assert "-p 2" in out
     assert "--threads-each 8" in out
@@ -394,7 +393,7 @@ def test_annotate_threads_each_overrides_default(sample_list_path, output_dir):
     # 16 threads / threads_each=4 -> parallel_cols=4, effective_each=4.
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--threads', '16',
         '--annotate-threads-each', '4',
         '--dryrun',
@@ -414,7 +413,7 @@ def test_annotate_threads_each_redistributes_leftover(sample_list_path, output_d
     # effective_each=ceil(12/2)=6, total used = 12 (no waste).
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--threads', '12',
         '--dryrun',
         '--extra-args=printshellcmds=True',
@@ -431,7 +430,7 @@ def test_annotate_threads_each_ceiling_overcommits_at_boundary(sample_list_path,
     # effective_each=ceil(13/2)=7, total=14 (1-thread overcommit).
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--threads', '13',
         '--dryrun',
         '--extra-args=printshellcmds=True',
@@ -446,7 +445,7 @@ def test_annotate_threads_each_ceiling_overcommits_at_boundary(sample_list_path,
 def test_disk_swap_dir_propagates_to_metagraph_stages(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--disk-swap-dir', '/var/tmp/test-swap',
         '--dryrun',
         '--extra-args=printshellcmds=True',
@@ -462,7 +461,7 @@ def test_disk_swap_dir_propagates_to_metagraph_stages(sample_list_path, output_d
 def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -475,7 +474,7 @@ def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
 def test_small_graph_step_runs(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -488,30 +487,87 @@ def test_small_graph_step_runs(sample_list_path, output_dir):
     assert "--state small" in out
 
 
-def test_mem_cap_gb_sets_max_memory_mb(sample_list_path, output_dir):
+def test_coords_mode_auto_picks_threads_each_16(sample_list_path, output_dir):
+    # Snakefile derives annotate_threads_each from mode when unset; for
+    # coords it becomes 16, so parallel_cols=ceil(16/16)=1.
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
-        '--mem-cap-gb', '12',
+        sample_list_path,
+        '--annotation-format', AnnotationFormats.ROW_DIFF_BRWT_COORD.value,
+        '--threads', '16',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "-p 1" in out
+    assert "--threads-each 16" in out
+
+
+def test_brwt_parallel_nodes_default_is_10(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "--parallel-nodes 10" in out
+
+
+def test_brwt_subsample_default_and_override(sample_list_path, output_dir, tmpdir):
+    # Default: 100000 from default.yml; reaches the row_diff_brwt rule.
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    assert "--subsample 1000000" in proc.stdout.decode()
+
+    # CLI override.
+    other_out = tmpdir / 'other_out'
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--brwt-subsample', '200000',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        other_out,
+    ])
+    assert proc.returncode == 0
+    assert "--subsample 200000" in proc.stdout.decode()
+
+
+def test_mem_gb_sets_max_memory_mb(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--mem-gb', '12',
         '--dryrun',
         output_dir,
     ])
     assert proc.returncode == 0
     cfg = (output_dir / "config.yaml").read()
-    # 12 GB -> 12 * 1024 = 12288 MB
+    # 12 GiB -> 12 * 1024 = 12288 MB.
     assert "max_memory_mb: 12288" in cfg
 
 
-def test_mem_cap_gb_must_be_positive(sample_list_path, output_dir):
+def test_mem_gb_must_be_positive(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
-        '--mem-cap-gb', '0',
+        sample_list_path,
+        '--mem-gb', '0',
         '--dryrun',
         output_dir,
     ])
     assert proc.returncode != 0
-    assert "--mem-cap-gb must be > 0" in proc.stdout.decode()
+    assert "--mem-gb must be > 0" in proc.stdout.decode()
 
 
 @pytest.fixture
@@ -525,7 +581,7 @@ def test_annotate_subcommand_skips_build_rules(sample_list_path, stub_graph_path
     proc = run_wrapper([
         'annotate',
         '--graph', stub_graph_path,
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--dryrun',
         '--extra-args=printshellcmds=True',
         '-o', output_dir,
@@ -566,7 +622,7 @@ def test_annotate_subcommand_requires_existing_graph(sample_list_path, output_di
     proc = run_wrapper([
         'annotate',
         '--graph', missing,
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--dryrun',
         '-o', output_dir,
     ])
@@ -577,7 +633,7 @@ def test_annotate_subcommand_requires_existing_graph(sample_list_path, output_di
 def test_annotate_threads_each_must_be_positive(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',
-        '--seqs-file-list-path', sample_list_path,
+        sample_list_path,
         '--annotate-threads-each', '0',
         '--dryrun',
         output_dir,

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -88,8 +88,8 @@ def sample_list_path(tmpdir):
     return list_path
 
 
-@pytest.mark.parametrize('primary,annotation_format,annotation_label_src', list(product([False], [AnnotationFormats.ROW_DIFF_BRWT], [AnnotationLabelsSource.SEQUENCE_HEADERS])) +
-    list(product([False, True], AnnotationFormats, [AnnotationLabelsSource.FILE_NAMES])))
+@pytest.mark.parametrize('primary,annotation_format,annotation_label_src', list(product([False], [AnnotationFormats.ROW_DIFF_BRWT], [AnnotationLabelsSource.HEADER])) +
+    list(product([False, True], AnnotationFormats, [AnnotationLabelsSource.FILENAME])))
 def test_build_workflow(primary, annotation_format, annotation_label_src, sample_list_path, output_dir):
 
     base_args = ['build',
@@ -494,7 +494,7 @@ def test_index_header_coords_fires_in_coords_filenames_mode(sample_list_path, ou
         'build',
         sample_list_path,
         '--annotation-format', fmt,
-        '--anno-source', 'file_names',
+        '--anno-source', 'filename',
         '--dryrun',
         '--extra-args=printshellcmds=True',
         output_dir,
@@ -510,10 +510,27 @@ def test_index_header_coords_fires_in_coords_filenames_mode(sample_list_path, ou
     assert "--index-header-coords" in out
 
 
+def test_with_coords_alone_fires_seqs_sidecar(sample_list_path, output_dir):
+    # The default --anno-source is `filename`, so `--with-coords` alone is
+    # enough to trigger the .seqs sidecar rule.
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--with-coords',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    out = proc.stdout.decode()
+    assert "rule index_header_coords" in out
+    assert "--index-header-coords" in out
+
+
 @pytest.mark.parametrize("flags,reason", [
-    (["--with-coords"], "sequence_headers is the default anno-source"),
-    (["--anno-source", "file_names"], "no --with-coords -> binary mode"),
-    (["--with-counts", "--anno-source", "file_names"], "counts + file_names doesn't need .seqs"),
+    (["--with-coords", "--anno-source", "header"], "header mode doesn't need .seqs"),
+    (["--anno-source", "filename"], "no --with-coords -> binary mode"),
+    (["--with-counts", "--anno-source", "filename"], "counts + filename doesn't need .seqs"),
 ])
 def test_index_header_coords_does_not_fire_outside_coords_filenames(
         sample_list_path, output_dir, flags, reason):

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -506,12 +506,31 @@ def test_default_silences_metagraph_terminal_output(sample_list_path, output_dir
         assert '> /dev/null' in line, f"non-verbose tee missing silencer: {line}"
 
 
-def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
-    # `metagraph transform_anno --disk-swap` defaults to OUT_BASEDIR (not
-    # off), so without an explicit --disk-swap-dir the workflow must pass
-    # `--disk-swap ""` to actually disable disk spill. Every occurrence
-    # of --disk-swap in the dryrun output should be the empty-string
-    # form, not a real path.
+def test_disk_swap_dir_empty_string_disables_swap(sample_list_path, output_dir):
+    # `--disk-swap-dir ""` is the explicit-off sentinel: every metagraph
+    # invocation gets `--disk-swap ""` so nothing spills to disk.
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--disk-swap-dir', '',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    out = proc.stdout.decode()
+    for line in out.splitlines():
+        if '--disk-swap' not in line:
+            continue
+        assert '--disk-swap ""' in line, f"Unexpected --disk-swap target: {line}"
+    cfg = (output_dir / "config.yaml").read()
+    assert "tmpdir:" not in cfg
+
+
+def test_disk_swap_dir_defaults_to_output_temp(sample_list_path, output_dir):
+    # When --disk-swap-dir is omitted, the workflow defaults to
+    # <output_dir>/temp so metagraph transform_anno doesn't fall back to
+    # its OUT_BASEDIR default and silently spill next to artifacts.
     proc = run_wrapper([
         'build',
         sample_list_path,
@@ -521,10 +540,13 @@ def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
     ])
     assert proc.returncode == 0
     out = proc.stdout.decode()
+    expected = f'--disk-swap "{output_dir}/temp"'
     for line in out.splitlines():
         if '--disk-swap' not in line:
             continue
-        assert '--disk-swap ""' in line, f"Unexpected --disk-swap target: {line}"
+        assert expected in line, f"Unexpected --disk-swap target: {line}"
+    cfg = (output_dir / "config.yaml").read()
+    assert f"tmpdir: {output_dir}/temp" in cfg
 
 
 def test_small_graph_step_runs(sample_list_path, output_dir):

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -450,10 +450,16 @@ def test_disk_swap_dir_propagates_to_metagraph_stages(sample_list_path, output_d
     cfg = (output_dir / "config.yaml").read()
     assert "tmpdir: /var/tmp/test-swap" in cfg
     out = proc.stdout.decode()
-    assert "--disk-swap /var/tmp/test-swap" in out
+    # The dir is quoted (so empty/whitespace paths round-trip safely too).
+    assert '--disk-swap "/var/tmp/test-swap"' in out
 
 
 def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
+    # `metagraph transform_anno --disk-swap` defaults to OUT_BASEDIR (not
+    # off), so without an explicit --disk-swap-dir the workflow must pass
+    # `--disk-swap ""` to actually disable disk spill. Every occurrence
+    # of --disk-swap in the dryrun output should be the empty-string
+    # form, not a real path.
     proc = run_wrapper([
         'build',
         sample_list_path,
@@ -463,7 +469,10 @@ def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
     ])
     assert proc.returncode == 0
     out = proc.stdout.decode()
-    assert "--disk-swap" not in out
+    for line in out.splitlines():
+        if '--disk-swap' not in line:
+            continue
+        assert '--disk-swap ""' in line, f"Unexpected --disk-swap target: {line}"
 
 
 def test_small_graph_step_runs(sample_list_path, output_dir):

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -87,8 +87,28 @@ def sample_list_path(tmpdir):
     return list_path
 
 
-@pytest.mark.parametrize('primary,annotation_format,annotation_label_src', list(product([False], [AnnotationFormats.ROW_DIFF_BRWT], [AnnotationLabelsSource.HEADER])) +
-    list(product([False, True], AnnotationFormats, [AnnotationLabelsSource.FILENAME])))
+# Representatives of distinct workflow code paths. Each `AnnotationFormats`
+# value is already exercised at the dry-run level by other tests (resolved
+# `--anno-type FMT` is asserted in `test_with_*_respects_explicit_*` etc.),
+# so this end-to-end matrix only needs one format per Snakefile rule branch:
+#
+#   BRWT                  -> annotate_brwt + relax_brwt (default uses RELAXED_BRWT)
+#   RELAXED_ROW_DIFF_BRWT -> row-diff stages 0-2 + annotate_row_diff_brwt + relax_row_diff_brwt
+#   ROW_DIFF_DISK         -> annotate_row_diff_binary wildcard rule
+#   ROW_DIFF_INT_BRWT     -> row-diff counts pipeline (annotate_row_diff_int_brwt)
+#   ROW_DIFF_BRWT_COORD   -> row-diff coords + .seqs sidecar (index_header_coords)
+_INTEGRATION_FORMATS = [
+    AnnotationFormats.BRWT,
+    AnnotationFormats.RELAXED_ROW_DIFF_BRWT,
+    AnnotationFormats.ROW_DIFF_DISK,
+    AnnotationFormats.ROW_DIFF_INT_BRWT,
+    AnnotationFormats.ROW_DIFF_BRWT_COORD,
+]
+
+
+@pytest.mark.parametrize('primary,annotation_format,annotation_label_src',
+    list(product([False], [AnnotationFormats.ROW_DIFF_BRWT], [AnnotationLabelsSource.HEADER])) +
+    list(product([False, True], _INTEGRATION_FORMATS, [AnnotationLabelsSource.FILENAME])))
 def test_build_workflow(primary, annotation_format, annotation_label_src, sample_list_path, output_dir):
 
     base_args = ['build',

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -277,9 +277,10 @@ def test_build_help_mentions_defaults():
     # Argparse may insert newlines + indentation into long help strings;
     # normalize all whitespace so substring checks are stable.
     out_norm = re.sub(r'\s+', ' ', out).strip()
-    assert "[relax.row_diff_brwt/row_diff_int_brwt/row_diff_brwt_coord]" in out_norm
-    assert "row_diff_int_brwt" in out
-    assert "row_diff_brwt_coord" in out
+    # Default formats are rendered bracketed in the list, e.g. `[relax.row_diff_brwt]`.
+    assert "[relax.row_diff_brwt]" in out_norm
+    assert "[row_diff_int_brwt]" in out_norm
+    assert "[row_diff_brwt_coord]" in out_norm
 
 
 def test_dryrun_prints_summary(sample_list_path, output_dir):
@@ -440,6 +441,61 @@ def test_annotate_threads_each_ceiling_overcommits_at_boundary(sample_list_path,
     out = proc.stdout.decode()
     assert "--parallel 2" in out
     assert "--threads-each 7" in out
+
+
+def test_disk_swap_dir_propagates_to_metagraph_stages(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--disk-swap-dir', '/var/tmp/test-swap',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    assert "tmpdir: /var/tmp/test-swap" in cfg
+    out = proc.stdout.decode()
+    assert "--disk-swap /var/tmp/test-swap" in out
+
+
+def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "--disk-swap" not in out
+
+
+def test_mem_cap_gb_sets_max_memory_mb(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--mem-cap-gb', '12',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    cfg = (output_dir / "config.yaml").read()
+    # 12 GB -> 12 * 1024 = 12288 MB
+    assert "max_memory_mb: 12288" in cfg
+
+
+def test_mem_cap_gb_must_be_positive(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--mem-cap-gb', '0',
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode != 0
+    assert "--mem-cap-gb must be > 0" in proc.stdout.decode()
 
 
 def test_annotate_threads_each_must_be_positive(sample_list_path, output_dir):

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -472,6 +472,22 @@ def test_disk_swap_dir_unset_means_in_ram(sample_list_path, output_dir):
     assert "--disk-swap" not in out
 
 
+def test_small_graph_step_runs(sample_list_path, output_dir):
+    proc = run_wrapper([
+        'build',
+        '--seqs-file-list-path', sample_list_path,
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0
+    out = proc.stdout.decode()
+    assert "rule build_small_graph" in out
+    # The transform step writes <base>_small.dbg via `-o <base>_small`.
+    assert "metagraph transform" in out
+    assert "--state small" in out
+
+
 def test_mem_cap_gb_sets_max_memory_mb(sample_list_path, output_dir):
     proc = run_wrapper([
         'build',

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -60,15 +60,11 @@ def run_wrapper(args_list):
 
     # If tests are running without `metagraph` on PATH, inject `--metagraph-cmd`
     # pointing to the locally built binary (when available).
-    if "--metagraph-cmd" not in normalized_args:
+    if "--metagraph-cmd" not in normalized_args and shutil.which("metagraph") is None:
         metagraph_cmd = _resolve_metagraph_cmd()
         if metagraph_cmd is None:
             pytest.skip("metagraph executable not found in PATH and local build/metagraph missing")
-        if not normalized_args:
-            pytest.skip("empty args_list passed to run_wrapper")
-        process_args = ['python', '-m', 'metagraph_workflows.cli'] + normalized_args + [
-            "--metagraph-cmd", metagraph_cmd
-        ]
+        process_args = process_args + ["--metagraph-cmd", metagraph_cmd]
 
     proc = subprocess.run(
         [str(a) for a in process_args],
@@ -540,7 +536,7 @@ def test_brwt_parallel_nodes_default_is_10(sample_list_path, output_dir):
 
 
 def test_brwt_subsample_default_and_override(sample_list_path, output_dir, tmpdir):
-    # Default: 100000 from default.yml; reaches the row_diff_brwt rule.
+    # Default: 1000000 from default.yml; reaches the row_diff_brwt rule.
     proc = run_wrapper([
         'build',
         sample_list_path,

--- a/metagraph/workflows/tests/test_build_cli.py
+++ b/metagraph/workflows/tests/test_build_cli.py
@@ -483,6 +483,54 @@ def test_small_graph_step_runs(sample_list_path, output_dir):
     assert "--state small" in out
 
 
+@pytest.mark.parametrize("fmt", [
+    "brwt_coord", "row_diff_coord", "row_diff_brwt_coord", "row_diff_disk_coord",
+])
+def test_index_header_coords_fires_in_coords_filenames_mode(sample_list_path, output_dir, fmt):
+    # `.seqs` only makes sense for coord-aware annotations indexed with
+    # --anno-filename: the sidecar maps file-level coord ranges back to
+    # original sequence headers.
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        '--annotation-format', fmt,
+        '--anno-source', 'file_names',
+        '--dryrun',
+        '--extra-args=printshellcmds=True',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    out = proc.stdout.decode()
+    assert "rule index_header_coords" in out
+    # Per-format output: <graph>.<fmt>.seqs sits next to <graph>.<fmt>.annodbg.
+    assert f"graph.{fmt}.seqs" in out
+    # Column order comes from the final annotation (not the input file list),
+    # so BRWT-reordered columns line up.
+    assert "stats --print-col-names" in out
+    assert "--index-header-coords" in out
+
+
+@pytest.mark.parametrize("flags,reason", [
+    (["--with-coords"], "sequence_headers is the default anno-source"),
+    (["--anno-source", "file_names"], "no --with-coords -> binary mode"),
+    (["--with-counts", "--anno-source", "file_names"], "counts + file_names doesn't need .seqs"),
+])
+def test_index_header_coords_does_not_fire_outside_coords_filenames(
+        sample_list_path, output_dir, flags, reason):
+    proc = run_wrapper([
+        'build',
+        sample_list_path,
+        *flags,
+        '--dryrun',
+        output_dir,
+    ])
+    assert proc.returncode == 0, proc.stdout.decode()
+    # Match the rule line specifically -- pytest's tmpdir path may contain
+    # the substring "index_header_coords" when the test name does.
+    assert "rule index_header_coords" not in proc.stdout.decode(), reason
+    assert "--index-header-coords" not in proc.stdout.decode(), reason
+
+
 def test_coords_mode_auto_picks_threads_each_16(sample_list_path, output_dir):
     # Snakefile derives annotate_threads_each from mode when unset; for
     # coords it becomes 16, so parallel_cols=ceil(16/16)=1.

--- a/metagraph/workflows/tests/test_resource_management.py
+++ b/metagraph/workflows/tests/test_resource_management.py
@@ -34,3 +34,43 @@ def test_TransformRdStage1Resources(config):
     config['rules'][rule_name]['mem_buffer_mb'] = mem_buffer
     assert inst.get_mem()(None, None, None) == mem
     assert inst.get_mem_buffer_gib()(None, None, None, resources) == int(math.ceil(mem_buffer / 1024))
+
+
+def test_AnnotateResources_per_column_buffer(config):
+    # annotate --mem-cap-gb is per-column, so the global budget must be
+    # divided across columns built in parallel (= threads // threads_each).
+    mem = 64000  # MB available to the rule
+    config[workflow_configs.ANNOTATE_THREADS_EACH] = 8
+    inst = rm.AnnotateResources(config)
+
+    threads = 64
+    parallel_cols = threads // 8  # 8 parallel columns
+
+    assert inst.get_parallel_cols(threads) == parallel_cols
+
+    resources = {'mem_mb': mem}
+    expected_total = int(rm.SupportsMemBufferSize.CAP_MEM_FRACTION * mem)
+    expected_total = min(expected_total, config[workflow_configs.MAX_BUFFER_SIZE_MB])
+    expected_per_col_mb = max(expected_total // parallel_cols, 1024)
+    expected_gib = int(math.ceil(expected_per_col_mb / 1024.0))
+    assert inst.get_mem_buffer_gib()(None, None, threads, resources) == expected_gib
+
+    # threads_each not set in config -> falls back to 1 (workflow default
+    # comes from default.yml, see ANNOTATE_THREADS_EACH there).
+    config2 = {
+        workflow_configs.MAX_MEMORY_MB: 16000,
+        workflow_configs.MAX_BUFFER_SIZE_MB: 50000,
+    }
+    inst2 = rm.AnnotateResources(config2)
+    assert inst2.threads_each == 1
+    assert inst2.get_parallel_cols(8) == 8
+
+    # explicit mem_buffer_mb is treated as the per-column value
+    config3 = {
+        workflow_configs.MAX_MEMORY_MB: 16000,
+        workflow_configs.MAX_BUFFER_SIZE_MB: 50000,
+        workflow_configs.ANNOTATE_THREADS_EACH: 4,
+        'rules': {'annotate': {'mem_buffer_mb': 3000}},
+    }
+    inst3 = rm.AnnotateResources(config3)
+    assert inst3.get_mem_buffer_gib()(None, None, 16, {'mem_mb': 16000}) == int(math.ceil(3000 / 1024))

--- a/metagraph/workflows/tests/test_resource_management.py
+++ b/metagraph/workflows/tests/test_resource_management.py
@@ -39,13 +39,13 @@ def test_TransformRdStage1Resources(config):
 
 def test_AnnotateResources_per_column_buffer(config):
     # annotate --mem-cap-gb is per-column, so the global budget must be
-    # divided across columns built in parallel (= threads // threads_each).
+    # divided across columns built in parallel (= ceil(threads / threads_each)).
     mem = 64000  # MB available to the rule
     config[workflow_configs.ANNOTATE_THREADS_EACH] = 8
     inst = rm.AnnotateResources(config)
 
     threads = 64
-    parallel_cols = threads // 8  # 8 parallel columns
+    parallel_cols = math.ceil(threads / 8)  # 8 parallel columns (64/8 is exact)
 
     assert inst.get_parallel_cols(threads) == parallel_cols
 
@@ -75,3 +75,20 @@ def test_AnnotateResources_per_column_buffer(config):
     }
     inst3 = rm.AnnotateResources(config3)
     assert inst3.get_mem_buffer_gib()(None, None, 16, {'mem_mb': 16000}) == int(math.ceil(3000 / 1024))
+
+
+@pytest.mark.parametrize("threads,threads_each,expected_cols", [
+    (8, 8, 1),     # exact divisor
+    (12, 8, 2),    # ceil(12/8) = 2, the "redistribute leftover" case
+    (13, 8, 2),    # ceil(13/8) = 2, the overcommit case
+    (16, 8, 2),    # exact
+    (1, 8, 1),     # min clamp
+])
+def test_get_parallel_cols_ceil_behavior(threads, threads_each, expected_cols):
+    config = {
+        workflow_configs.MAX_MEMORY_MB: 16000,
+        workflow_configs.MAX_BUFFER_SIZE_MB: 50000,
+        workflow_configs.ANNOTATE_THREADS_EACH: threads_each,
+    }
+    inst = rm.AnnotateResources(config)
+    assert inst.get_parallel_cols(threads) == expected_cols

--- a/metagraph/workflows/tests/test_resource_management.py
+++ b/metagraph/workflows/tests/test_resource_management.py
@@ -7,7 +7,7 @@ from metagraph_workflows import workflow_configs
 @pytest.fixture()
 def config():
     return {
-        workflow_configs.MAX_MEMORY_MB: 16000,
+        workflow_configs.MEMORY_MB: 16000,
         workflow_configs.MAX_BUFFER_SIZE_MB: 50000
     }
 
@@ -59,7 +59,7 @@ def test_AnnotateResources_per_column_buffer(config):
     # threads_each not set in config -> falls back to 1 (workflow default
     # comes from default.yml, see ANNOTATE_THREADS_EACH there).
     config2 = {
-        workflow_configs.MAX_MEMORY_MB: 16000,
+        workflow_configs.MEMORY_MB: 16000,
         workflow_configs.MAX_BUFFER_SIZE_MB: 50000,
     }
     inst2 = rm.AnnotateResources(config2)
@@ -68,7 +68,7 @@ def test_AnnotateResources_per_column_buffer(config):
 
     # explicit mem_buffer_mb is treated as the per-column value
     config3 = {
-        workflow_configs.MAX_MEMORY_MB: 16000,
+        workflow_configs.MEMORY_MB: 16000,
         workflow_configs.MAX_BUFFER_SIZE_MB: 50000,
         workflow_configs.ANNOTATE_THREADS_EACH: 4,
         'rules': {'annotate': {'mem_buffer_mb': 3000}},
@@ -86,7 +86,7 @@ def test_AnnotateResources_per_column_buffer(config):
 ])
 def test_get_parallel_cols_ceil_behavior(threads, threads_each, expected_cols):
     config = {
-        workflow_configs.MAX_MEMORY_MB: 16000,
+        workflow_configs.MEMORY_MB: 16000,
         workflow_configs.MAX_BUFFER_SIZE_MB: 50000,
         workflow_configs.ANNOTATE_THREADS_EACH: threads_each,
     }

--- a/metagraph/workflows/tests/test_resource_management.py
+++ b/metagraph/workflows/tests/test_resource_management.py
@@ -27,7 +27,8 @@ def test_TransformRdStage1Resources(config):
     assert inst.get_mem()(None, None, None) == mem
 
     resources = {'mem_mb': mem}
-    assert inst.get_mem_buffer_gib()(None, None, None, resources) == int(math.ceil(0.8 * mem / 1024))
+    expected_mb = int(rm.SupportsMemBufferSize.CAP_MEM_FRACTION * mem)
+    assert inst.get_mem_buffer_gib()(None, None, None, resources) == int(math.ceil(expected_mb / 1024.0))
 
     # now additionally setting mem cap explicitly
     mem_buffer = 2048

--- a/metagraph/workflows/tests/test_utils.py
+++ b/metagraph/workflows/tests/test_utils.py
@@ -17,11 +17,6 @@ def test_get_sample_name(case, expected):
     assert metagraph_workflows.utils.get_sample_name(case) == expected
 
 
-def test_get_gnu_time_command_uses_python_wrapper():
-    cmd = metagraph_workflows.utils.get_gnu_time_command({})
-    assert "metagraph_workflows.time_wrapper" in cmd
-
-
 def test_get_time_wrapper_command_uses_python_wrapper():
     cmd = metagraph_workflows.utils.get_time_wrapper_command({})
     assert "metagraph_workflows.time_wrapper" in cmd


### PR DESCRIPTION
## Motivation

The production indexing pipelines we use for FUNGI, Random100, Random5K, the metazoa-1k preamble, TCGA, and the tara-assemblies set live as hand-rolled bash scripts in `experiments/large_index_scripts.md`. Each one is essentially the same recipe -- graph build, annotate, row-diff transform, BRWT cluster -- but with subtly different per-stage memory caps, thread packing, and disk-swap flags tuned by hand for the dataset size and annotation mode (binary / counts / coordinates).

`metagraph-workflows` was supposed to be the one-command alternative but it had drifted: `--mem-cap-gb` was passed identically to every stage (which is wrong, because `annotate --mem-cap-gb` is *per-column* while `build --mem-cap-gb` is global), `annotate --threads-each` was 1 by default, and the CLI required the user to know which of `--seqs-file-list-path` or `--seqs-dir-path` matched their input layout. So in practice everyone just copied the scripts.

This PR makes the one-command path actually reproduce the scripts.

## The new one-liner

```bash
metagraph-workflows build samples.txt -o out/ --primary \
    -p 34 --mem-gb 70 --disk-swap-dir /scratch/swap
```

The user only specifies the hardware budget (`-p`, `--mem-gb`, `--disk-swap-dir`) and the intent (`--primary`, `--with-counts`, `--with-coords`, `--anno-type`). Everything else -- per-stage `--mem-cap-gb`, `-p × --anno-threads-each` packing, BRWT clustering parameters, which stages get `--disk-swap` -- is derived automatically from those inputs and the annotation mode.

For Random100, Random5K, FUNGI, the metazoa-1k preamble, the TCGA counts pipeline, and the tara-assemblies coords pipeline, the resolved commands match the scripts step-for-step, up to numeric values that legitimately scale with `--mem-gb` (the per-stage `--mem-cap-gb` is `CAP_MEM_FRACTION × --mem-gb`, currently 0.85).

## What changed in the CLI

The samples input is now a single positional argument; the type (directory / file list / process substitution `<(...)`) is auto-detected:

```bash
metagraph-workflows build samples.txt           -o out/ --primary
metagraph-workflows build samples_dir/          -o out/ --primary
metagraph-workflows build <(ls /data/*.fa)      -o out/ --primary
```

CLI rename / shape changes (no aliases for the old names):

| Old | New |
|---|---|
| `--seqs-file-list-path` / `--seqs-dir-path` | positional `SAMPLES` (auto-detected) |
| `--mem-cap-gb` | `--mem-gb` (workflow RAM budget, not metagraph's per-stage flag) |
| `--threads` | `-p` |
| `--annotation-format` | `--anno-type` |
| `--annotate-threads-each` | `--anno-threads-each` |
| `--anno-source sequence_headers` / `file_names` | `--anno-source header` / `filename` |
| `--output_dir` | (dropped; `-o` only) |
| `annotate` subcommand | `build --graph X.dbg` |
| `cli.run_build_workflow` / `cli.run_annotate_workflow` | `cli.run_workflow(..., graph=None)` |

New CLI knobs:

- `--brwt-subsample N` (default `1e6`; accepts scientific notation, minimum 1000).
- `--disk-swap-dir DIR` defaults to `<output_dir>/temp` (workflow eagerly mkdirs it); pass `""` to disable disk swap entirely. The default keeps `transform_anno` (whose own default is `[OUT_BASEDIR]`) from silently spilling next to artifacts.
- `-v` / `--verbose` streams metagraph progress to the terminal -- logs always capture full `-v` output.
- `--graph EXISTING.dbg` reuses a built graph and skips the build pipeline.
- `--keep-columns` keeps `columns.<mode>/*.column.annodbg` past the rules that produce them. Useful for re-running just the row-diff / BRWT clustering stages without redoing per-sample annotation.
- `--keep-rd-columns` keeps `rd_cols.<mode>/*.{column,row_diff}.annodbg` plus the `rd_succ` / `anchors` graph sidecars. Together these are everything needed to re-run `annotate_row_diff_*` with different BRWT parameters without redoing stages 0-2.

New annotation formats wired up: `row_diff_flat`, `row_diff_sparse`, `row_diff_disk`.

New `build_small_graph` rule emits `<base>_small.dbg` alongside the full graph.

## Default changes

| Key | Old | New |
|---|---|---|
| `annotation_labels_source` | `sequence_headers` | `filename` (matches every production script using `--anno-filename`) |
| `memory_mb` (was `max_memory_mb`) | 4048 | 16384 (16 GiB) |
| `max_buffer_size_mb` | 51200 | 81920 (80 GiB) |
| `brwt_parallel_nodes` | 5 | 10 (matches the scripts) |
| `default_disk_mb` (orphan, never read) | 10 GiB | renamed to `max_disk_mb`, 1 TiB |

These are breaking changes for users with saved configs that still use the old enum values; there are no aliases. See the migration cheat sheet below.

## Auto-derivation rules

| Setting | Rule |
|---|---|
| `--anno-threads-each` | 8 for binary/counts, 16 for coordinates (per-k-mer payload is larger) |
| `annotate -p` | `ceil(-p / --anno-threads-each)` columns in parallel |
| `annotate --mem-cap-gb` | global budget ÷ parallel columns, capped at `max_buffer_size_mb` |
| `annotate --mem-cap-gb` / `--disk-swap` | only emitted for counts/coords (binary doesn't need them) |
| `transform_anno --mem-cap-gb` | for row-diff stages, *not* capped by `max_buffer_size_mb` -- annotation size routinely exceeds it |
| `transform_anno --disk-swap` | omitted from row-diff stage 0 and from `row_diff_flat` / `row_diff_sparse` / `row_diff_disk` (metagraph doesn't use it there) |
| `--parallel-nodes` (BRWT) | default raised from 5 to 10 to match every production script |
| `--disk-cap-gb` (build) | no longer passed -- the 1 TiB default was effectively unbounded and the scripts omit it |

## CoordToHeader sidecar (`.seqs`)

When `--with-coords` is used together with `--anno-source filename` (the new default), the workflow additionally produces `<graph>.seqs` -- the CoordToHeader sidecar that `metagraph query --query-mode coords` and `metagraph align` look for. The sidecar is built in a second `metagraph annotate --index-header-coords` pass; the input fasta order is recovered from the final annotation via `metagraph stats --print-col-names` so that file labels and coord offsets line up even after BRWT clustering reorders columns. The loader strips the annotation's full kExtension (e.g. `.row_diff_brwt_coord.annodbg`) and appends `.seqs`, so a single `<graph>.seqs` serves whichever coord format is queried. If multiple coord formats are requested in one run, the sidecar is derived from the first in the list.

## Live progress streaming

By default metagraph runs verbose into the per-rule log files, but the terminal stays quiet (snakemake job-status messages only). With `-v` / `--verbose`, the workflow `tee`s metagraph stdout/stderr through to the terminal too, so the user sees progress as it happens. Logs are unaffected either way.

## Dependency bump

`snakemake` pinned to `>=9.21.0,<9.22.0` (was `9.15`). The 9.21 `TBDString` sentinel rejects comparisons with `int`; the workflow's optional "estimated memory > max" warning now skips that branch when the estimate is still TBD (DAG-construction time).

## Tests

75 fast unit / dry-run tests cover:
- mode-derived defaults (binary vs counts vs coords; `header` vs `filename`)
- flag validation and mutually-exclusive guards
- `--graph` dispatch (skips build rules, symlinks the external graph)
- all four binary row-diff formats reaching the shell
- annotate thread packing at boundary inputs (12/8, 13/8, 16/16)
- `--mem-gb`, `--brwt-subsample` (incl. scientific notation), `-p` flow-through
- samples auto-detection across file / dir / FIFO
- `.seqs` sidecar firing (and not firing) per mode; output path matches the loader
- `--disk-swap-dir` default `<output_dir>/temp` and explicit `""` disable
- terminal-streaming behavior with and without `--verbose`
- `--keep-columns` / `--keep-rd-columns` flag propagation

## Migration cheat sheet

```bash
# Before
metagraph-workflows build --seqs-file-list-path samples.txt \
  --output_dir out/ --mem-cap-gb 70 --threads 34

# After
metagraph-workflows build samples.txt -o out/ \
  --mem-gb 70 -p 34 --disk-swap-dir /scratch/swap
```

```yaml
# config.yaml
annotation_labels_source: sequence_headers   # → header
# or
annotation_labels_source: file_names         # → filename
max_memory_mb: 16384                         # → memory_mb
```

```python
# Python API
cli.run_workflow(out_dir, samples=path, mem_gb=70, threads=34)
```

## Docs

- README quick-start rewritten to lead with the one-liner; calls out that `metagraph-workflows` ships as a separate Python package on top of the conda `metagraph` recipe.
- Sphinx `workflows.rst` updated for the new CLI shape, the `cli.run_workflow(...)` Python entry point, and the `.seqs` sidecar section.

## Test plan

- [ ] Run the workflow's slow integration tests (parametrized over all annotation formats × primary on/off × `filename` label source) on a real machine.
- [ ] Spot-check on real data: `metagraph-workflows build files.txt -o out/ --primary`.
- [ ] Verify resolved commands for a representative script match the workflow output (e.g. Random100 with `-p 34 --mem-gb 70 --primary --brwt-subsample 1e7`).
- [ ] Coord query against `graph.seqs` returns sequence-level coords (`<header>/<N>:<positions>`), not file-level.
