### PR TITLE
coords: report target sequence length, expose align coords in JSON (#632)

### DIFF
--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -503,14 +503,17 @@ a new annotation label will be created for every sequence in the input, and the 
 will be re-set to 0 for every sequence. Note, however, that this assumes that all sequence headers in the FASTA file are unique
 and do not repeat. If this condition is not met, an error will be returned.
 
+.. _index_header_coords:
+
 Map file coordinates to sequence headers
 """"""""""""""""""""""""""""""""""""""""
 When indexing coordinates with ``--anno-filename``, one can additionally build a mapping from file-level coordinates
 to original sequence headers using ``--index-header-coords``. **This step is what lets callers compute the
-fraction of each target sequence that was covered by a query**: it produces a ``.seqs`` sidecar file
-alongside the annotation so that ``metagraph query --query-mode coords`` can report per-sequence positions
-and the per-target k-mer count (see :ref:`query_kmer_coordinates`). Without it, the query falls back to
-file-level coordinates and omits the per-target k-mer count.
+fraction of each target sequence covered by a hit**: it produces a ``.seqs`` sidecar file
+alongside the annotation so that both ``metagraph query --query-mode coords``
+(see :ref:`query_kmer_coordinates`) and ``metagraph align`` (see :ref:`align_nt_coordinates`)
+can report per-sequence positions and the per-target sequence length. Without it, both fall back
+to file-level coordinates and omit the per-target length.
 
 This is a second ``metagraph annotate`` run: the first run creates the annotation (``*.annodbg`` + ``*.coords``),
 and the second run creates only the coordinate-to-header (``CoordToHeader``) mapping (``*.seqs``)::
@@ -560,27 +563,33 @@ Note that if neither ``--query-mode coords`` nor ``--query-mode counts`` is pass
         metagraph query --query-mode coords --no-coord-mapping ...
 
 .. note::
-    When the ``.seqs`` mapping is in use, each hit is annotated with the k-mer count of the
-    target sequence it was found in, so callers can compute the fraction of each target
-    covered by matched k-mers. In the default TSV output the count
-    appears right after the header inside the angle brackets, separated by ``/``::
+    When the ``.seqs`` mapping is in use (see :ref:`index_header_coords`), each hit is annotated
+    with the k-mer count of the target sequence it was found in, so callers can compute the
+    fraction of the target covered. The count appears after the ``>`` of the bracketed header,
+    separated by ``/``::
 
         0    query1    <seq1>/6:0-1-5    <seq3>/24:1-4:1-0-3
 
-    Here ``seq1`` has 6 k-mers total and was hit at coords ``1..5`` from query position 0.
+    Here ``seq1`` has 6 k-mers total and was hit at target k-mer coords ``1..5`` starting at
+    query k-mer position ``0`` (positions are k-mer-indexed and 0-based; each ``pos-first-last``
+    triplet describes one matched run).
+
     In JSON output the same number is exposed as the ``kmers_in_target`` field next to
     ``kmer_coords``. The target sequence's nucleotide length is ``kmers_in_target + k - 1``.
 
-.. _align_kmer_coordinates:
+.. _align_nt_coordinates:
 
-Align k-mer coordinates
-"""""""""""""""""""""""
+Align nucleotide coordinates
+""""""""""""""""""""""""""""
 ``metagraph align`` also reports per-target-sequence coordinates when the index is
 coordinate-aware and a ``.seqs`` mapping is present (same setup as for query, see
-:ref:`query_kmer_coordinates`). The last TSV column of each alignment is a
-semicolon-separated list of ``<header>/<nt_length>:<start>-<end>`` entries, where ``<start>``
-and ``<end>`` are 1-based inclusive nucleotide positions on the target. Multiple ``:<start>-<end>``
-ranges after the same header correspond to multiple alignment positions for the same target::
+:ref:`index_header_coords`). Unlike the query-side output, align coordinates are
+**1-based inclusive nucleotide positions on the target** (not k-mer indices), to match
+the alignment length given by the CIGAR.
+
+The last TSV column of each alignment is a semicolon-separated list of
+``<header>/<nt_length>:<start>-<end>`` entries. Multiple ``:<start>-<end>`` ranges after the
+same header correspond to multiple alignment positions for the same target::
 
     q1    GCTAGCTA    +    GCTAGCTA    26    8    8=    0    seq2/16:1-8:5-12:9-16
 
@@ -594,8 +603,7 @@ In JSON output (``--json``) the same information appears as ``annotation.labels[
       "ref_sequence": "GCTAGCTA"
     }
 
-The fraction of the target covered by a given alignment range is
-``(end - start + 1) / nt_length``.
+The fraction of the target covered by a given alignment range is ``(end - start + 1) / nt_length``.
 
 .. note::
     By default the JSON output omits the bulky VG-style ``path.mapping[]`` object
@@ -841,7 +849,7 @@ To query a MetaGraph index (graph + annotation) using the command line interface
 
 For alignment, see ``metagraph align``. When the index is coordinate-aware and a ``.seqs`` mapping is loaded,
 alignments include per-target-sequence positions and lengths so the fraction of each target covered
-can be derived directly from the output — see :ref:`align_kmer_coordinates`.
+can be derived directly from the output — see :ref:`align_nt_coordinates`.
 
 To load up a MetaGraph index in server mode for querying it with the Python API or via HTTP requests, run::
 

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -547,6 +547,18 @@ Note that if neither ``--query-mode coords`` nor ``--query-mode counts`` is pass
 
         metagraph query --query-mode coords --no-coord-mapping ...
 
+.. note::
+    When the ``.seqs`` mapping is in use, each hit is annotated with the k-mer count of the
+    target sequence it was found in, so callers can compute the breadth of coverage (the
+    fraction of the target covered by matched k-mers). In the default TSV output the count
+    appears right after the header inside the angle brackets, separated by ``/``::
+
+        0    query1    <seq1>/6:0-1-5    <seq3>/24:1-4:1-0-3
+
+    Here ``seq1`` has 6 k-mers total and was hit at coords ``1..5`` from query position 0.
+    In JSON output the same number is exposed as the ``kmers_in_target`` field next to
+    ``kmer_coords``. The target sequence's nucleotide length is ``kmers_in_target + k - 1``.
+
 .. _transform annotation:
 
 Transform annotation

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -577,6 +577,10 @@ Note that if neither ``--query-mode coords`` nor ``--query-mode counts`` is pass
     In JSON output the same number is exposed as the ``kmers_in_target`` field next to
     ``kmer_coords``. The target sequence's nucleotide length is ``kmers_in_target + k - 1``.
 
+    Targets hit at multiple positions produce multiple ``pos-first-last`` triplets. For an
+    actual fraction-of-target-covered figure, take the **union** of the k-mer positions
+    those triplets cover (merging any overlaps) and divide by ``kmers_in_target``.
+
 .. _align_nt_coordinates:
 
 Align nucleotide coordinates
@@ -604,6 +608,8 @@ In JSON output (``--json``) the same information appears as ``annotation.labels[
     }
 
 The fraction of the target covered by a given alignment range is ``(end - start + 1) / nt_length``.
+When a target carries multiple ranges, take the **union** of their nt positions (overlapping ranges
+should be merged) — not the sum of individual spans — before dividing by ``nt_length``.
 
 .. note::
     By default the JSON output omits the bulky VG-style ``path.mapping[]`` object

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -571,6 +571,37 @@ Note that if neither ``--query-mode coords`` nor ``--query-mode counts`` is pass
     In JSON output the same number is exposed as the ``kmers_in_target`` field next to
     ``kmer_coords``. The target sequence's nucleotide length is ``kmers_in_target + k - 1``.
 
+.. _align_kmer_coordinates:
+
+Align k-mer coordinates
+"""""""""""""""""""""""
+``metagraph align`` also reports per-target-sequence coordinates when the index is
+coordinate-aware and a ``.seqs`` mapping is present (same setup as for query, see
+:ref:`query_kmer_coordinates`). The last TSV column of each alignment is a
+semicolon-separated list of ``<header>/<nt_length>:<start>-<end>`` entries, where ``<start>``
+and ``<end>`` are 1-based inclusive nucleotide positions on the target. Multiple ``:<start>-<end>``
+ranges after the same header correspond to multiple alignment positions for the same target::
+
+    q1    GCTAGCTA    +    GCTAGCTA    26    8    8=    0    seq2/16:1-8:5-12:9-16
+
+Here ``seq2`` is 16 nt long and the 8 nt query matched it at three different starting positions.
+
+In JSON output (``--json``) the same information appears as ``annotation.labels[]``::
+
+    "annotation": {
+      "cigar": "8=",
+      "labels": [{"sample": "seq2", "nt_length": 16, "nt_coords": "1-8:5-12:9-16"}],
+      "ref_sequence": "GCTAGCTA"
+    }
+
+The fraction of the target covered by a given alignment range is
+``(end - start + 1) / nt_length``.
+
+.. note::
+    By default the JSON output omits the bulky VG-style ``path.mapping[]`` object
+    (one entry per visited graph node, duplicating the edit script already in
+    ``cigar``). Pass ``--align-output-path`` to include it for VG/Cactus interop.
+
 .. _transform annotation:
 
 Transform annotation
@@ -808,7 +839,9 @@ To query a MetaGraph index (graph + annotation) using the command line interface
                     --min-kmers-fraction-label 0.1 \
                     transcripts_1000.fa
 
-For alignment, see ``metagraph align``.
+For alignment, see ``metagraph align``. When the index is coordinate-aware and a ``.seqs`` mapping is loaded,
+alignments include per-target-sequence positions and lengths so the fraction of each target covered
+can be derived directly from the output — see :ref:`align_kmer_coordinates`.
 
 To load up a MetaGraph index in server mode for querying it with the Python API or via HTTP requests, run::
 

--- a/metagraph/docs/source/quick_start.rst
+++ b/metagraph/docs/source/quick_start.rst
@@ -506,19 +506,24 @@ and do not repeat. If this condition is not met, an error will be returned.
 Map file coordinates to sequence headers
 """"""""""""""""""""""""""""""""""""""""
 When indexing coordinates with ``--anno-filename``, one can additionally build a mapping from file-level coordinates
-to original sequence headers using ``--index-header-coords``.
+to original sequence headers using ``--index-header-coords``. **This step is what lets callers compute the
+fraction of each target sequence that was covered by a query**: it produces a ``.seqs`` sidecar file
+alongside the annotation so that ``metagraph query --query-mode coords`` can report per-sequence positions
+and the per-target k-mer count (see :ref:`query_kmer_coordinates`). Without it, the query falls back to
+file-level coordinates and omits the per-target k-mer count.
 
 This is a second ``metagraph annotate`` run: the first run creates the annotation (``*.annodbg`` + ``*.coords``),
 and the second run creates only the coordinate-to-header (``CoordToHeader``) mapping (``*.seqs``)::
 
-    # 1) build coordinate-aware annotation
+    # 1) build coordinate-aware annotation (possibly in multiple chunks or with --separately)
     metagraph annotate -v -i graph.dbg --anno-filename --coordinates -p 4 \
                        -o annotation transcripts_1000.fa
 
     # ... optionally transform annotation to the final query representation
     #     (e.g., row_diff_brwt_coord)
 
-    # 2) build the CoordToHeader mapping
+    # 2) build the CoordToHeader mapping ONCE, against the final annotation,
+    #    with the FULL set of input FASTAs (in the order matching the final column layout)
     metagraph annotate -v -i graph.dbg --anno-filename --index-header-coords -p 4 \
                        -o annotation transcripts_1000.fa
 
@@ -528,7 +533,14 @@ Pass these files in an order that is consistent with the final transformed annot
 During query, MetaGraph loads ``annotation.*.annodbg.seqs`` (where ``*`` is the final transformed annotation type)
 automatically and reports sequence-based hits (header + local coordinate) instead of file-based coordinates.
 
+The ``--index-header-coords`` step is a one-shot run against the final merged annotation. If the annotation
+was built in multiple chunks (multiple ``metagraph annotate`` invocations with disjoint FASTA subsets) or
+with ``--separately``, run ``--index-header-coords`` once after all annotation/transform steps are complete,
+passing every input FASTA in column order. ``metagraph stats --print-col-names`` will show the column order.
+
 All other flags (e.g., ``--separately`` and ``--disk-swap``) described above are also supported similarly as for binary annotations.
+
+.. _query_kmer_coordinates:
 
 Query k-mer coordinates
 """""""""""""""""""""""
@@ -549,8 +561,8 @@ Note that if neither ``--query-mode coords`` nor ``--query-mode counts`` is pass
 
 .. note::
     When the ``.seqs`` mapping is in use, each hit is annotated with the k-mer count of the
-    target sequence it was found in, so callers can compute the breadth of coverage (the
-    fraction of the target covered by matched k-mers). In the default TSV output the count
+    target sequence it was found in, so callers can compute the fraction of each target
+    covered by matched k-mers. In the default TSV output the count
     appears right after the header inside the angle brackets, separated by ``/``::
 
         0    query1    <seq1>/6:0-1-5    <seq3>/24:1-4:1-0-3

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -766,6 +766,21 @@ class TestAlignCoordToHeader(TestingBase):
                                  "nt_length must only appear when .seqs is loaded")
                 self.assertEqual(entry['sample'], test_fa)
 
+        # With --align-output-path, the bulky `path.mapping[]` is re-enabled,
+        # AND `annotation.labels[]` with `nt_length` is still present.
+        align_cmd_with_path = align_cmd + ' --align-output-path'
+        res = subprocess.run([align_cmd_with_path], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0)
+        records = [json.loads(line) for line in res.stdout.decode().splitlines() if line.strip()]
+        for record in records:
+            self.assertIn('path', record, "--align-output-path should emit the path field")
+            self.assertIn('mapping', record['path'])
+            self.assertGreater(len(record['path']['mapping']), 0)
+            # Both views coexist: labels still carries the per-target info.
+            for entry in record['annotation']['labels']:
+                self.assertIn('nt_length', entry)
+                self.assertIn('nt_coords', entry)
+
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_coord_to_header_matches_per_sequence_columns(self, anno_repr):
         """CoordToHeader output matches per-sequence-column annotation output.

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -344,7 +344,10 @@ class TestDNAAlign(TestingBase):
         self.assertEqual('16438', params['nodes (k)'])
         self.assertEqual('basic', params['mode'])
 
-        stats_command = '{exe} align --json -i {graph} --align-min-exact-match 0.0 {reads}'.format(
+        # The fixture includes the VG-style `path.mapping[]` object, which is
+        # now opt-in via --align-output-path (off by default).
+        stats_command = ('{exe} align --json --align-output-path -i {graph} '
+                         '--align-min-exact-match 0.0 {reads}').format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/genome.MT' + graph_file_extension[representation],
             reads=TEST_DATA_DIR + '/genome_MT1.fq',
@@ -370,7 +373,11 @@ class TestDNAAlign(TestingBase):
         self.assertEqual('16438', params['nodes (k)'])
         self.assertEqual('basic', params['mode'])
 
-        stats_command = '{exe} align --json --align-edit-distance -i {graph} --align-min-exact-match 0.0 {reads}'.format(
+        # See note in test_simple_align_all_graphs: --align-output-path opts in
+        # to the bulky path.mapping[] object that the fixture pins.
+        stats_command = ('{exe} align --json --align-output-path '
+                         '--align-edit-distance -i {graph} '
+                         '--align-min-exact-match 0.0 {reads}').format(
             exe=METAGRAPH,
             graph=self.tempdir.name + '/genome.MT' + graph_file_extension[representation],
             reads=TEST_DATA_DIR + '/genome_MT1.fq',
@@ -726,6 +733,12 @@ class TestAlignCoordToHeader(TestingBase):
 
         records = [json.loads(line) for line in res.stdout.decode().splitlines() if line.strip()]
         self.assertEqual(len(records), 2)
+
+        # Default JSON omits the bulky VG-style `path.mapping[]` object;
+        # callers opt in via --align-output-path.
+        for record in records:
+            self.assertNotIn('path', record,
+                             "`path` must be opt-in via --align-output-path")
 
         # query1 -> seq1 (10 nt), 1-based inclusive range 2-10.
         labels1 = records[0]['annotation']['labels']

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -425,13 +425,13 @@ class TestAlignCoordToHeader(TestingBase):
     That is a larger change — design to be worked out separately.
     """
 
-    # Strip the per-target k-mer count (`/N`) emitted in CoordToHeader mode
-    # from a label-coord string so it can be compared against the
+    # Strip the per-target nucleotide length (`/N`) emitted in CoordToHeader
+    # mode from a label-coord string so it can be compared against the
     # --anno-header mode output (which has no `/N`).
-    _STRIP_KMERS_RE = re.compile(r'(^|;)([^:;]+)/\d+:')
+    _STRIP_NT_LENGTH_RE = re.compile(r'(^|;)([^:;]+)/\d+:')
     @classmethod
-    def _strip_kmers_in_target(cls, s):
-        return cls._STRIP_KMERS_RE.sub(r'\1\2:', s)
+    def _strip_nt_length(cls, s):
+        return cls._STRIP_NT_LENGTH_RE.sub(r'\1\2:', s)
 
     def setUp(self):
         self.tempdir = TemporaryDirectory()
@@ -494,7 +494,7 @@ class TestAlignCoordToHeader(TestingBase):
     def _assert_cth_matches_anno_header(self, rows_a, rows_b):
         """Check per-row CIGAR + label equivalence between CoordToHeader and
         per-sequence-column modes. CoordToHeader mode prefixes each header
-        with the per-target k-mer count (`/N`); strip it so the label set
+        with the per-target nucleotide length (`/N`); strip it so the label set
         matches --anno-header mode output, and sort to ignore label order."""
         self.assertEqual(len(rows_a), len(rows_b))
         for row_a, row_b in zip(rows_a, rows_b):
@@ -502,7 +502,7 @@ class TestAlignCoordToHeader(TestingBase):
             self.assertEqual(row_a[6], row_b[6],
                              f"CIGAR mismatch for {row_a[0]}: "
                              f"CoordToHeader={row_a[6]!r} vs per-sequence={row_b[6]!r}")
-            labels_a = sorted(self._strip_kmers_in_target(row_a[8]).split(';'))
+            labels_a = sorted(self._strip_nt_length(row_a[8]).split(';'))
             labels_b = sorted(row_b[8].split(';'))
             self.assertEqual(labels_a, labels_b,
                              f"label mismatch for {row_a[0]}: "

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -1,6 +1,8 @@
 import unittest
 from parameterized import parameterized
 import subprocess
+import json
+import re
 from subprocess import PIPE
 from tempfile import TemporaryDirectory
 import glob
@@ -416,6 +418,14 @@ class TestAlignCoordToHeader(TestingBase):
     That is a larger change — design to be worked out separately.
     """
 
+    # Strip the per-target k-mer count (`/N`) emitted in CoordToHeader mode
+    # from a label-coord string so it can be compared against the
+    # --anno-header mode output (which has no `/N`).
+    _STRIP_KMERS_RE = re.compile(r'(^|;)([^:;]+)/\d+:')
+    @classmethod
+    def _strip_kmers_in_target(cls, s):
+        return cls._STRIP_KMERS_RE.sub(r'\1\2:', s)
+
     def setUp(self):
         self.tempdir = TemporaryDirectory()
 
@@ -495,29 +505,31 @@ class TestAlignCoordToHeader(TestingBase):
         rows = self._run_align(graph, anno, query_fa)
         self.assertEqual(len(rows), 3)
 
-        # query1 -> seq1:2-10
+        # `/N` after each header is the target sequence's nucleotide length:
+        # seq1 -> 10, seq2 -> 16, seq3 -> 28.
+        # query1 -> seq1/10:2-10
         self.assertEqual(rows[0][0], 'query1')
         self.assertEqual(rows[0][1], 'TATCGATCG')
         self.assertEqual(rows[0][3], 'TATCGATCG')
         self.assertEqual(rows[0][6], '9=')
         self.assertEqual(rows[0][7], '0')
-        self.assertEqual(rows[0][8], 'seq1:2-10')
+        self.assertEqual(rows[0][8], 'seq1/10:2-10')
 
-        # query2 -> seq2:1-13
+        # query2 -> seq2/16:1-13
         self.assertEqual(rows[1][0], 'query2')
         self.assertEqual(rows[1][1], 'GCTAGCTAGCTAG')
         self.assertEqual(rows[1][3], 'GCTAGCTAGCTAG')
         self.assertEqual(rows[1][6], '13=')
         self.assertEqual(rows[1][7], '0')
-        self.assertEqual(rows[1][8], 'seq2:1-13')
+        self.assertEqual(rows[1][8], 'seq2/16:1-13')
 
-        # query3 -> seq3:9-18
+        # query3 -> seq3/28:9-18
         self.assertEqual(rows[2][0], 'query3')
         self.assertEqual(rows[2][1], 'AAAAACCCCC')
         self.assertEqual(rows[2][3], 'AAAAACCCCC')
         self.assertEqual(rows[2][6], '10=')
         self.assertEqual(rows[2][7], '0')
-        self.assertEqual(rows[2][8], 'seq3:9-18')
+        self.assertEqual(rows[2][8], 'seq3/28:9-18')
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_no_coord_mapping_flag(self, anno_repr):
@@ -571,7 +583,8 @@ class TestAlignCoordToHeader(TestingBase):
         self.assertEqual(rows[0][6], '8=')
         self.assertEqual(rows[0][7], '0')
         # Both sequences reported, separated by ;
-        self.assertEqual(rows[0][8], 'seq1:3-10;seq3:1-8')
+        # /N is the per-target nt length: seq1 -> 10, seq3 -> 28.
+        self.assertEqual(rows[0][8], 'seq1/10:3-10;seq3/28:1-8')
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_multiple_input_files(self, anno_repr):
@@ -592,17 +605,18 @@ class TestAlignCoordToHeader(TestingBase):
         rows = self._run_align(graph, anno, query_fa)
         self.assertEqual(len(rows), 2)
 
-        # q_alpha -> alpha:2-10 (in file1.fa)
+        # /N is the per-target nt length: alpha -> 14, gamma -> 18.
+        # q_alpha -> alpha/14:2-10 (in file1.fa)
         self.assertEqual(rows[0][0], 'q_alpha')
         self.assertEqual(rows[0][3], 'TATCGATCG')
         self.assertEqual(rows[0][6], '9=')
-        self.assertEqual(rows[0][8], 'alpha:2-10')
+        self.assertEqual(rows[0][8], 'alpha/14:2-10')
 
-        # q_gamma -> gamma:9-18 (in file2.fa)
+        # q_gamma -> gamma/18:9-18 (in file2.fa)
         self.assertEqual(rows[1][0], 'q_gamma')
         self.assertEqual(rows[1][3], 'AAAAACCCCC')
         self.assertEqual(rows[1][6], '10=')
-        self.assertEqual(rows[1][8], 'gamma:9-18')
+        self.assertEqual(rows[1][8], 'gamma/18:9-18')
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_with_mismatch(self, anno_repr):
@@ -623,7 +637,8 @@ class TestAlignCoordToHeader(TestingBase):
         self.assertEqual(rows[0][1], 'GTATCGATCGACATACGT')
         self.assertEqual(rows[0][3], 'GTATCGATCGACGTACGT')
         self.assertEqual(rows[0][6], '12=1X5=')
-        self.assertEqual(rows[0][8], 'seq1:1-18')
+        # seq1 GTATCGATCGACGTACGT -> 18 nt.
+        self.assertEqual(rows[0][8], 'seq1/18:1-18')
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_sequence_boundaries(self, anno_repr):
@@ -637,19 +652,20 @@ class TestAlignCoordToHeader(TestingBase):
 
         graph, anno = self._setup_graph(test_fa, anno_repr)
 
+        # seq1 ACGTACGTACGT -> 12 nt.
         # Match at start of seq1 -> coord starts at 1
         rows = self._run_align(graph, anno, query_start)
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0][0], 'q_start')
         self.assertEqual(rows[0][6], '9=')
-        self.assertEqual(rows[0][8], 'seq1:1-9')
+        self.assertEqual(rows[0][8], 'seq1/12:1-9')
 
         # Match at end of seq1 -> coord ends at len(seq1)=12
         rows = self._run_align(graph, anno, query_end)
         self.assertEqual(len(rows), 1)
         self.assertEqual(rows[0][0], 'q_end')
         self.assertEqual(rows[0][6], '10=')
-        self.assertEqual(rows[0][8], 'seq1:3-12')
+        self.assertEqual(rows[0][8], 'seq1/12:3-12')
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_cross_sequence_boundary(self, anno_repr):
@@ -682,7 +698,60 @@ class TestAlignCoordToHeader(TestingBase):
         self.assertEqual(rows[0][0], 'q_concat')
         self.assertEqual(rows[0][6], '8S16=')
         # Range 8 nt in seq1 (local 5-12) + 8 nt in seq2 (local 1-8).
-        self.assertEqual(rows[0][8], 'seq1:5-12;seq2:1-8')
+        # seq1 -> 12 nt, seq2 -> 12 nt.
+        self.assertEqual(rows[0][8], 'seq1/12:5-12;seq2/12:1-8')
+
+    @parameterized.expand(COORD_ANNO_TYPES)
+    def test_align_json_labels_array(self, anno_repr):
+        """JSON output should expose annotation.labels with nt_length and nt_coords.
+
+        Mirrors the TSV `<header>/N:start-end` so HTTP/API callers can compute
+        the fraction of the target covered directly from the nt coord range.
+        """
+        test_fa = self._write_fa('seqs.fa', [
+            ('seq1', 'GTATCGATCG'),                       # 10 nt
+            ('seq2', 'GCTAGCTAGCTAGCTA'),                 # 16 nt
+            ('seq3', 'ATCGATCGAAAAACCCCCGGGGGTTTTT'),     # 28 nt
+        ])
+        query_fa = self._write_fa('query.fa', [
+            ('query1', 'TATCGATCG'),      # seq1
+            ('query2', 'GCTAGCTAGCTAG'),  # seq2
+        ])
+
+        graph, anno = self._setup_graph(test_fa, anno_repr)
+        align_cmd = (f'{METAGRAPH} align --align-only-forwards --json '
+                     f'-i {graph} -a {anno} {query_fa}' + MMAP_FLAG)
+        res = subprocess.run([align_cmd], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0, f"Align failed: {res.stderr.decode()}")
+
+        records = [json.loads(line) for line in res.stdout.decode().splitlines() if line.strip()]
+        self.assertEqual(len(records), 2)
+
+        # query1 -> seq1 (10 nt), 1-based inclusive range 2-10.
+        labels1 = records[0]['annotation']['labels']
+        self.assertEqual(len(labels1), 1)
+        self.assertEqual(labels1[0]['sample'], 'seq1')
+        self.assertEqual(labels1[0]['nt_length'], 10)
+        self.assertEqual(labels1[0]['nt_coords'], '2-10')
+
+        # query2 -> seq2 (16 nt), 1-based inclusive range 1-13.
+        labels2 = records[1]['annotation']['labels']
+        self.assertEqual(len(labels2), 1)
+        self.assertEqual(labels2[0]['sample'], 'seq2')
+        self.assertEqual(labels2[0]['nt_length'], 16)
+        self.assertEqual(labels2[0]['nt_coords'], '1-13')
+
+        # With --no-coord-mapping, labels reference the file label (no .seqs
+        # used) and nt_length is omitted.
+        align_cmd_nomap = align_cmd + ' --no-coord-mapping'
+        res = subprocess.run([align_cmd_nomap], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0)
+        records = [json.loads(line) for line in res.stdout.decode().splitlines() if line.strip()]
+        for record in records:
+            for entry in record['annotation']['labels']:
+                self.assertNotIn('nt_length', entry,
+                                 "nt_length must only appear when .seqs is loaded")
+                self.assertEqual(entry['sample'], test_fa)
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_coord_to_header_matches_per_sequence_columns(self, anno_repr):
@@ -725,8 +794,11 @@ class TestAlignCoordToHeader(TestingBase):
             self.assertEqual(row_a[6], row_b[6],
                              f"CIGAR mismatch for {row_a[0]}: "
                              f"CoordToHeader={row_a[6]!r} vs per-sequence={row_b[6]!r}")
-            # Normalize semicolon-separated labels (order may vary across modes).
-            labels_a = sorted(row_a[8].split(';'))
+            # Normalize semicolon-separated labels (order may vary across
+            # modes). CoordToHeader mode prefixes each header with the
+            # per-target k-mer count; strip it so the label-equivalence
+            # check matches --anno-header mode output.
+            labels_a = sorted(self._strip_kmers_in_target(row_a[8]).split(';'))
             labels_b = sorted(row_b[8].split(';'))
             self.assertEqual(labels_a, labels_b,
                              f"label mismatch for {row_a[0]}: "
@@ -787,7 +859,7 @@ class TestAlignCoordToHeader(TestingBase):
             self.assertEqual(row_a[6], row_b[6],
                              f"CIGAR mismatch for {row_a[0]}: "
                              f"CoordToHeader={row_a[6]!r} vs per-sequence={row_b[6]!r}")
-            labels_a = sorted(row_a[8].split(';'))
+            labels_a = sorted(self._strip_kmers_in_target(row_a[8]).split(';'))
             labels_b = sorted(row_b[8].split(';'))
             self.assertEqual(labels_a, labels_b,
                              f"label mismatch for {row_a[0]}: "

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -757,19 +757,15 @@ class TestAlignCoordToHeader(TestingBase):
             self.assertNotIn('path', record,
                              "`path` must be opt-in via --align-output-path")
 
-        # query1 -> seq1 (10 nt), 1-based inclusive range 2-10.
+        # query1 -> seq1 (10 nt), 1-based inclusive range 2-10. One query
+        # is enough to pin the CTH JSON branch; query2 is kept in the
+        # fixture only because the --no-coord-mapping sub-case below
+        # asserts distinct nt_coords for both queries.
         labels1 = records[0]['annotation']['labels']
         self.assertEqual(len(labels1), 1)
         self.assertEqual(labels1[0]['sample'], 'seq1')
         self.assertEqual(labels1[0]['nt_length'], 10)
         self.assertEqual(labels1[0]['nt_coords'], '2-10')
-
-        # query2 -> seq2 (16 nt), 1-based inclusive range 1-13.
-        labels2 = records[1]['annotation']['labels']
-        self.assertEqual(len(labels2), 1)
-        self.assertEqual(labels2[0]['sample'], 'seq2')
-        self.assertEqual(labels2[0]['nt_length'], 16)
-        self.assertEqual(labels2[0]['nt_coords'], '1-13')
 
         # With --no-coord-mapping, labels reference the file label (no .seqs
         # used) and nt_length is omitted. nt_coords mirrors the TSV

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -491,6 +491,23 @@ class TestAlignCoordToHeader(TestingBase):
                 f.write(f'>{header}\n{seq}\n')
         return path
 
+    def _assert_cth_matches_anno_header(self, rows_a, rows_b):
+        """Check per-row CIGAR + label equivalence between CoordToHeader and
+        per-sequence-column modes. CoordToHeader mode prefixes each header
+        with the per-target k-mer count (`/N`); strip it so the label set
+        matches --anno-header mode output, and sort to ignore label order."""
+        self.assertEqual(len(rows_a), len(rows_b))
+        for row_a, row_b in zip(rows_a, rows_b):
+            self.assertEqual(row_a[0], row_b[0])  # query name
+            self.assertEqual(row_a[6], row_b[6],
+                             f"CIGAR mismatch for {row_a[0]}: "
+                             f"CoordToHeader={row_a[6]!r} vs per-sequence={row_b[6]!r}")
+            labels_a = sorted(self._strip_kmers_in_target(row_a[8]).split(';'))
+            labels_b = sorted(row_b[8].split(';'))
+            self.assertEqual(labels_a, labels_b,
+                             f"label mismatch for {row_a[0]}: "
+                             f"CoordToHeader={row_a[8]!r} vs per-sequence={row_b[8]!r}")
+
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_with_seqs_maps_coords_to_headers(self, anno_repr):
         """Core test: .seqs resolves global coords to per-sequence header:start-end."""
@@ -815,22 +832,7 @@ class TestAlignCoordToHeader(TestingBase):
         self._annotate_graph(test_fa, graph_b, anno_b_base, anno_repr, anno_type='header')
         rows_b = self._run_align(graph_b, anno_b, query_fa, only_forwards=False)
 
-        # The CIGAR (col 6) and label field (col 8) must match between modes.
-        self.assertEqual(len(rows_a), len(rows_b))
-        for row_a, row_b in zip(rows_a, rows_b):
-            self.assertEqual(row_a[0], row_b[0])  # query name
-            self.assertEqual(row_a[6], row_b[6],
-                             f"CIGAR mismatch for {row_a[0]}: "
-                             f"CoordToHeader={row_a[6]!r} vs per-sequence={row_b[6]!r}")
-            # Normalize semicolon-separated labels (order may vary across
-            # modes). CoordToHeader mode prefixes each header with the
-            # per-target k-mer count; strip it so the label-equivalence
-            # check matches --anno-header mode output.
-            labels_a = sorted(self._strip_kmers_in_target(row_a[8]).split(';'))
-            labels_b = sorted(row_b[8].split(';'))
-            self.assertEqual(labels_a, labels_b,
-                             f"label mismatch for {row_a[0]}: "
-                             f"CoordToHeader={row_a[8]!r} vs per-sequence={row_b[8]!r}")
+        self._assert_cth_matches_anno_header(rows_a, rows_b)
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_coord_to_header_matches_per_sequence_columns_two_files(self, anno_repr):
@@ -880,18 +882,7 @@ class TestAlignCoordToHeader(TestingBase):
         self._annotate_graph(combined_fa, graph_b, anno_b_base, anno_repr, anno_type='header')
         rows_b = self._run_align(graph_b, anno_b, query_fa, only_forwards=False)
 
-        # Per-row CIGAR + label equivalence, as in the single-file case.
-        self.assertEqual(len(rows_a), len(rows_b))
-        for row_a, row_b in zip(rows_a, rows_b):
-            self.assertEqual(row_a[0], row_b[0])
-            self.assertEqual(row_a[6], row_b[6],
-                             f"CIGAR mismatch for {row_a[0]}: "
-                             f"CoordToHeader={row_a[6]!r} vs per-sequence={row_b[6]!r}")
-            labels_a = sorted(self._strip_kmers_in_target(row_a[8]).split(';'))
-            labels_b = sorted(row_b[8].split(';'))
-            self.assertEqual(labels_a, labels_b,
-                             f"label mismatch for {row_a[0]}: "
-                             f"CoordToHeader={row_a[8]!r} vs per-sequence={row_b[8]!r}")
+        self._assert_cth_matches_anno_header(rows_a, rows_b)
 
 
 if __name__ == '__main__':

--- a/metagraph/integration_tests/test_align.py
+++ b/metagraph/integration_tests/test_align.py
@@ -772,16 +772,23 @@ class TestAlignCoordToHeader(TestingBase):
         self.assertEqual(labels2[0]['nt_coords'], '1-13')
 
         # With --no-coord-mapping, labels reference the file label (no .seqs
-        # used) and nt_length is omitted.
+        # used) and nt_length is omitted. nt_coords mirrors the TSV
+        # `<file>:start-end` output of test_align_no_coord_mapping_flag
+        # (1-based inclusive, in global k-mer coords + alignment nt length).
         align_cmd_nomap = align_cmd + ' --no-coord-mapping'
         res = subprocess.run([align_cmd_nomap], shell=True, stdout=PIPE, stderr=PIPE)
         self.assertEqual(res.returncode, 0)
         records = [json.loads(line) for line in res.stdout.decode().splitlines() if line.strip()]
+        self.assertEqual(len(records), 2)
+        expected_nt_coords = {'query1': '2-10', 'query2': '7-19'}
         for record in records:
-            for entry in record['annotation']['labels']:
-                self.assertNotIn('nt_length', entry,
-                                 "nt_length must only appear when .seqs is loaded")
-                self.assertEqual(entry['sample'], test_fa)
+            labels = record['annotation']['labels']
+            self.assertEqual(len(labels), 1)
+            entry = labels[0]
+            self.assertNotIn('nt_length', entry,
+                             "nt_length must only appear when .seqs is loaded")
+            self.assertEqual(entry['sample'], test_fa)
+            self.assertEqual(entry['nt_coords'], expected_nt_coords[record['name']])
 
         # With --align-output-path, the bulky `path.mapping[]` is re-enabled,
         # AND `annotation.labels[]` with `nt_length` is still present.
@@ -797,6 +804,108 @@ class TestAlignCoordToHeader(TestingBase):
             for entry in record['annotation']['labels']:
                 self.assertIn('nt_length', entry)
                 self.assertIn('nt_coords', entry)
+
+    @parameterized.expand(COORD_ANNO_TYPES)
+    def test_align_json_labels_multi_target(self, anno_repr):
+        """`annotation.labels[]` carries multiple entries when one alignment
+        spans (or shares k-mers with) multiple indexed sequences. JSON twin
+        of `test_align_shared_kmers_multiple_labels`."""
+        test_fa = self._write_fa('seqs.fa', [
+            ('seq1', 'GTATCGATCG'),                       # 10 nt
+            ('seq2', 'GCTAGCTAGCTAGCTA'),                 # 16 nt
+            ('seq3', 'ATCGATCGAAAAACCCCCGGGGGTTTTT'),     # 28 nt
+        ])
+        # ATCGATCG appears in both seq1 (pos 3-10) and seq3 (pos 1-8).
+        query_fa = self._write_fa('query.fa', [('shared_query', 'ATCGATCG')])
+
+        graph, anno = self._setup_graph(test_fa, anno_repr)
+        align_cmd = (f'{METAGRAPH} align --align-only-forwards --json '
+                     f'-i {graph} -a {anno} {query_fa}' + MMAP_FLAG)
+        res = subprocess.run([align_cmd], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0, f"Align failed: {res.stderr.decode()}")
+
+        records = [json.loads(line) for line in res.stdout.decode().splitlines() if line.strip()]
+        self.assertEqual(len(records), 1)
+        labels = records[0]['annotation']['labels']
+        # Order across columns/sequences isn't guaranteed; index by sample.
+        by_sample = {entry['sample']: entry for entry in labels}
+        self.assertEqual(set(by_sample), {'seq1', 'seq3'})
+        # seq1 GTATCGATCG (10 nt), match at local 3-10.
+        self.assertEqual(by_sample['seq1']['nt_length'], 10)
+        self.assertEqual(by_sample['seq1']['nt_coords'], '3-10')
+        # seq3 ATCGATCG... (28 nt), match at local 1-8.
+        self.assertEqual(by_sample['seq3']['nt_length'], 28)
+        self.assertEqual(by_sample['seq3']['nt_coords'], '1-8')
+
+    @parameterized.expand(COORD_ANNO_TYPES)
+    def test_align_json_cross_sequence_boundary(self, anno_repr):
+        """JSON twin of `test_align_cross_sequence_boundary`. When one
+        alignment path spans two indexed sequences (sharing a boundary
+        k-1-mer), `annotation.labels[]` must contain two entries with
+        per-target nt ranges from the `while (remaining)` loop inside
+        `split_coords_by_target`."""
+        test_fa = self._write_fa('seqs.fa', [
+            ('seq1', 'AAAAACGTACGT'),  # 12 nt; ends with ACGT
+            ('seq2', 'ACGTTTTTTTTT'),  # 12 nt; starts with ACGT
+        ])
+        query_fa = self._write_fa('query.fa', [
+            ('q_concat', 'AAAAACGTACGTACGTTTTTTTTT'),
+        ])
+
+        graph, anno = self._setup_graph(test_fa, anno_repr)
+        align_cmd = (f'{METAGRAPH} align --align-only-forwards --json '
+                     f'-i {graph} -a {anno} {query_fa}' + MMAP_FLAG)
+        res = subprocess.run([align_cmd], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0, f"Align failed: {res.stderr.decode()}")
+
+        records = [json.loads(line) for line in res.stdout.decode().splitlines() if line.strip()]
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]['annotation']['cigar'], '8S16=')
+        by_sample = {entry['sample']: entry for entry in records[0]['annotation']['labels']}
+        self.assertEqual(set(by_sample), {'seq1', 'seq2'})
+        # 8 nt in seq1 (local 5-12) + 8 nt in seq2 (local 1-8).
+        self.assertEqual(by_sample['seq1']['nt_length'], 12)
+        self.assertEqual(by_sample['seq1']['nt_coords'], '5-12')
+        self.assertEqual(by_sample['seq2']['nt_length'], 12)
+        self.assertEqual(by_sample['seq2']['nt_coords'], '1-8')
+
+    @parameterized.expand(COORD_ANNO_TYPES)
+    def test_align_missing_seqs_warning(self, anno_repr):
+        """When a coord-aware annotation is loaded without its `.seqs`
+        sidecar, `metagraph align` must emit the rewritten warning that
+        points at `--index-header-coords` and mentions both output fields
+        whose per-target length will be omitted."""
+        test_fa = self._write_fa('seqs.fa', [
+            ('seq1', 'GTATCGATCG'),
+            ('seq2', 'GCTAGCTAGCTAGCTA'),
+        ])
+        query_fa = self._write_fa('query.fa', [('query1', 'TATCGATCG')])
+
+        # Build a coord-aware annotation but skip --index-header-coords.
+        graph_base = self.tempdir.name + '/graph_nosseqs'
+        graph = graph_base + '.dbg'
+        anno_base = self.tempdir.name + '/anno_nosseqs'
+        anno = anno_base + coord_anno_file_extension[anno_repr]
+        self._build_graph(test_fa, graph_base, k=5, repr='succinct', mode='basic')
+        self._annotate_graph(test_fa, graph, anno_base, anno_repr, anno_type='filename')
+        self.assertFalse(os.path.exists(anno_base + '.seqs'))
+
+        align_cmd = (f'{METAGRAPH} align --align-only-forwards '
+                     f'-i {graph} -a {anno} {query_fa}' + MMAP_FLAG)
+        res = subprocess.run([align_cmd], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0, f"Align failed: {res.stderr.decode()}")
+        stderr = res.stderr.decode()
+        self.assertIn('No CoordToHeader mapping found', stderr)
+        self.assertIn('--index-header-coords', stderr)
+        self.assertIn('kmers_in_target', stderr)
+        self.assertIn('nt_length', stderr)
+        self.assertIn('--no-coord-mapping', stderr)
+
+        # With --no-coord-mapping the warning must be suppressed.
+        res = subprocess.run([align_cmd + ' --no-coord-mapping'],
+                             shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0)
+        self.assertNotIn('No CoordToHeader mapping found', res.stderr.decode())
 
     @parameterized.expand(COORD_ANNO_TYPES)
     def test_align_coord_to_header_matches_per_sequence_columns(self, anno_repr):

--- a/metagraph/integration_tests/test_annotate.py
+++ b/metagraph/integration_tests/test_annotate.py
@@ -378,5 +378,48 @@ class TestAnnotate(TestingBase):
                                     f'{self.tempdir.name}/annotation_ram.column.annodbg.coords'))
 
 
+    def test_annotate_coordinates_hints_index_header_coords(self):
+        """`metagraph annotate --coordinates --anno-filename` (without
+        `--index-header-coords`) must point users at the second pass that
+        builds the CoordToHeader (.seqs) mapping. This is the brand-new
+        hint at the end of annotate_graph().
+
+        The hint is emitted via `logger->info()`; the split_sink in
+        common/logger.cpp routes info-level messages to stdout (warn+
+        goes to stderr), so we look in stdout.
+        """
+        construct_command = (f'{METAGRAPH} build --mask-dummy --in-ram '
+                             f'-p {NUM_THREADS} --graph succinct -k 11 '
+                             f'-o {self.tempdir.name}/graph '
+                             f'{TEST_DATA_DIR}/transcripts_100.fa')
+        res = subprocess.run([construct_command], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0)
+
+        annotate_cmd = (f'{METAGRAPH} annotate --anno-filename --coordinates '
+                        f'-p {NUM_THREADS} '
+                        f'-i {self.tempdir.name}/graph.dbg '
+                        f'-o {self.tempdir.name}/annotation '
+                        f'{TEST_DATA_DIR}/transcripts_100.fa')
+        res = subprocess.run([annotate_cmd], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0)
+        stdout = res.stdout.decode()
+        self.assertIn('To enable per-sequence coordinate reporting', stdout)
+        self.assertIn('--index-header-coords', stdout)
+        self.assertIn(f'-i {self.tempdir.name}/graph.dbg', stdout)
+        self.assertIn(f'-o {self.tempdir.name}/annotation', stdout)
+
+        # When --index-header-coords is passed, the hint must not appear
+        # (the user is already doing what the hint suggests).
+        index_cmd = (f'{METAGRAPH} annotate --anno-filename '
+                     f'--index-header-coords -p {NUM_THREADS} '
+                     f'-i {self.tempdir.name}/graph.dbg '
+                     f'-o {self.tempdir.name}/annotation '
+                     f'{TEST_DATA_DIR}/transcripts_100.fa')
+        res = subprocess.run([index_cmd], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0)
+        self.assertNotIn('To enable per-sequence coordinate reporting',
+                         res.stdout.decode())
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -1178,7 +1178,7 @@ class TestCoordToHeader(TestingBase):
         self.assertEqual(res.stdout.decode(), expected_output)
 
     def test_query_coords_json_kmers_in_target(self):
-        """JSON output should expose `kmers_in_target` so callers can compute breadth of coverage."""
+        """JSON output should expose `kmers_in_target` so callers can compute the fraction of the target covered."""
         graph_base = self.tempdir.name + '/graph'
         graph = self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr]
         anno_base = self.tempdir.name + '/annotation'

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -1320,7 +1320,7 @@ class TestCoordToHeader(TestingBase):
         self.assertEqual(output[-1], "", "Output should contain two query results")
         self.assertEqual(output[0].split('\t')[:2], ["0", "query1"])
         # `/N` after each header is the target sequence's k-mer count (k=5):
-        # seq1 (10bp)->6, seq3 (34bp)->30, seq4 (17bp)->13, seq2 (16bp)->12.
+        # seq1 (10 nt)->6, seq3 (34 nt)->30, seq4 (17 nt)->13, seq2 (16 nt)->12.
         self.assertEqual(set(output[0].split('\t')[2:]), {"<seq1>/6:0-1-5", "<seq3>/30:1-4:1-0-3", "<seq4>/13:0-0-4:1-5-8:1-9-12"})
         self.assertEqual(output[1].split('\t')[:2], ["1", "query2"])
         self.assertEqual(set(output[1].split('\t')[2:]), {"<seq2>/12:0-0-3:0-4-7:0-8-11", "<seq3>/30:0-28-29"})
@@ -1406,7 +1406,7 @@ class TestCoordToHeader(TestingBase):
                 self.assertEqual(set(out), expected_output)
 
         # `/N` after each header is the target sequence's k-mer count (k=5):
-        # seq1 TATCGATC (8bp)->4, seq2 GTATCGATCGATCGATCG (18bp)->14, seq3 ATCGATCG (8bp)->4.
+        # seq1 TATCGATC (8 nt)->4, seq2 GTATCGATCGATCGATCG (18 nt)->14, seq3 ATCGATCG (8 nt)->4.
         test_stdout('--num-top-labels 1',
             '0\tquery1\t<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13')
         test_stdout('--num-top-labels 2',

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -2,6 +2,7 @@ import unittest
 from parameterized import parameterized, parameterized_class
 import subprocess
 import itertools
+import json
 from subprocess import PIPE
 from tempfile import TemporaryDirectory
 import glob
@@ -1161,8 +1162,11 @@ class TestCoordToHeader(TestingBase):
 
         res = subprocess.run([query_command], shell=True, stdout=PIPE, stderr=PIPE)
         self.assertEqual(res.returncode, 0)
+        # `/N` after each header is the target sequence's k-mer count (k=5,
+        # so len(seq) - 4): seq1 GTATCGATCG -> 6, seq2 GCTAGCTAGCTAGCTA -> 12,
+        # seq3 ATCG...TTTTT (28bp) -> 24.
         self.assertEqual(res.stdout.decode(),
-                         '0\tquery1\t<seq1>:0-1-5\t<seq3>:1-4:1-0-3\n1\tquery2\t<seq2>:0-0-3:0-4-7:0-8-11\n')
+                         '0\tquery1\t<seq1>/6:0-1-5\t<seq3>/24:1-4:1-0-3\n1\tquery2\t<seq2>/12:0-0-3:0-4-7:0-8-11\n')
 
         # Query in the basic mode, without mapping to headers
         res = subprocess.run([query_command + ' --no-coord-mapping'], shell=True, stdout=PIPE, stderr=PIPE)
@@ -1172,6 +1176,58 @@ class TestCoordToHeader(TestingBase):
             f'1\tquery2\t<{self.tempdir.name}/test_sequences.fa>:0-7-10:0-11-14:0-15-18\n'
         )
         self.assertEqual(res.stdout.decode(), expected_output)
+
+    def test_query_coords_json_kmers_in_target(self):
+        """JSON output should expose `kmers_in_target` so callers can compute breadth of coverage."""
+        graph_base = self.tempdir.name + '/graph'
+        graph = self.tempdir.name + '/graph' + graph_file_extension[self.graph_repr]
+        anno_base = self.tempdir.name + '/annotation'
+        anno = anno_base + anno_file_extension[self.anno_repr]
+        self._build_graph(self.test_fa, graph_base, k=5, repr=self.graph_repr, mode='basic')
+        self._annotate_graph(self.test_fa, graph, anno_base, self.anno_repr, anno_type='filename')
+        self.index_headers(graph, anno_base, self.test_fa)
+
+        query_command = f'{METAGRAPH} query --batch-size 0 --query-mode coords --json \
+                         -i {graph} -a {anno} --min-kmers-fraction-label 0.0 \
+                         {self.query_fa}' + MMAP_FLAG
+        res = subprocess.run([query_command], shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0, res.stderr.decode())
+
+        # k=5; seq1 GTATCGATCG -> 6, seq2 GCTAGCTAGCTAGCTA -> 12, seq3 (28bp) -> 24.
+        expected_lengths = {'seq1': 6, 'seq2': 12, 'seq3': 24}
+
+        # The JSON writer pretty-prints with newlines, so parse the stream of objects.
+        decoder = json.JSONDecoder()
+        def parse_records(text):
+            records = []
+            idx = 0
+            while idx < len(text):
+                while idx < len(text) and text[idx].isspace():
+                    idx += 1
+                if idx >= len(text):
+                    break
+                record, end = decoder.raw_decode(text, idx)
+                records.append(record)
+                idx = end
+            return records
+
+        records = parse_records(res.stdout.decode())
+        self.assertEqual(len(records), 2)
+        for record in records:
+            for result in record['results']:
+                self.assertIn('kmers_in_target', result,
+                              f"Expected kmers_in_target field in {result}")
+                self.assertEqual(result['kmers_in_target'], expected_lengths[result['sample']])
+
+        # With --no-coord-mapping, the label refers to a whole annotation column
+        # rather than a single indexed sequence, so the field is omitted.
+        res = subprocess.run([query_command + ' --no-coord-mapping'],
+                             shell=True, stdout=PIPE, stderr=PIPE)
+        self.assertEqual(res.returncode, 0, res.stderr.decode())
+        for record in parse_records(res.stdout.decode()):
+            for result in record['results']:
+                self.assertNotIn('kmers_in_target', result,
+                                 "kmers_in_target must only appear when CoordToHeader is loaded")
 
     @parameterized.expand(['', '-p 4', '--separately', '-p 4 --separately'])
     def test_multiple_files(self, extra_flags):
@@ -1263,9 +1319,11 @@ class TestCoordToHeader(TestingBase):
         self.assertEqual(len(output), 3, "Output should contain two query results")
         self.assertEqual(output[-1], "", "Output should contain two query results")
         self.assertEqual(output[0].split('\t')[:2], ["0", "query1"])
-        self.assertEqual(set(output[0].split('\t')[2:]), {"<seq1>:0-1-5", "<seq3>:1-4:1-0-3", "<seq4>:0-0-4:1-5-8:1-9-12"})
+        # `/N` after each header is the target sequence's k-mer count (k=5):
+        # seq1 (10bp)->6, seq3 (34bp)->30, seq4 (17bp)->13, seq2 (16bp)->12.
+        self.assertEqual(set(output[0].split('\t')[2:]), {"<seq1>/6:0-1-5", "<seq3>/30:1-4:1-0-3", "<seq4>/13:0-0-4:1-5-8:1-9-12"})
         self.assertEqual(output[1].split('\t')[:2], ["1", "query2"])
-        self.assertEqual(set(output[1].split('\t')[2:]), {"<seq2>:0-0-3:0-4-7:0-8-11", "<seq3>:0-28-29"})
+        self.assertEqual(set(output[1].split('\t')[2:]), {"<seq2>/12:0-0-3:0-4-7:0-8-11", "<seq3>/30:0-28-29"})
 
     def test_multiple_files_bad(self):
         # Check that query fails when Annotation and CoordToHeaders are incompatible
@@ -1347,21 +1405,23 @@ class TestCoordToHeader(TestingBase):
                     out = sum((part.split(extra_split_by) for part in out), [])
                 self.assertEqual(set(out), expected_output)
 
+        # `/N` after each header is the target sequence's k-mer count (k=5):
+        # seq1 TATCGATC (8bp)->4, seq2 GTATCGATCGATCGATCG (18bp)->14, seq3 ATCGATCG (8bp)->4.
         test_stdout('--num-top-labels 1',
-            '0\tquery1\t<seq2>:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13')
+            '0\tquery1\t<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13')
         test_stdout('--num-top-labels 2',
-            '0\tquery1\t<seq2>:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13\t<seq3>:1-0-3:5-0-3:9-0-3')
+            '0\tquery1\t<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13\t<seq3>/4:1-0-3:5-0-3:9-0-3')
         # Without filtering by --num-top-labels, the matches are not sorted
         test_stdout('--min-kmers-fraction-label 0.5',
-            {'0', 'query1', '<seq2>:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>:1-0-3:5-0-3:9-0-3', '<seq1>:0-0-3:5-1-3:9-1-3'})
+            {'0', 'query1', '<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>/4:1-0-3:5-0-3:9-0-3', '<seq1>/4:0-0-3:5-1-3:9-1-3'})
         test_stdout('--min-kmers-fraction-label 1.0',
-            '0\tquery1\t<seq2>:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13')
+            '0\tquery1\t<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13')
         test_stdout('--min-kmers-fraction-graph 1.0',
-            {'0', 'query1', '<seq1>:0-0-3:5-1-3:9-1-3', '<seq2>:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>:1-0-3:5-0-3:9-0-3'})
+            {'0', 'query1', '<seq1>/4:0-0-3:5-1-3:9-1-3', '<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>/4:1-0-3:5-0-3:9-0-3'})
         test_stdout('--min-kmers-fraction-label 0.0',
-            {'0', 'query1', '<seq1>:0-0-3:5-1-3:9-1-3', '<seq2>:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>:1-0-3:5-0-3:9-0-3'})
+            {'0', 'query1', '<seq1>/4:0-0-3:5-1-3:9-1-3', '<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>/4:1-0-3:5-0-3:9-0-3'})
         test_stdout('',
-            {'0', 'query1', '<seq1>:0-0-3:5-1-3:9-1-3', '<seq2>:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>:1-0-3:5-0-3:9-0-3'})
+            {'0', 'query1', '<seq1>/4:0-0-3:5-1-3:9-1-3', '<seq2>/14:1-10-13:1-6-13:9-2-5:5-2-9:0-1-13', '<seq3>/4:1-0-3:5-0-3:9-0-3'})
 
         # --num-top-labels is not used in the labels mode
         test_stdout('--num-top-labels 1', {'0', 'query1', 'seq2', 'seq3', 'seq1'}, mode='labels', extra_split_by=':')
@@ -1480,6 +1540,14 @@ class TestCoordToHeader(TestingBase):
                     for i, (header, _) in enumerate(sequences, 1):
                         output_without = output_without.replace(self.tempdir.name + f'/file_{i}.fa', header)
 
+                    if query_mode == 'coords':
+                        # The with-mapping path emits the per-sequence k-mer
+                        # count after the header (e.g., `<seq1>/14:0-0-3`).
+                        # Without mapping the label is per-file and has no
+                        # per-sequence length, so strip the `/N` suffix before
+                        # comparing.
+                        output_with = re.sub(r'(<[^>]+>)/\d+', r'\1', output_with)
+
                     if query_mode == 'labels':
                         output_with = output_with.split('\t')[-1].split(':')
                         output_without = output_without.split('\t')[-1].split(':')
@@ -1545,6 +1613,13 @@ class TestCoordToHeader(TestingBase):
                 # Replace the file labels with the corresponding headers
                 for i, (header, _) in enumerate(sequences, 1):
                     output_without = output_without.replace(self.tempdir.name + f'/file_{i}.fa', header)
+
+                if query_mode == 'coords':
+                    # The with-mapping path emits the per-sequence k-mer count
+                    # after the header (e.g., `<seq1>/14:0-0-3`). Strip it for
+                    # comparison since the without-mapping path has no
+                    # per-sequence length.
+                    output_with = re.sub(r'(<[^>]+>)/\d+', r'\1', output_with)
 
                 # Should have same results
                 self.assertEqual(output_with, output_without)

--- a/metagraph/integration_tests/test_query.py
+++ b/metagraph/integration_tests/test_query.py
@@ -1213,6 +1213,15 @@ class TestCoordToHeader(TestingBase):
 
         records = parse_records(res.stdout.decode())
         self.assertEqual(len(records), 2)
+        # Pin the multi-target case explicitly: query1 hits seq1 and seq3
+        # (shared ATCGATCG), query2 hits seq2 only. Mirrors the TSV
+        # expectation in test_query_coords.
+        by_name = {record['seq_description']: record for record in records}
+        self.assertEqual(set(by_name), {'query1', 'query2'})
+        self.assertEqual({r['sample'] for r in by_name['query1']['results']},
+                         {'seq1', 'seq3'})
+        self.assertEqual({r['sample'] for r in by_name['query2']['results']},
+                         {'seq2'})
         for record in records:
             for result in record['results']:
                 self.assertIn('kmers_in_target', result,

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -292,7 +292,8 @@ std::string format_alignment(const std::string &header,
         for (size_t i = 0; i < paths.size(); ++i) {
             const auto &path = paths[i];
 
-            Json::Value json_line = path.to_json(graph.get_k(), secondary, header);
+            Json::Value json_line = path.to_json(graph.get_k(), secondary, header,
+                                                 /*label=*/{}, encoder, cth);
             sout += fmt::format("{}\n", Json::writeString(builder, json_line));
             secondary = true;
         }

--- a/metagraph/src/cli/align.cpp
+++ b/metagraph/src/cli/align.cpp
@@ -293,7 +293,8 @@ std::string format_alignment(const std::string &header,
             const auto &path = paths[i];
 
             Json::Value json_line = path.to_json(graph.get_k(), secondary, header,
-                                                 /*label=*/{}, encoder, cth);
+                                                 /*label=*/{}, encoder, cth,
+                                                 config.align_output_path);
             sout += fmt::format("{}\n", Json::writeString(builder, json_line));
             secondary = true;
         }

--- a/metagraph/src/cli/annotate.cpp
+++ b/metagraph/src/cli/annotate.cpp
@@ -511,6 +511,24 @@ int annotate_graph(Config *config) {
         }
     }
 
+    // Coordinate-aware annotations need a CoordToHeader (.seqs) mapping so that
+    // `metagraph query --query-mode coords` can report per-sequence positions
+    // and the per-target k-mer count needed to compute the fraction of the
+    // target covered. This mapping must be built once against the FINAL merged
+    // annotation with the FULL set of input FASTAs (run it after any
+    // transform/merge step). It is a separate step because the column order
+    // may shift during transforms and a single annotate call may only see a
+    // subset of the inputs.
+    if (config->coordinates && config->filename_anno
+            && !config->annotate_sequence_headers && config->anno_labels.empty()) {
+        logger->info("To enable per-sequence coordinate reporting (`<seq>/N:...` "
+                     "and the JSON `kmers_in_target` field), build the CoordToHeader "
+                     "mapping once against the final merged annotation with all input "
+                     "FASTAs:\n"
+                     "    metagraph annotate --anno-filename --index-header-coords "
+                     "-i <graph> -o <final_anno_basename> <all_input_fastas>");
+    }
+
     return 0;
 }
 

--- a/metagraph/src/cli/annotate.cpp
+++ b/metagraph/src/cli/annotate.cpp
@@ -527,7 +527,7 @@ int annotate_graph(Config *config) {
                      "once against the final merged annotation with all input "
                      "FASTAs:\n"
                      "    metagraph annotate --anno-filename --index-header-coords "
-                     "-i {} -o {} <all_input_fastas>",
+                     "-i {} -o {} <input_fastas>",
                      !config->infbase.empty() ? config->infbase : "<graph>",
                      !config->outfbase.empty() ? config->outfbase
                                                : "<final_anno_basename>");

--- a/metagraph/src/cli/annotate.cpp
+++ b/metagraph/src/cli/annotate.cpp
@@ -519,7 +519,7 @@ int annotate_graph(Config *config) {
     // FASTAs (run it after any transform/merge step). It is a separate step
     // because the column order may shift during transforms and a single
     // annotate call may only see a subset of the inputs.
-    if (config->coordinates && config->filename_anno
+    if (config->coordinates && config->filename_anno && !config->index_header_coords
             && !config->annotate_sequence_headers && config->anno_labels.empty()) {
         logger->info("To enable per-sequence coordinate reporting "
                      "(`<seq>/N:...` in TSV; JSON `kmers_in_target` for query, "
@@ -527,7 +527,10 @@ int annotate_graph(Config *config) {
                      "once against the final merged annotation with all input "
                      "FASTAs:\n"
                      "    metagraph annotate --anno-filename --index-header-coords "
-                     "-i <graph> -o <final_anno_basename> <all_input_fastas>");
+                     "-i {} -o {} <all_input_fastas>",
+                     !config->infbase.empty() ? config->infbase : "<graph>",
+                     !config->outfbase.empty() ? config->outfbase
+                                               : "<final_anno_basename>");
     }
 
     return 0;

--- a/metagraph/src/cli/annotate.cpp
+++ b/metagraph/src/cli/annotate.cpp
@@ -512,18 +512,19 @@ int annotate_graph(Config *config) {
     }
 
     // Coordinate-aware annotations need a CoordToHeader (.seqs) mapping so that
-    // `metagraph query --query-mode coords` can report per-sequence positions
-    // and the per-target k-mer count needed to compute the fraction of the
-    // target covered. This mapping must be built once against the FINAL merged
-    // annotation with the FULL set of input FASTAs (run it after any
-    // transform/merge step). It is a separate step because the column order
-    // may shift during transforms and a single annotate call may only see a
-    // subset of the inputs.
+    // `metagraph query --query-mode coords` and `metagraph align` can report
+    // per-sequence positions and the per-target sequence length needed to
+    // compute the fraction of the target covered. This mapping must be built
+    // once against the FINAL merged annotation with the FULL set of input
+    // FASTAs (run it after any transform/merge step). It is a separate step
+    // because the column order may shift during transforms and a single
+    // annotate call may only see a subset of the inputs.
     if (config->coordinates && config->filename_anno
             && !config->annotate_sequence_headers && config->anno_labels.empty()) {
-        logger->info("To enable per-sequence coordinate reporting (`<seq>/N:...` "
-                     "and the JSON `kmers_in_target` field), build the CoordToHeader "
-                     "mapping once against the final merged annotation with all input "
+        logger->info("To enable per-sequence coordinate reporting "
+                     "(`<seq>/N:...` in TSV; JSON `kmers_in_target` for query, "
+                     "`nt_length` for align), build the CoordToHeader mapping "
+                     "once against the final merged annotation with all input "
                      "FASTAs:\n"
                      "    metagraph annotate --anno-filename --index-header-coords "
                      "-i <graph> -o <final_anno_basename> <all_input_fastas>");

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -248,6 +248,8 @@ Config::Config(int argc, char *argv[]) {
             align_sequences = true;
         } else if (!strcmp(argv[i], "--align-only-forwards")) {
             align_only_forwards = true;
+        } else if (!strcmp(argv[i], "--align-output-path")) {
+            align_output_path = true;
         } else if (!strcmp(argv[i], "--align-edit-distance")) {
             alignment_edit_distance = true;
         } else if (!strcmp(argv[i], "--align-chain")) {
@@ -1097,6 +1099,7 @@ if (advanced) {
             fprintf(stderr, "\t-a --annotator [STR] \t\t\t\tannotator to load for label/trace-consistent alignment []\n");
             fprintf(stderr, "\t-o --outfile-base [STR]\t\t\t\tbasename of output file []\n");
             fprintf(stderr, "\t   --json \t\t\t\t\toutput alignment in JSON format [off]\n");
+            fprintf(stderr, "\t   --align-output-path \t\t\t\twith --json, also emit the bulky VG-style path.mapping object [off]\n");
 if (advanced) {
             fprintf(stderr, "\t   --align-only-forwards \t\t\tdo not align backwards from a seed on basic-mode graphs [off]\n");
             fprintf(stderr, "\t   --align-no-seed-complexity-filter \t\t\t\tdisable the filter for low-complexity seeds. [off]\n");

--- a/metagraph/src/cli/config/config.cpp
+++ b/metagraph/src/cli/config/config.cpp
@@ -1099,10 +1099,10 @@ if (advanced) {
             fprintf(stderr, "\t-a --annotator [STR] \t\t\t\tannotator to load for label/trace-consistent alignment []\n");
             fprintf(stderr, "\t-o --outfile-base [STR]\t\t\t\tbasename of output file []\n");
             fprintf(stderr, "\t   --json \t\t\t\t\toutput alignment in JSON format [off]\n");
-            fprintf(stderr, "\t   --align-output-path \t\t\t\twith --json, also emit the bulky VG-style path.mapping object [off]\n");
 if (advanced) {
             fprintf(stderr, "\t   --align-only-forwards \t\t\tdo not align backwards from a seed on basic-mode graphs [off]\n");
             fprintf(stderr, "\t   --align-no-seed-complexity-filter \t\t\t\tdisable the filter for low-complexity seeds. [off]\n");
+            fprintf(stderr, "\t   --align-output-path \t\t\t\twith --json, also emit the VG-style path.mapping object [off]\n");
 }
             fprintf(stderr, "\t   --align-alternative-alignments \t\tthe number of alternative paths to report per seed [1]\n");
             fprintf(stderr, "\t   --align-chain \t\t\t\tconstruct seed chains before alignment. Useful for long error-prone reads. [off]\n");
@@ -1367,7 +1367,7 @@ if (advanced) {
             fprintf(stderr, "\t   --num-top-labels [INT] \t\tmaximum number of top labels to output [inf]\n");
             fprintf(stderr, "\t   --min-kmers-fraction-label [FLOAT] \tmin fraction of k-mers from the query required to be present in a label [0.7]\n");
             fprintf(stderr, "\t   --min-kmers-fraction-graph [FLOAT] \tmin fraction of k-mers from the query required to be present in the graph [0.0]\n");
-            fprintf(stderr, "\t   --no-coord-mapping \t\t\tquery without mapping coords to sequence headers even if the .seq index exists [off]\n");
+            fprintf(stderr, "\t   --no-coord-mapping \t\t\tquery without mapping coords to sequence headers even if the .seqs index exists [off]\n");
 if (advanced) {
             fprintf(stderr, "\t   --labels-delimiter [STR]\tdelimiter for annotation labels [\":\"]\n");
             fprintf(stderr, "\t   --suppress-unlabeled \tdo not show results for sequences missing in graph [off]\n");
@@ -1440,7 +1440,7 @@ if (advanced) {
             fprintf(stderr, "\t   --one-pass-brwt \tuse one-pass parallel BRWT traversal for queries [off]\n");
             // fprintf(stderr, "\t   --cache-size [INT] \tnumber of uncompressed rows to store in the cache [0]\n");
             fprintf(stderr, "\n\t   --num-top-labels [INT] \tmaximum number of top labels per query by default [10'000]\n");
-            fprintf(stderr, "\t   --no-coord-mapping \t\tquery without mapping coords to sequence headers even if the .seq index exists [off]\n");
+            fprintf(stderr, "\t   --no-coord-mapping \t\tquery without mapping coords to sequence headers even if the .seqs index exists [off]\n");
             fprintf(stderr, "\t   --mem-cap-gb [FLOAT] \tmemory in GB available for the server to load graphs for queries into RAM [0]\n");
         } break;
     }

--- a/metagraph/src/cli/config/config.hpp
+++ b/metagraph/src/cli/config/config.hpp
@@ -62,6 +62,10 @@ class Config {
     bool coordinates = false;
     bool index_header_coords = false;
     bool no_coord_mapping = false;
+    // Opt-in: include the bulky VG-style `path.mapping[]` object in
+    // `metagraph align --json` output. Off by default since nothing in-tree
+    // consumes it and it dominates the JSON size for long alignments.
+    bool align_output_path = false;
     bool advanced = false;
 
     unsigned int k = 3;

--- a/metagraph/src/cli/load/load_annotated_graph.cpp
+++ b/metagraph/src/cli/load/load_annotated_graph.cpp
@@ -54,10 +54,11 @@ load_coord_to_header(const annot::MultiLabelAnnotation<std::string> &annotation,
                                                             annotation.file_extension());
             logger->warn("No CoordToHeader mapping found at '{}'. Coords output will use "
                          "file-level positions (e.g., '<file_37.fa>:0-1086-1090') instead of "
-                         "per-sequence positions (e.g., '<seq_9>:0-1-5'), and the "
-                         "'kmers_in_target' field needed to compute the fraction of the "
-                         "target covered will be omitted. To enable per-sequence reporting, "
-                         "run once against the final annotation with all input FASTAs:\n"
+                         "per-sequence positions (e.g., '<seq_9>:0-1-5'), and the per-target "
+                         "sequence length needed to compute the fraction of the target covered "
+                         "('kmers_in_target' for query, 'nt_length' for align) will be omitted. "
+                         "To enable per-sequence reporting, run once against the final annotation "
+                         "with all input FASTAs:\n"
                          "    metagraph annotate --anno-filename --index-header-coords "
                          "-i {} -o {} <input_fastas>\n"
                          "Pass '--no-coord-mapping' to suppress this warning.",

--- a/metagraph/src/cli/load/load_annotated_graph.cpp
+++ b/metagraph/src/cli/load/load_annotated_graph.cpp
@@ -50,13 +50,18 @@ load_coord_to_header(const annot::MultiLabelAnnotation<std::string> &annotation,
                           "All queries will be performed against individual sequences.",
                           cth_fname);
         } else {
-            logger->warn("CoordToHeader mapping file not found at {}. Querying will be done "
-                         "against original labels indexed in annotation {}. Results will show "
-                         "file-based coordinates (e.g., '<file_37.fa>:0-1086-1090') instead of "
-                         "sequence-based coordinates (e.g., '<seq_9>:0-1-5'). For sequence-"
-                         "based queries, create a mapping with '--index-header-coords' during "
-                         "annotation, or pass '--no-coord-mapping' to suppress this warning.",
-                         cth_fname, config.infbase_annotators.at(0));
+            const auto anno_basename = utils::remove_suffix(config.infbase_annotators.at(0),
+                                                            annotation.file_extension());
+            logger->warn("No CoordToHeader mapping found at '{}'. Coords output will use "
+                         "file-level positions (e.g., '<file_37.fa>:0-1086-1090') instead of "
+                         "per-sequence positions (e.g., '<seq_9>:0-1-5'), and the "
+                         "'kmers_in_target' field needed to compute the fraction of the "
+                         "target covered will be omitted. To enable per-sequence reporting, "
+                         "run once against the final annotation with all input FASTAs:\n"
+                         "    metagraph annotate --anno-filename --index-header-coords "
+                         "-i {} -o {} <input_fastas>\n"
+                         "Pass '--no-coord-mapping' to suppress this warning.",
+                         cth_fname, config.infbase, anno_basename);
         }
     }
 

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -163,7 +163,7 @@ Json::Value get_label_as_json(const std::string &label) {
     std::vector<std::string> label_parts = utils::split_string(label, ";");
 
     // First field is always the sample
-    label_root["sample"] = label_parts[0];
+    label_root[SeqSearchResult::LABEL_SAMPLE_FIELD] = label_parts[0];
 
     // Fill properties if existant
     Json::Value properties = Json::objectValue;

--- a/metagraph/src/cli/query.cpp
+++ b/metagraph/src/cli/query.cpp
@@ -268,9 +268,14 @@ Json::Value SeqSearchResult::to_json(bool verbose_output, size_t k) const {
         }
     } else {
         // Kmer coordinates
-        for (const auto &[label, count, tuples] : std::get<LabelCountCoordsVec>(result_)) {
+        for (const auto &[label, count, tuples, num_kmers_in_target]
+                : std::get<LabelCountCoordsVec>(result_)) {
             Json::Value &label_obj = root["results"].append(get_label_as_json(label));
             label_obj[KMER_COUNT_FIELD] = static_cast<Json::Int64>(count);
+            if (num_kmers_in_target) {
+                label_obj[KMERS_IN_TARGET_FIELD]
+                    = static_cast<Json::Int64>(num_kmers_in_target);
+            }
             if (verbose_output) {
                 std::vector<std::string> segments;
                 segments.reserve(tuples.size());
@@ -362,8 +367,12 @@ std::string SeqSearchResult::to_string(const std::string delimiter,
         }
     } else {
         // Kmer coordinates
-        for (const auto &[label, count, tuples] : std::get<LabelCountCoordsVec>(result_)) {
+        for (const auto &[label, count, tuples, num_kmers_in_target]
+                : std::get<LabelCountCoordsVec>(result_)) {
             output += "\t<" + label + ">";
+            if (num_kmers_in_target) {
+                output += fmt::format("/{}", num_kmers_in_target);
+            }
 
             if (verbose_output) {
                 for (const auto &coords : tuples) {

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -80,7 +80,10 @@ class SeqSearchResult {
     typedef std::vector<std::pair<Label, size_t>> LabelCountVec;
     typedef std::vector<std::tuple<Label, size_t, sdsl::bit_vector>> LabelSigVec;
     typedef std::vector<std::tuple<Label, size_t, std::vector<size_t>>> LabelCountAbundancesVec;
-    typedef std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>> LabelCountCoordsVec;
+    // (label, num_kmer_matches, kmer_coordinates, num_kmers_in_target). The last
+    // element is 0 when no CoordToHeader mapping is loaded (the label refers to
+    // a whole annotation column rather than a single indexed sequence).
+    typedef std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>, size_t>> LabelCountCoordsVec;
 
     typedef std::variant<LabelVec,
                          LabelCountVec,
@@ -92,6 +95,7 @@ class SeqSearchResult {
     static constexpr auto SEQ_DESCRIPTION_JSON_FIELD = "seq_description";
     static constexpr auto KMER_COUNT_FIELD = "kmer_count";
     static constexpr auto KMER_COORDINATE_FIELD = "kmer_coords";
+    static constexpr auto KMERS_IN_TARGET_FIELD = "kmers_in_target";
     static constexpr auto SIGNATURE_FIELD = "signature";
     static constexpr auto KMER_ABUNDANCE_FIELD = "kmer_abundances";
     static constexpr auto SCORE_JSON_FIELD = "score";

--- a/metagraph/src/cli/query.hpp
+++ b/metagraph/src/cli/query.hpp
@@ -93,6 +93,7 @@ class SeqSearchResult {
 
     // JSON Field Keys
     static constexpr auto SEQ_DESCRIPTION_JSON_FIELD = "seq_description";
+    static constexpr auto LABEL_SAMPLE_FIELD = "sample";
     static constexpr auto KMER_COUNT_FIELD = "kmer_count";
     static constexpr auto KMER_COORDINATE_FIELD = "kmer_coords";
     static constexpr auto KMERS_IN_TARGET_FIELD = "kmers_in_target";

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -39,8 +39,11 @@ std::string Alignment::format_coords(const annot::LabelEncoder<> &encoder) const
 namespace {
 
 // JSON field names emitted inside each `annotation.labels[]` entry by
-// `to_json`. `LABEL_SAMPLE_FIELD` mirrors the inline `"sample"` literal in
-// `cli/query.cpp:get_label_as_json`; the two must stay in lockstep.
+// `to_json`. `LABEL_SAMPLE_FIELD` is intentionally duplicated from
+// `cli/query::SeqSearchResult::LABEL_SAMPLE_FIELD` rather than imported,
+// to keep graph-layer code free of a cli-layer dependency; the value
+// must stay in lockstep (covered by integration tests that assert
+// `sample` from both producers).
 constexpr auto LABEL_SAMPLE_FIELD = "sample";
 constexpr auto NT_LENGTH_FIELD = "nt_length";
 constexpr auto NT_COORDS_FIELD = "nt_coords";

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -36,25 +36,28 @@ std::string Alignment::format_coords(const annot::LabelEncoder<> &encoder) const
     return fmt::format("{}", fmt::join(decoded_labels, ";"));
 }
 
-std::string Alignment::format_coords(const annot::CoordToHeader &cth, size_t k) const {
-    if (!label_coordinates.size())
-        return "";
+namespace {
 
-    assert(label_columns.size());
-    assert(label_coordinates.size() == label_columns.size());
-    assert(k > 0 && "k must be >0 when CoordToHeader is in use");
+// (column, seq_id, list of [start, end_inclusive] 0-based local ranges).
+using PerTargetRanges = VectorMap<std::pair<Alignment::Column, size_t>,
+                                  std::vector<std::pair<uint64_t, uint64_t>>>;
 
-    using Key = std::pair<Column, size_t>;  // (column, seq_id)
-    // Per-key list of local (start, end_inclusive) ranges, 0-based.
-    VectorMap<Key, std::vector<std::pair<uint64_t, uint64_t>>> seq_ranges;
-
-    const uint64_t L = sequence_.size();
+// Split a flat set of (column, global-coord) entries into per-(column, seq_id)
+// local-coordinate ranges using `cth`. Used by both `format_coords` (TSV) and
+// `to_json` (JSON) so they stay in lockstep.
+PerTargetRanges
+split_coords_by_target(const Alignment::Columns &label_columns,
+                       const Alignment::CoordinateSet &label_coordinates,
+                       const annot::CoordToHeader &cth,
+                       uint64_t alignment_nt_length,
+                       size_t k) {
+    PerTargetRanges seq_ranges;
     for (size_t i = 0; i < label_columns.size(); ++i) {
-        Column col = label_columns[i];
+        auto col = label_columns[i];
         const size_t n_seqs = cth.num_sequences(col);
         for (uint64_t coord : label_coordinates[i]) {
             auto [seq_id, local_coord] = cth.map_single_coord(col, coord);
-            uint64_t remaining = L;
+            uint64_t remaining = alignment_nt_length;
             uint64_t cur_local = local_coord;
             size_t cur_seq_id = seq_id;
             while (remaining) {
@@ -76,12 +79,33 @@ std::string Alignment::format_coords(const annot::CoordToHeader &cth, size_t k) 
             }
         }
     }
+    return seq_ranges;
+}
+
+} // namespace
+
+std::string Alignment::format_coords(const annot::CoordToHeader &cth, size_t k) const {
+    if (!label_coordinates.size())
+        return "";
+
+    assert(label_columns.size());
+    assert(label_coordinates.size() == label_columns.size());
+    assert(k > 0 && "k must be >0 when CoordToHeader is in use");
+
+    auto seq_ranges = split_coords_by_target(label_columns, label_coordinates,
+                                             cth, sequence_.size(), k);
 
     std::vector<std::string> decoded_labels;
     decoded_labels.reserve(seq_ranges.size());
     for (const auto &[key, ranges] : seq_ranges) {
         const auto &[col, seq_id] = key;
-        decoded_labels.emplace_back(cth.get_headers(col)[seq_id]);
+        // `<header>/<nt_length>` exposes the target's nucleotide length so
+        // callers can compute the fraction of the target covered directly
+        // from the nt coord range (1-based inclusive) that follows.
+        uint64_t nt_length = cth.num_kmers_in_sequence(col, seq_id) + k - 1;
+        decoded_labels.emplace_back(fmt::format("{}/{}",
+                                                cth.get_headers(col)[seq_id],
+                                                nt_length));
         for (auto [start, end] : ranges) {
             // 1-based inclusive ranges
             decoded_labels.back() += fmt::format(":{}-{}", start + 1, end + 1);
@@ -883,7 +907,9 @@ Json::Value path_json(const std::vector<DeBruijnGraph::node_index> &nodes,
 Json::Value Alignment::to_json(size_t node_size,
                                bool is_secondary,
                                const std::string &read_name,
-                               const std::string &label) const {
+                               const std::string &label,
+                               const annot::LabelEncoder<> *encoder,
+                               const annot::CoordToHeader *cth) const {
     if (sequence_.find("$") != std::string::npos
             || std::find(nodes_.begin(), nodes_.end(), DeBruijnGraph::npos) != nodes_.end()) {
         throw std::runtime_error("JSON output for chains not supported");
@@ -911,6 +937,58 @@ Json::Value Alignment::to_json(size_t node_size,
             == full_query.size());
 
     alignment["annotation"]["cigar"] = cigar_.to_string();
+
+    // Emit label/coord info when an encoder is available. With CTH, labels
+    // are per-target-sequence (`<header>/N` + nt ranges); without CTH, labels
+    // are per-annotation-column (decoded label + global column nt ranges).
+    // The `nt_coords` field is named to distinguish from query.cpp's
+    // `kmer_coords`, which encodes k-mer-indexed positions instead.
+    if (encoder && label_columns.size()) {
+        Json::Value labels = Json::arrayValue;
+        if (!label_coordinates.size()) {
+            // Labels-only path: just the decoded label, no coords.
+            for (auto col : label_columns) {
+                Json::Value entry;
+                entry["sample"] = encoder->decode(col);
+                labels.append(entry);
+            }
+        } else if (cth) {
+            auto seq_ranges = split_coords_by_target(label_columns, label_coordinates,
+                                                     *cth, sequence_.size(), node_size);
+            for (const auto &[key, ranges] : seq_ranges) {
+                const auto &[col, seq_id] = key;
+                Json::Value entry;
+                entry["sample"] = cth->get_headers(col)[seq_id];
+                entry["nt_length"] = static_cast<Json::Int64>(
+                        cth->num_kmers_in_sequence(col, seq_id) + node_size - 1);
+                std::vector<std::string> range_strs;
+                range_strs.reserve(ranges.size());
+                for (auto [start, end] : ranges) {
+                    range_strs.push_back(fmt::format("{}-{}", start + 1, end + 1));
+                }
+                entry["nt_coords"] = fmt::format("{}", fmt::join(range_strs, ":"));
+                labels.append(entry);
+            }
+        } else {
+            // No CTH: emit per-column global coord ranges (each coord spans
+            // the alignment's nucleotide length on the column).
+            assert(label_coordinates.size() == label_columns.size());
+            for (size_t i = 0; i < label_columns.size(); ++i) {
+                Json::Value entry;
+                entry["sample"] = encoder->decode(label_columns[i]);
+                std::vector<std::string> range_strs;
+                range_strs.reserve(label_coordinates[i].size());
+                for (uint64_t coord : label_coordinates[i]) {
+                    range_strs.push_back(fmt::format("{}-{}",
+                                                     coord + 1,
+                                                     coord + sequence_.size()));
+                }
+                entry["nt_coords"] = fmt::format("{}", fmt::join(range_strs, ":"));
+                labels.append(entry);
+            }
+        }
+        alignment["annotation"]["labels"] = std::move(labels);
+    }
 
     // encode path
     if (nodes_.size())

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -38,6 +38,13 @@ std::string Alignment::format_coords(const annot::LabelEncoder<> &encoder) const
 
 namespace {
 
+// JSON field names emitted inside each `annotation.labels[]` entry by
+// `to_json`. `LABEL_SAMPLE_FIELD` mirrors the inline `"sample"` literal in
+// `cli/query.cpp:get_label_as_json`; the two must stay in lockstep.
+constexpr auto LABEL_SAMPLE_FIELD = "sample";
+constexpr auto NT_LENGTH_FIELD = "nt_length";
+constexpr auto NT_COORDS_FIELD = "nt_coords";
+
 // (column, seq_id, list of [start, end_inclusive] 0-based local ranges).
 using PerTargetRanges = VectorMap<std::pair<Alignment::Column, size_t>,
                                   std::vector<std::pair<uint64_t, uint64_t>>>;
@@ -51,6 +58,8 @@ split_coords_by_target(const Alignment::Columns &label_columns,
                        const annot::CoordToHeader &cth,
                        uint64_t alignment_nt_length,
                        size_t k) {
+    assert(label_coordinates.size() == label_columns.size());
+    assert(k > 0 && "k must be >0 when CoordToHeader is in use");
     PerTargetRanges seq_ranges;
     for (size_t i = 0; i < label_columns.size(); ++i) {
         auto col = label_columns[i];
@@ -87,10 +96,6 @@ split_coords_by_target(const Alignment::Columns &label_columns,
 std::string Alignment::format_coords(const annot::CoordToHeader &cth, size_t k) const {
     if (!label_coordinates.size())
         return "";
-
-    assert(label_columns.size());
-    assert(label_coordinates.size() == label_columns.size());
-    assert(k > 0 && "k must be >0 when CoordToHeader is in use");
 
     auto seq_ranges = split_coords_by_target(label_columns, label_coordinates,
                                              cth, sequence_.size(), k);
@@ -938,48 +943,40 @@ Json::Value Alignment::to_json(size_t node_size,
 
     alignment["annotation"]["cigar"] = cigar_.to_string();
 
-    // Emit label/coord info when an encoder is available. Three sub-cases:
-    //   * `label_coordinates` empty: labels-only, no positions.
-    //   * `cth` present: per-target-sequence labels (`<header>/N` + nt ranges).
-    //   * `cth` absent: per-annotation-column labels (decoded label + global
-    //     column nt ranges, where each coord spans the alignment length).
-    // The `nt_coords` / `nt_length` field names use nucleotide units to
-    // distinguish from query.cpp's `kmer_coords` / `kmers_in_target`, which
-    // are k-mer-indexed.
+    // `nt_coords` / `nt_length` use nucleotide units, to distinguish from
+    // query.cpp's `kmer_coords` / `kmers_in_target` (which are k-mer-indexed).
     if (encoder && label_columns.size()) {
         Json::Value labels = Json::arrayValue;
         if (!label_coordinates.size()) {
-            // Labels-only path: just the decoded label, no coords.
             for (auto col : label_columns) {
                 Json::Value entry;
-                entry["sample"] = encoder->decode(col);
+                entry[LABEL_SAMPLE_FIELD] = encoder->decode(col);
                 labels.append(entry);
             }
         } else if (cth) {
-            assert(label_coordinates.size() == label_columns.size());
             auto seq_ranges = split_coords_by_target(label_columns, label_coordinates,
                                                      *cth, sequence_.size(), node_size);
             for (const auto &[key, ranges] : seq_ranges) {
                 const auto &[col, seq_id] = key;
                 Json::Value entry;
-                entry["sample"] = cth->get_headers(col)[seq_id];
-                entry["nt_length"] = static_cast<Json::Int64>(
+                entry[LABEL_SAMPLE_FIELD] = cth->get_headers(col)[seq_id];
+                entry[NT_LENGTH_FIELD] = static_cast<Json::Int64>(
                         cth->num_kmers_in_sequence(col, seq_id) + node_size - 1);
                 std::vector<std::string> range_strs;
                 range_strs.reserve(ranges.size());
                 for (auto [start, end] : ranges) {
                     range_strs.push_back(fmt::format("{}-{}", start + 1, end + 1));
                 }
-                entry["nt_coords"] = fmt::format("{}", fmt::join(range_strs, ":"));
+                entry[NT_COORDS_FIELD] = fmt::format("{}", fmt::join(range_strs, ":"));
                 labels.append(entry);
             }
         } else {
-            // No CTH: emit per-column global coord ranges (each coord spans
-            // the alignment's nucleotide length on the column).
+            // No CTH: each coord spans the alignment's nucleotide length on
+            // the column.
             assert(label_coordinates.size() == label_columns.size());
             for (size_t i = 0; i < label_columns.size(); ++i) {
                 Json::Value entry;
-                entry["sample"] = encoder->decode(label_columns[i]);
+                entry[LABEL_SAMPLE_FIELD] = encoder->decode(label_columns[i]);
                 std::vector<std::string> range_strs;
                 range_strs.reserve(label_coordinates[i].size());
                 for (uint64_t coord : label_coordinates[i]) {
@@ -987,7 +984,7 @@ Json::Value Alignment::to_json(size_t node_size,
                                                      coord + 1,
                                                      coord + sequence_.size()));
                 }
-                entry["nt_coords"] = fmt::format("{}", fmt::join(range_strs, ":"));
+                entry[NT_COORDS_FIELD] = fmt::format("{}", fmt::join(range_strs, ":"));
                 labels.append(entry);
             }
         }

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -909,7 +909,8 @@ Json::Value Alignment::to_json(size_t node_size,
                                const std::string &read_name,
                                const std::string &label,
                                const annot::LabelEncoder<> *encoder,
-                               const annot::CoordToHeader *cth) const {
+                               const annot::CoordToHeader *cth,
+                               bool include_path_mapping) const {
     if (sequence_.find("$") != std::string::npos
             || std::find(nodes_.begin(), nodes_.end(), DeBruijnGraph::npos) != nodes_.end()) {
         throw std::runtime_error("JSON output for chains not supported");
@@ -990,8 +991,11 @@ Json::Value Alignment::to_json(size_t node_size,
         alignment["annotation"]["labels"] = std::move(labels);
     }
 
-    // encode path
-    if (nodes_.size())
+    // Encode path (VG-style protobuf-as-JSON). Off by default — the
+    // `path.mapping[]` list is bulky and currently has no in-tree consumer;
+    // top-level `cigar` already encodes the edit script. Callers needing
+    // VG interop opt in via `include_path_mapping`.
+    if (include_path_mapping && nodes_.size())
         alignment["path"] = path_json(nodes_, cigar_, node_size, query_view_, offset_, label);
 
     alignment["score"] = static_cast<int32_t>(score_);

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -95,19 +95,18 @@ std::string Alignment::format_coords(const annot::CoordToHeader &cth, size_t k) 
     auto seq_ranges = split_coords_by_target(label_columns, label_coordinates,
                                              cth, sequence_.size(), k);
 
+    // Emit `<header>/<nt_length>:<start>-<end>...` per target so callers can
+    // compute the fraction of the target covered from the nt range that
+    // follows (1-based inclusive).
     std::vector<std::string> decoded_labels;
     decoded_labels.reserve(seq_ranges.size());
     for (const auto &[key, ranges] : seq_ranges) {
         const auto &[col, seq_id] = key;
-        // `<header>/<nt_length>` exposes the target's nucleotide length so
-        // callers can compute the fraction of the target covered directly
-        // from the nt coord range (1-based inclusive) that follows.
         uint64_t nt_length = cth.num_kmers_in_sequence(col, seq_id) + k - 1;
         decoded_labels.emplace_back(fmt::format("{}/{}",
                                                 cth.get_headers(col)[seq_id],
                                                 nt_length));
         for (auto [start, end] : ranges) {
-            // 1-based inclusive ranges
             decoded_labels.back() += fmt::format(":{}-{}", start + 1, end + 1);
         }
     }

--- a/metagraph/src/graph/alignment/alignment.cpp
+++ b/metagraph/src/graph/alignment/alignment.cpp
@@ -939,11 +939,14 @@ Json::Value Alignment::to_json(size_t node_size,
 
     alignment["annotation"]["cigar"] = cigar_.to_string();
 
-    // Emit label/coord info when an encoder is available. With CTH, labels
-    // are per-target-sequence (`<header>/N` + nt ranges); without CTH, labels
-    // are per-annotation-column (decoded label + global column nt ranges).
-    // The `nt_coords` field is named to distinguish from query.cpp's
-    // `kmer_coords`, which encodes k-mer-indexed positions instead.
+    // Emit label/coord info when an encoder is available. Three sub-cases:
+    //   * `label_coordinates` empty: labels-only, no positions.
+    //   * `cth` present: per-target-sequence labels (`<header>/N` + nt ranges).
+    //   * `cth` absent: per-annotation-column labels (decoded label + global
+    //     column nt ranges, where each coord spans the alignment length).
+    // The `nt_coords` / `nt_length` field names use nucleotide units to
+    // distinguish from query.cpp's `kmer_coords` / `kmers_in_target`, which
+    // are k-mer-indexed.
     if (encoder && label_columns.size()) {
         Json::Value labels = Json::arrayValue;
         if (!label_coordinates.size()) {
@@ -954,6 +957,7 @@ Json::Value Alignment::to_json(size_t node_size,
                 labels.append(entry);
             }
         } else if (cth) {
+            assert(label_coordinates.size() == label_columns.size());
             auto seq_ranges = split_coords_by_target(label_columns, label_coordinates,
                                                      *cth, sequence_.size(), node_size);
             for (const auto &[key, ranges] : seq_ranges) {
@@ -1044,6 +1048,11 @@ Json::Value Alignment::to_json(size_t node_size,
     return alignment;
 }
 
+// Reconstructs an Alignment from a JSON object produced by `to_json`. Reads
+// `path.mapping[]` to recover nodes and edits, so the encoder must have been
+// called with `include_path_mapping=true`. The `annotation.labels[]` block
+// is *not* read back here — it's derivable from the reconstructed alignment
+// plus the loaded annotator.
 void Alignment::load_from_json(const Json::Value &alignment,
                                const DeBruijnGraph &graph,
                                std::string *query_sequence) {

--- a/metagraph/src/graph/alignment/alignment.hpp
+++ b/metagraph/src/graph/alignment/alignment.hpp
@@ -271,10 +271,15 @@ class Alignment {
     bool operator!=(const Alignment &other) const { return !(*this == other); }
 
     // `encoder` and `cth` are optional. When `encoder` is supplied, the
-    // returned object includes an `annotation.labels` array. With `cth` the
-    // labels are per-target-sequence (using `.seqs` to map global column
-    // coordinates to per-sequence positions); without it, the labels are
-    // per-annotation-column.
+    // returned object includes an `annotation.labels` array; the shape of
+    // each entry depends on what coord information is available:
+    //   - no `label_coordinates` (label-only annotator): `{sample}` only.
+    //   - `label_coordinates` + `cth` set: `{sample, nt_length, nt_coords}`
+    //     per target sequence (`.seqs` maps global column coords to
+    //     per-sequence local positions).
+    //   - `label_coordinates` set, `cth` null: `{sample, nt_coords}`
+    //     per annotation column; `nt_length` is omitted because the column
+    //     does not correspond to a single indexed sequence.
     //
     // `include_path_mapping` controls whether the bulky VG-style
     // `path.mapping[]` object is emitted. Off by default: the path lists

--- a/metagraph/src/graph/alignment/alignment.hpp
+++ b/metagraph/src/graph/alignment/alignment.hpp
@@ -270,10 +270,17 @@ class Alignment {
 
     bool operator!=(const Alignment &other) const { return !(*this == other); }
 
+    // `encoder` and `cth` are optional. When `encoder` is supplied, the
+    // returned object includes an `annotation.labels` array. With `cth` the
+    // labels are per-target-sequence (using `.seqs` to map global column
+    // coordinates to per-sequence positions); without it, the labels are
+    // per-annotation-column.
     Json::Value to_json(size_t node_size,
                         bool is_secondary = false,
                         const std::string &name = {},
-                        const std::string &label = {}) const;
+                        const std::string &label = {},
+                        const annot::LabelEncoder<> *encoder = nullptr,
+                        const annot::CoordToHeader *cth = nullptr) const;
 
     // writes to |query_str| the string which will be referenced in this object
     void load_from_json(const Json::Value &alignment,

--- a/metagraph/src/graph/alignment/alignment.hpp
+++ b/metagraph/src/graph/alignment/alignment.hpp
@@ -275,12 +275,19 @@ class Alignment {
     // labels are per-target-sequence (using `.seqs` to map global column
     // coordinates to per-sequence positions); without it, the labels are
     // per-annotation-column.
+    //
+    // `include_path_mapping` controls whether the bulky VG-style
+    // `path.mapping[]` object is emitted. Off by default: the path lists
+    // every visited node with redundant `edit` blocks (already in `cigar`)
+    // and dominates the JSON size for long alignments; no in-tree consumer
+    // currently reads it.
     Json::Value to_json(size_t node_size,
                         bool is_secondary = false,
                         const std::string &name = {},
                         const std::string &label = {},
                         const annot::LabelEncoder<> *encoder = nullptr,
-                        const annot::CoordToHeader *cth = nullptr) const;
+                        const annot::CoordToHeader *cth = nullptr,
+                        bool include_path_mapping = false) const;
 
     // writes to |query_str| the string which will be referenced in this object
     void load_from_json(const Json::Value &alignment,

--- a/metagraph/src/graph/annotated_dbg.cpp
+++ b/metagraph/src/graph/annotated_dbg.cpp
@@ -256,7 +256,7 @@ std::vector<Label> AnnotatedDBG::get_labels(std::string_view sequence,
                                                    discovery_fraction, presence_fraction);
         std::vector<Label> result;
         result.reserve(kmer_coord_res.size());
-        for (auto &[label, count, coords] : kmer_coord_res) {
+        for (auto &[label, count, coords, num_kmers_in_target] : kmer_coord_res) {
             result.emplace_back(std::move(label));
         }
         return result;
@@ -359,7 +359,7 @@ AnnotatedDBG::get_top_labels(std::string_view sequence,
                                                    discovery_fraction, presence_fraction);
         std::vector<StringCountPair> result;
         result.reserve(kmer_coord_res.size());
-        for (auto &[label, count, coords] : kmer_coord_res) {
+        for (auto &[label, count, coords, num_kmers_in_target] : kmer_coord_res) {
             if (with_kmer_counts) {
                 count = 0;
                 for (const auto &tuple : coords) {
@@ -530,7 +530,7 @@ AnnotatedDBG::get_kmer_counts(std::string_view sequence,
                                                    discovery_fraction, presence_fraction);
         std::vector<std::tuple<std::string, size_t, std::vector<size_t>>> result;
         result.reserve(kmer_coord_res.size());
-        for (auto &[label, count, coords] : kmer_coord_res) {
+        for (auto &[label, count, coords, num_kmers_in_target] : kmer_coord_res) {
             result.emplace_back(std::move(label), count, coords.size());
             auto &counts = std::get<2>(result.back());
             for (size_t i = 0; i < coords.size(); ++i) {
@@ -583,7 +583,7 @@ AnnotatedDBG::get_kmer_counts(std::string_view sequence,
     return get_results(enumerate_row_values);
 }
 
-std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
+std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>, size_t>>
 AnnotatedDBG::get_kmer_coordinates(std::string_view sequence,
                                    size_t num_top_labels,
                                    double discovery_fraction,
@@ -679,13 +679,14 @@ AnnotatedDBG::get_kmer_coordinates(std::string_view sequence,
         }
         rows_tuples.clear();
 
-        std::vector<std::tuple<std::string, Count, std::vector<Tuple>>> result;
+        std::vector<std::tuple<std::string, Count, std::vector<Tuple>, size_t>> result;
         result.reserve(counts.size());
         for (const auto &[h, count] : counts) {
             const auto &[col, header] = h;
             auto &coords = coords_map[h];
             result.emplace_back(coord_to_header_->get_headers(col)[header],
-                                count, std::move(coords));
+                                count, std::move(coords),
+                                coord_to_header_->num_kmers_in_sequence(col, header));
         }
 
         return result;
@@ -698,7 +699,16 @@ AnnotatedDBG::get_kmer_coordinates(std::string_view sequence,
     auto results = filter_and_aggregate<std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>>(
         call_rows_tuples, annotator_->get_label_encoder(), min_count, num_top_labels, kmer_positions, num_kmers);
     assert(same_results(results, get_top_labels(sequence, num_top_labels, discovery_fraction, presence_fraction)));
-    return results;
+
+    // Without a CoordToHeader mapping, the label refers to a whole annotation
+    // column rather than a single indexed sequence, so num_kmers_in_target is
+    // undefined.
+    std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>, size_t>> with_lengths;
+    with_lengths.reserve(results.size());
+    for (auto &[label, count, coords] : results) {
+        with_lengths.emplace_back(std::move(label), count, std::move(coords), 0);
+    }
+    return with_lengths;
 }
 
 std::vector<std::tuple<Label, size_t, sdsl::bit_vector>>
@@ -736,7 +746,7 @@ AnnotatedDBG::get_top_label_signatures(std::string_view sequence,
                                                    discovery_fraction, presence_fraction);
         std::vector<std::tuple<Label, size_t, sdsl::bit_vector>> result;
         result.reserve(kmer_coord_res.size());
-        for (auto &[label, count, coords] : kmer_coord_res) {
+        for (auto &[label, count, coords, num_kmers_in_target] : kmer_coord_res) {
             assert(coords.size() == sequence.size() - dbg_.get_k() + 1);
             result.emplace_back(std::move(label), count, coords.size());
             auto &mask = std::get<2>(result.back());

--- a/metagraph/src/graph/annotated_dbg.hpp
+++ b/metagraph/src/graph/annotated_dbg.hpp
@@ -123,8 +123,11 @@ class AnnotatedDBG : public AnnotatedSequenceGraph {
                     double discovery_fraction,
                     double presence_fraction) const;
 
-    // returns tuples (label, num_kmer_matches, kmer_coordinates)
-    std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>>>
+    // returns tuples (label, num_kmer_matches, kmer_coordinates, num_kmers_in_target).
+    // num_kmers_in_target is 0 when no CoordToHeader mapping is loaded (the
+    // label refers to a whole annotation column rather than a single indexed
+    // sequence).
+    std::vector<std::tuple<Label, size_t, std::vector<SmallVector<uint64_t>>, size_t>>
     get_kmer_coordinates(std::string_view sequence,
                          size_t num_top_labels,
                          double discovery_fraction,

--- a/metagraph/tests/annotation/test_aligner_labeled.cpp
+++ b/metagraph/tests/annotation/test_aligner_labeled.cpp
@@ -334,7 +334,7 @@ TEST_F(LabeledAlignerCoordTest, CrossBoundary) {
     EXPECT_EQ(4u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:5-12;seq2:1-8", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:5-12;seq2/12:1-8", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerCoordTest, CrossBoundaryThreeSequences) {
@@ -356,7 +356,7 @@ TEST_F(LabeledAlignerCoordTest, CrossBoundaryThreeSequences) {
     EXPECT_EQ(4u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2", "seq3" } }, { { 8, 8, 8 } });
-    EXPECT_EQ("seq1:5-12;seq2:1-12;seq3:1-4", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:5-12;seq2/12:1-12;seq3/12:1-4", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerCoordTest, CrossBoundaryThreeSequencesWithIndels) {
@@ -382,7 +382,7 @@ TEST_F(LabeledAlignerCoordTest, CrossBoundaryThreeSequencesWithIndels) {
     EXPECT_EQ(4u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2", "seq3" } }, { { 8, 8, 8 } });
-    EXPECT_EQ("seq1:5-12;seq2:1-12;seq3:1-4", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:5-12;seq2/12:1-12;seq3/12:1-4", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerCoordTest, ThreeSequencesPartialCoverage) {
@@ -407,7 +407,7 @@ TEST_F(LabeledAlignerCoordTest, ThreeSequencesPartialCoverage) {
     EXPECT_EQ(18u, aln.label_coordinates[0][2]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2", "seq3" } }, { { 8, 8, 8 } });
-    EXPECT_EQ("seq1:3-9;seq2:3-9;seq3:3-9", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:3-9;seq2/12:3-9;seq3/12:3-9", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerCoordTest, CrossBoundaryReverseComplement) {
@@ -426,7 +426,7 @@ TEST_F(LabeledAlignerCoordTest, CrossBoundaryReverseComplement) {
     EXPECT_EQ(4u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:5-12;seq2:1-8", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:5-12;seq2/12:1-8", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerCoordTest, CrossBoundaryWithIndel) {
@@ -447,7 +447,7 @@ TEST_F(LabeledAlignerCoordTest, CrossBoundaryWithIndel) {
     EXPECT_EQ(0u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:1-12;seq2:1-8", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:1-12;seq2/12:1-8", alignments[0].format_coords(cth, k));
 }
 #endif  // ! _PROTEIN_GRAPH
 
@@ -495,7 +495,7 @@ TEST_F(LabeledAlignerProteinCoordTest, CrossBoundary) {
     EXPECT_EQ(4u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:5-12;seq2:1-4", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:5-12;seq2/12:1-4", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerProteinCoordTest, SharedKmerMultipleLabels) {
@@ -513,7 +513,7 @@ TEST_F(LabeledAlignerProteinCoordTest, SharedKmerMultipleLabels) {
     ASSERT_EQ(2u, aln.label_coordinates[0].size());
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:4-8;seq2:4-8", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:4-8;seq2/12:4-8", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerProteinCoordTest, CrossBoundaryWithMismatch) {
@@ -534,7 +534,7 @@ TEST_F(LabeledAlignerProteinCoordTest, CrossBoundaryWithMismatch) {
     EXPECT_EQ(4u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:5-12;seq2:1-4", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:5-12;seq2/12:1-4", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerProteinCoordTest, SoftClipPrefix) {
@@ -553,7 +553,7 @@ TEST_F(LabeledAlignerProteinCoordTest, SoftClipPrefix) {
     EXPECT_EQ(4u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:5-12;seq2:1-4", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:5-12;seq2/12:1-4", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerProteinCoordTest, CrossBoundaryWithInsertion) {
@@ -575,7 +575,7 @@ TEST_F(LabeledAlignerProteinCoordTest, CrossBoundaryWithInsertion) {
     EXPECT_EQ(0u, aln.label_coordinates[0][0]);
 
     annot::CoordToHeader cth({ { "seq1", "seq2" } }, { { 8, 8 } });
-    EXPECT_EQ("seq1:1-12;seq2:1-8", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:1-12;seq2/12:1-8", alignments[0].format_coords(cth, k));
 }
 
 TEST_F(LabeledAlignerProteinCoordTest, ThreeSequencesPartialCoverage) {
@@ -597,7 +597,7 @@ TEST_F(LabeledAlignerProteinCoordTest, ThreeSequencesPartialCoverage) {
     ASSERT_EQ(3u, aln.label_coordinates[0].size());
 
     annot::CoordToHeader cth({ { "seq1", "seq2", "seq3" } }, { { 8, 8, 8 } });
-    EXPECT_EQ("seq1:3-7;seq2:3-7;seq3:3-7", alignments[0].format_coords(cth, k));
+    EXPECT_EQ("seq1/12:3-7;seq2/12:3-7;seq3/12:3-7", alignments[0].format_coords(cth, k));
 }
 #endif  // _PROTEIN_GRAPH
 

--- a/metagraph/tests/annotation/test_coord_to_header.cpp
+++ b/metagraph/tests/annotation/test_coord_to_header.cpp
@@ -243,7 +243,7 @@ TEST(AlignmentFormatCoords, WithCoordToHeader) {
         { 12 },  // column 0, coord 12 -> accession_B, local 2 -> "3-6"
     };
 
-    EXPECT_EQ(aln.format_coords(cth, 5), "accession_A:4-7;accession_B:3-6");
+    EXPECT_EQ(aln.format_coords(cth, 5), "accession_A/14:4-7;accession_B/24:3-6");
 }
 
 TEST(AlignmentFormatCoords, CoordToHeaderGroupsByHeader) {
@@ -267,7 +267,7 @@ TEST(AlignmentFormatCoords, CoordToHeaderGroupsByHeader) {
         { 2, 7 },  // coord 2 -> seqA local 2, coord 7 -> seqB local 2
     };
 
-    EXPECT_EQ(aln.format_coords(cth, 5), "seqA:3-5;seqB:3-5");
+    EXPECT_EQ(aln.format_coords(cth, 5), "seqA/9:3-5;seqB/9:3-5");
 }
 
 TEST(AlignmentFormatCoords, CoordToHeaderSameHeaderMultipleCoords) {
@@ -291,7 +291,7 @@ TEST(AlignmentFormatCoords, CoordToHeaderSameHeaderMultipleCoords) {
     };
 
     // Same header gets both ranges appended
-    EXPECT_EQ(aln.format_coords(cth, 5), "ref:4-5:11-12");
+    EXPECT_EQ(aln.format_coords(cth, 5), "ref/24:4-5:11-12");
 }
 
 TEST(AlignmentFormatCoords, EmptyCoordinates) {
@@ -345,7 +345,7 @@ TEST(AlignmentFormatCoords, CrossSequenceBoundaryWithK) {
     aln.label_columns = { 0 };
     aln.label_coordinates = { { 7 } };  // seqA local 7; 7 nt fit + 1 spills
 
-    EXPECT_EQ(aln.format_coords(cth, 5), "seqA:8-14;seqB:1-1");
+    EXPECT_EQ(aln.format_coords(cth, 5), "seqA/14:8-14;seqB/14:1-1");
 }
 
 TEST(AlignmentFormatCoords, CrossThreeSequences) {
@@ -365,7 +365,7 @@ TEST(AlignmentFormatCoords, CrossThreeSequences) {
     aln.label_columns = { 0 };
     aln.label_coordinates = { { 3 } };
 
-    EXPECT_EQ(aln.format_coords(cth, 3), "seqA:4-7;seqB:1-7;seqC:1-5");
+    EXPECT_EQ(aln.format_coords(cth, 3), "seqA/7:4-7;seqB/7:1-7;seqC/7:1-5");
 }
 
 TEST(AlignmentFormatCoords, TwoCoordsBothCrossIntoSameNextSequence) {
@@ -391,7 +391,7 @@ TEST(AlignmentFormatCoords, TwoCoordsBothCrossIntoSameNextSequence) {
     //   coord 7 -> seqA local 7, avail=5, spills 3 nt into seqB
     aln.label_coordinates = { { 6, 7 } };
 
-    EXPECT_EQ(aln.format_coords(cth, 5), "seqA:7-12:8-12;seqB:1-2:1-3");
+    EXPECT_EQ(aln.format_coords(cth, 5), "seqA/12:7-12:8-12;seqB/12:1-2:1-3");
 }
 
 TEST(AlignmentFormatCoords, OverflowPastLastHeader) {
@@ -412,7 +412,7 @@ TEST(AlignmentFormatCoords, OverflowPastLastHeader) {
     aln.label_columns = { 0 };
     aln.label_coordinates = { { 0 } };
 
-    EXPECT_EQ(aln.format_coords(cth, 3), "seqA:1-7;seqB:1-7");
+    EXPECT_EQ(aln.format_coords(cth, 3), "seqA/7:1-7;seqB/7:1-7");
 }
 
 TEST(AlignmentFormatCoords, ExactlyFillsStartingHeader) {
@@ -432,7 +432,7 @@ TEST(AlignmentFormatCoords, ExactlyFillsStartingHeader) {
     aln.label_columns = { 0 };
     aln.label_coordinates = { { 2 } };
 
-    EXPECT_EQ(aln.format_coords(cth, 3), "seqA:3-7");
+    EXPECT_EQ(aln.format_coords(cth, 3), "seqA/7:3-7");
 }
 
 TEST(AlignmentFormatCoords, SpansEntireColumn) {
@@ -453,7 +453,7 @@ TEST(AlignmentFormatCoords, SpansEntireColumn) {
     aln.label_columns = { 0 };
     aln.label_coordinates = { { 0 } };
 
-    EXPECT_EQ(aln.format_coords(cth, 3), "seqA:1-5;seqB:1-6;seqC:1-4");
+    EXPECT_EQ(aln.format_coords(cth, 3), "seqA/5:1-5;seqB/6:1-6;seqC/4:1-4");
 }
 
 } // namespace

--- a/metagraph/tests/graph/test_aligner_helpers.hpp
+++ b/metagraph/tests/graph/test_aligner_helpers.hpp
@@ -35,7 +35,13 @@ void check_json_dump_load(const DeBruijnGraph &graph,
 
     Alignment load_alignment;
     std::string load_sequence;
-    load_alignment.load_from_json(alignment.to_json(graph.get_k()), graph, &load_sequence);
+    // load_from_json reads `path.mapping[]`, which to_json now omits by
+    // default; opt back in for the round-trip check.
+    load_alignment.load_from_json(
+            alignment.to_json(graph.get_k(), /*is_secondary=*/false, /*name=*/{},
+                              /*label=*/{}, /*encoder=*/nullptr, /*cth=*/nullptr,
+                              /*include_path_mapping=*/true),
+            graph, &load_sequence);
 
     EXPECT_EQ(path_query, load_sequence);
 


### PR DESCRIPTION
Closes #632.

## Goal

Let callers compute **how much of each target sequence was hit** from `metagraph query --query-mode coords` and `metagraph align` output — without looking up sequence lengths separately.

## Prerequisite

Build a **CoordToHeader** sidecar (`.seqs`) once against the final annotation:

```bash
metagraph annotate --anno-filename --index-header-coords \
  -i <graph> -o <final_anno_basename> <all_input_fastas>
```

No annotation re-build is required. Without `.seqs`, behavior is unchanged and the new length fields are omitted.

---

## Output changes (with `.seqs` loaded)

| | **Query** (`--query-mode coords`) | **Align** (`metagraph align`) |
|---|---|---|
| **Units** | k-mer indices (0-based) | nucleotides (1-based inclusive) |
| **TSV** | `<seq>/N:pos-first-last` after `>` | `<header>/N:start-end` in last column |
| **JSON** | `kmers_in_target` on each result | `annotation.labels[]` with `sample`, `nt_length`, `nt_coords` |
| **Denominator** | `N` = k-mers in target | `N` = nt length of target (`num_kmers + k - 1`) |

### Query example

TSV:
```
0    q1    <seq1>/6:0-1-5
```
`/6` = target k-mer count. `0-1-5` is a `query_pos-target_first-target_last` triplet (k-mer indices, 0-based) — here query k-mer 0 matched target k-mers 1 through 5. Multiple consecutive-run matches produce multiple `:`-separated triplets after the `/N`.

JSON adds `kmers_in_target` next to `kmer_coords` / `kmer_count` / `sample`.

### Align example

TSV (last column):
```
seq1/10:2-10
```
`/10` = target nt length; `2-10` = 1-based inclusive range on the target.

JSON (new — align had no label/coord block before):
```json
"annotation": {
  "cigar": "9=",
  "labels": [{"sample": "seq1", "nt_length": 10, "nt_coords": "2-10"}],
  ...
}
```

### Computing fraction covered

- **Single range:** `(end - start + 1) / N`
- **Multiple ranges/triplets on the same target:** take the **union** of positions (merge overlaps), then divide by `N` — do not sum spans.

---

## Breaking / behavior changes

**Query coords TSV** — when `.seqs` is present, each header gains a `/N` suffix:
`<seq1>:0-1-5` → `<seq1>/6:0-1-5`

**Align coords TSV** — same pattern:
`seq1:2-10` → `seq1/10:2-10`

**Align JSON** — `path.mapping[]` is **off by default** (was ~80 KB/record for long alignments; top-level `cigar` is unchanged). Opt back in with `--align-output-path` for VG/Cactus interop.

---

## Also in this PR

- Load-time warning when `.seqs` is missing (query + align), with a concrete `metagraph annotate --index-header-coords ...` command using the user's graph/annotation paths
- Info hint after `metagraph annotate --coordinates` (skipped when running `--index-header-coords`)
- Docs: `quick_start.rst` — align nt coordinates section, cross-links, union note for multi-hit targets

---

## Test plan

- [x] Unit: `AlignmentFormatCoords`, `LabeledAlignerCoordTest`, `CoordToHeader`, `load_from_json` round-trip (with `--align-output-path`)
- [x] Integration: `*test_query*`, `*test_align*`, `*test_api*` — CI green (DNA/Protein x Debug/Release x g++-11/12/13 x static)
- [x] Manual: query/align with and without `.seqs`; TSV vs JSON; align JSON default vs `--align-output-path`

